### PR TITLE
Hyperthreading setting for BullSequana SH160 (Sapphire Rapids) - For …

### DIFF
--- a/scripts/lib/check/1250_cpu_hyperthreading_intel.check
+++ b/scripts/lib/check/1250_cpu_hyperthreading_intel.check
@@ -87,8 +87,9 @@ function check_1250_cpu_hyperthreading_intel {
         elif [[ ${LIB_PLATF_CPU_MODELID:-} -eq 143 ]]; then
 
             # ATOS/Bull Sequana - Sapphire Rapids
+            logCheckInfo 'For SAP S/4HANA (analytical and transactional workloads). For 16s Systems and above, Hyperthreading will be disabled.'
             logCheckInfo 'For SAP BW/4HANA (analytical workloads), Hyperthreading should be enabled for all system sizes (12s and 16s).'
-            max_cpu_sockets_with_hyperthreads=16
+            max_cpu_sockets_with_hyperthreads=12
 
         fi
 


### PR DESCRIPTION
…SAP S/4HANA (analytical and transactional workloads), Hyperthreading will be disabled for 16s systems