### PR TITLE
Pacemaker attributes - handle different XML output formats

### DIFF
--- a/scripts/lib/check/7018_pacemaker_attributes.check
+++ b/scripts/lib/check/7018_pacemaker_attributes.check
@@ -61,12 +61,15 @@ function check_7018_pacemaker_attributes {
 
             logTrace "<${FUNCNAME[0]}> # read <${line}>"
 
-            [[ ${line} != *'nvpair name'* ]] && continue
+            [[ ${line} != *'nvpair'* ]] && continue
+            [[ ${line} != *'name='* ]] && continue
 
-            if [[ ${line} =~ name=\"(.+?)\"[[:space:]]value=\"(.+?)\"[[:space:]] ]]; then
+            if [[ ${line} =~ name=\"(.+?)\"[[:space:]]value=\"([[:digit:]]+?)\" ]]; then
 
                 _parameter=${BASH_REMATCH[1]}
                 _curr_value=${BASH_REMATCH[2]}
+
+                logTrace "<${FUNCNAME[0]}> # <${_parameter}>=<${_curr_value}>"
 
             fi
 


### PR DESCRIPTION
The current pattern only matches lines containing "nvpair name" but pacemaker XML can also have "nvpair id" format.

handle pacemaker XML output in both formats:

<nvpair name="resource-stickiness" value="1000"/>
<nvpair id="some-id" name="resource-stickiness" value="1000"/>