### PR TITLE
Azure instances - add new emerald rapid E96*; remove old baremetal-sku

### DIFF
--- a/scripts/lib/check/0101_supported_instances_azure.check
+++ b/scripts/lib/check/0101_supported_instances_azure.check
@@ -24,6 +24,8 @@ function check_0101_supported_instances_azure {
                         'E64s_v3'   \
                         'E20s_v5'   'E32s_v5'   'E48s_v5'   'E64s_v5'   'E96s_v5'  \
 
+                        'E96s_v6'   'E96ds_v6'  \
+
                         'M32ls'     'M32ts'     \
                         'M32ms_v2'  'M32dms_v2' \
                         'M48ds_1_v3'    'M48s_1_v3'     \
@@ -52,14 +54,11 @@ function check_0101_supported_instances_azure {
 
     # array             'Instance Type'
     local -ar _azure_bm=(\
-                        'S144'     'S144m'    \
-                        'S192'     'S192m'    \
                         'S224'     'S224m'    'S224om'  'S224oo'    'S224ooo'   'S224oom' \
                         'S384'     'S384m'    'S384xm'   \
                         'S448'     'S448m'    'S448om'  'S448a'    'S448ma'\
                         'S576m'        \
                         'S672'     'S672m'    'S672om'  \
-                        'S72'      'S72m'     \
                         'S768m'        \
                         'S896'     'S896m'    'S896om'\
                         'S96'          \


### PR DESCRIPTION
https://github.com/MicrosoftDocs/azure-docs/blob/main/articles/sap/large-instances/hana-available-skus.md 
The following SKUs, though still supported, can't be purchased anymore: S72, S72m, S144, S144m, S192, and S192m.