### PR TITLE
Unittest HANA Infra issues - fix non running checks and rename file

### DIFF
--- a/scripts/tests/check/8050_hana_revision_infra_issues_test.sh
+++ b/scripts/tests/check/8050_hana_revision_infra_issues_test.sh
@@ -5,6 +5,8 @@ PROGRAM_DIR="$( cd "${BASH_SOURCE[0]%/*}" && pwd )"
 readonly PROGRAM_DIR
 
 #mock PREREQUISITE functions
+LIB_FUNC_IS_INTEL() { return 0 ; }
+
 function LIB_FUNC_COMPARE_VERSIONS {
 
     logTrace "<${BASH_SOURCE[0]}:${FUNCNAME[*]}>"


### PR DESCRIPTION
fix not running checks due to INTEL/IBMPOWER changes (broken since 02/25), 
rename file name to align with check name