### PR TITLE
VMware - fix LIB_CHECK_IS_VMware consider enhanced output of vmware-t…

### DIFF
--- a/scripts/bin/saphana-helper-funcs
+++ b/scripts/bin/saphana-helper-funcs
@@ -77,7 +77,7 @@ function LIB_FUNC_IS_VIRT_VMWARE {
 
     logTrace "<${BASH_SOURCE[0]}:${FUNCNAME[*]}>"
 
-    [[ "${LIB_PLATF_VIRT_HYPER:-}" == 'VMware' ]] && _retval=0
+    [[ "${LIB_PLATF_VIRT_HYPER:-}" == 'VMware'* ]] && _retval=0
 
     logDebug "<${BASH_SOURCE[0]}:${FUNCNAME[0]}> # RC=${_retval}"
     return ${_retval}


### PR DESCRIPTION
…oolbox-cmd

introduced June 28 with a5011b4f288272245b754f35fd60d55fda32b8b1

`[C] L2800 <SKIP>  Not running on VMware vSphere. `

[[ "${LIB_PLATF_VIRT_HYPER:-}" == 'VMware' ]]

<(lscpu)
VMware

but
<(vmware-toolbox-cmd stat raw txt session version)
VMware ESX 7.0.3 build-23794027