### PR TITLE
New PR for check 5540_fs_hana_mount

### DIFF
--- a/scripts/lib/check/5540_fs_hana_mount.check
+++ b/scripts/lib/check/5540_fs_hana_mount.check
@@ -14,6 +14,7 @@ function check_5540_fs_hana_mount {
 
     local _rxHANAmounts
     _rxHANAmounts='/hana/(data|log|shared).*'
+
     # MODIFICATION SECTION<<
 
     # SAP Note 2972496 - SAP HANA Filesystem Types
@@ -44,6 +45,7 @@ function check_5540_fs_hana_mount {
         local is_expired_cert=false
 
         while read -r _mount_point _type _rest; do
+
             is_supported_fs "${_type,,}"
 
             case $? in
@@ -60,6 +62,7 @@ function check_5540_fs_hana_mount {
                     is_not_supported=true
                     ;;
             esac
+
         done <<< "$(grep -soE "${_rxHANAmounts}" /proc/mounts)"
 
 

--- a/scripts/lib/check/5540_fs_hana_mount.check
+++ b/scripts/lib/check/5540_fs_hana_mount.check
@@ -23,8 +23,8 @@ function check_5540_fs_hana_mount {
         _retval=3
     fi
 
-    # helper function using regex strings
-    is_supported_fs() {
+    # helper function using LIB_FUNC_STRINGCONTAIN
+    is_supported_fs() { 
         local fs="$1"
         LIB_FUNC_STRINGCONTAIN "${fs_list_supported}" "${fs}" && return 0
         LIB_FUNC_STRINGCONTAIN "${fs_list_supported_expiredCertification}" "${fs}" && return 1
@@ -34,40 +34,40 @@ function check_5540_fs_hana_mount {
     # CHECK
     if [[ ${_retval} -eq 99 ]]; then
 
-        local -i counter_mount_points_not_supported=0
-        local -i counter_mount_points_supported=0
-        local -i counter_mount_points_supported_expired_certification=0
+        local is_supported=false
+        local is_not_supported=false
+        local is_expired_cert=false
 
-        while read -r _mount_point _type _rest; do
-            if [[ "$_mount_point" =~ $_rxHANAmounts ]]; then
-                local type_value="${_type,,}"   # force lowercase
-                local current_mount_point="$_mount_point"
+        # parse /proc/mounts correctly: device mountpoint type ...
+        while read -r _device _mount_point _type _rest; do
 
-                is_supported_fs "$type_value"
-                case $? in
-                    0)
-                        logCheckOk "File-system type is supported for HANA mount-point <$current_mount_point> (is: $type_value)"
-                        ((counter_mount_points_supported++))
-                        ;;
-                    1)
-                        logCheckWarning "File-system type is supported but part of an expired certification for HANA mount-point <$current_mount_point> (is: $type_value)"
-                        ((counter_mount_points_supported_expired_certification++))
-                        ;;
-                    2)
-                        logCheckError "File-system type is NOT supported for HANA mount-point <$current_mount_point> (is: $type_value, should be: ${fs_list_all_supported})"
-                        ((counter_mount_points_not_supported++))
-                        ;;
-                esac
-            fi
-        done <<< "$(grep -soE "${_rxHANAmounts}" /proc/mounts)"
+            is_supported_fs "${_type,,}"
+            case $? in
+                0)
+                    logCheckOk "File-system type is supported for HANA mount-point <$_mount_point> (is: ${_type,,})"
+                    is_supported=true
+                    ;;
+                1)
+                    logCheckWarning "File-system type is supported but part of an expired certification for HANA mount-point <$_mount_point> (is: ${_type,,})"
+                    is_expired_cert=true
+                    ;;
+                2)
+                    logCheckError "File-system type is NOT supported for HANA mount-point <$_mount_point> (is: ${_type,,}, should be: ${fs_list_all_supported})"
+                    is_not_supported=true
+                    ;;
+            esac
 
-        if [[ $counter_mount_points_supported -gt 0 && $counter_mount_points_not_supported -eq 0 && $counter_mount_points_supported_expired_certification -eq 0 ]]; then
+        done <<< "$(grep -E "${_rxHANAmounts}" /proc/mounts)"
+
+        if $is_supported && ! $is_not_supported && ! $is_expired_cert; then
             logCheckOk "All HANA mount-point file-system types are supported (SAP Note ${sapnote:-})"
             _retval=0
-        elif [[ $counter_mount_points_not_supported -gt 0 ]]; then
+
+        elif $is_not_supported; then
             logCheckError "NOT all HANA mount-point file-system types are supported (SAP Note ${sapnote:-})"
             _retval=2
-        elif [[ $counter_mount_points_supported_expired_certification -gt 0 ]]; then
+
+        elif $is_expired_cert; then
             logCheckWarning "At least one HANA mount-point file-system type is supported but part of an expired certification (SAP Note ${sapnote:-})"
             _retval=1
         fi

--- a/scripts/lib/check/5540_fs_hana_mount.check
+++ b/scripts/lib/check/5540_fs_hana_mount.check
@@ -62,6 +62,7 @@ function check_5540_fs_hana_mount {
             esac
         done <<< "$(grep -soE "${_rxHANAmounts}" /proc/mounts)"
 
+
         if $is_supported && ! $is_not_supported && ! $is_expired_cert; then
 
             logCheckOk "All HANA mount-point file-system types are supported (SAP Note ${sapnote:-})"
@@ -83,4 +84,5 @@ function check_5540_fs_hana_mount {
 
     logDebug "<${BASH_SOURCE[0]}:${FUNCNAME[0]}> # RC=${_retval}"
     return $_retval
+
 }

--- a/scripts/lib/check/5540_fs_hana_mount.check
+++ b/scripts/lib/check/5540_fs_hana_mount.check
@@ -28,10 +28,12 @@ function check_5540_fs_hana_mount {
 
     # helper function using LIB_FUNC_STRINGCONTAIN
     is_supported_fs() {
+
         local fs="$1"
         LIB_FUNC_STRINGCONTAIN "${fs_list_supported}" "${fs}" && return 0
         LIB_FUNC_STRINGCONTAIN "${fs_list_supported_expiredCertification}" "${fs}" && return 1
         return 2
+
     }
 
     # CHECK
@@ -43,6 +45,7 @@ function check_5540_fs_hana_mount {
 
         while read -r _mount_point _type _rest; do
             is_supported_fs "${_type,,}"
+
             case $? in
                 0)
                     logCheckOk "File-system type is supported for HANA mount-point <$_mount_point> (is: ${_type,,})"

--- a/scripts/lib/check/5540_fs_hana_mount.check
+++ b/scripts/lib/check/5540_fs_hana_mount.check
@@ -12,7 +12,8 @@ function check_5540_fs_hana_mount {
     local -r fs_list_supported_expiredCertification='ext3|mpfs|ocfs2'
     local -r fs_list_all_supported='xfs|gpfs|nfs|ext3*|mpfs*|ocfs2*'
 
-    local _rxHANAmounts='/hana/(data|log|shared).*'
+    local _rxHANAmounts
+    _rxHANAmounts='/hana/(data|log|shared).*'
     # MODIFICATION SECTION<<
 
     # SAP Note 2972496 - SAP HANA Filesystem Types
@@ -24,7 +25,7 @@ function check_5540_fs_hana_mount {
     fi
 
     # helper function using LIB_FUNC_STRINGCONTAIN
-    is_supported_fs() { 
+    is_supported_fs() {
         local fs="$1"
         LIB_FUNC_STRINGCONTAIN "${fs_list_supported}" "${fs}" && return 0
         LIB_FUNC_STRINGCONTAIN "${fs_list_supported_expiredCertification}" "${fs}" && return 1
@@ -38,9 +39,7 @@ function check_5540_fs_hana_mount {
         local is_not_supported=false
         local is_expired_cert=false
 
-        # parse /proc/mounts correctly: device mountpoint type ...
-        while read -r _device _mount_point _type _rest; do
-
+        while read -r _mount_point _type _rest; do
             is_supported_fs "${_type,,}"
             case $? in
                 0)
@@ -56,8 +55,7 @@ function check_5540_fs_hana_mount {
                     is_not_supported=true
                     ;;
             esac
-
-        done <<< "$(grep -E "${_rxHANAmounts}" /proc/mounts)"
+        done <<< "$(grep -soE "${_rxHANAmounts}" /proc/mounts)"
 
         if $is_supported && ! $is_not_supported && ! $is_expired_cert; then
             logCheckOk "All HANA mount-point file-system types are supported (SAP Note ${sapnote:-})"

--- a/scripts/lib/check/5540_fs_hana_mount.check
+++ b/scripts/lib/check/5540_fs_hana_mount.check
@@ -20,8 +20,10 @@ function check_5540_fs_hana_mount {
 
     # PRECONDITIONS
     if ! grep -qsE "${_rxHANAmounts}" /proc/mounts; then
+
         logCheckSkipped "No HANA filesystem mounted (SAP Note ${sapnote:-}). Skipping" "<${FUNCNAME[0]}>"
         _retval=3
+
     fi
 
     # helper function using LIB_FUNC_STRINGCONTAIN
@@ -58,17 +60,22 @@ function check_5540_fs_hana_mount {
         done <<< "$(grep -soE "${_rxHANAmounts}" /proc/mounts)"
 
         if $is_supported && ! $is_not_supported && ! $is_expired_cert; then
+
             logCheckOk "All HANA mount-point file-system types are supported (SAP Note ${sapnote:-})"
             _retval=0
 
         elif $is_not_supported; then
+
             logCheckError "NOT all HANA mount-point file-system types are supported (SAP Note ${sapnote:-})"
             _retval=2
 
         elif $is_expired_cert; then
+
             logCheckWarning "At least one HANA mount-point file-system type is supported but part of an expired certification (SAP Note ${sapnote:-})"
             _retval=1
+
         fi
+
     fi
 
     logDebug "<${BASH_SOURCE[0]}:${FUNCNAME[0]}> # RC=${_retval}"

--- a/scripts/lib/check/5540_fs_hana_mount.check
+++ b/scripts/lib/check/5540_fs_hana_mount.check
@@ -8,9 +8,9 @@ function check_5540_fs_hana_mount {
     local -r sapnote='#2972496'
 
     # String declaration
-    local -r fs_list_supported='xfs|GPFS|nfs'
-    local -r fs_list_supported_expiredCertification='ext3|MPFS|OCFS2'
-    local -r fs_list_all_supported='xfs|GPFS|nfs|ext3*|MPFS*|OCFS2*'
+    local -r fs_list_supported='xfs|gpfs|nfs'
+    local -r fs_list_supported_expiredCertification='ext3|mpfs|ocfs2'
+    local -r fs_list_all_supported='xfs|gpfs|nfs|ext3*|mpfs*|ocfs2*'
 
     local _rxHANAmounts='/hana/(data|log|shared).*'
     # MODIFICATION SECTION<<
@@ -40,7 +40,7 @@ function check_5540_fs_hana_mount {
 
         while read -r _mount_point _type _rest; do
             if [[ "$_mount_point" =~ $_rxHANAmounts ]]; then
-                local type_value="$_type"
+                local type_value="${_type,,}"   # force lowercase
                 local current_mount_point="$_mount_point"
 
                 is_supported_fs "$type_value"

--- a/scripts/lib/check/7018_pacemaker_attributes.check
+++ b/scripts/lib/check/7018_pacemaker_attributes.check
@@ -61,12 +61,15 @@ function check_7018_pacemaker_attributes {
 
             logTrace "<${FUNCNAME[0]}> # read <${line}>"
 
-            [[ ${line} != *'nvpair name'* ]] && continue
+            [[ ${line} != *'nvpair'* ]] && continue
+            [[ ${line} != *'name='* ]] && continue
 
-            if [[ ${line} =~ name=\"(.+?)\"[[:space:]]value=\"(.+?)\"[[:space:]] ]]; then
+            if [[ ${line} =~ name=\"(.+?)\"[[:space:]]value=\"([[:digit:]]+?)\" ]]; then
 
                 _parameter=${BASH_REMATCH[1]}
                 _curr_value=${BASH_REMATCH[2]}
+
+                logTrace "<${FUNCNAME[0]}> # <${_parameter}>=<${_curr_value}>"
 
             fi
 

--- a/scripts/lib/checkset/RHELonPoweronly.checkset
+++ b/scripts/lib/checkset/RHELonPoweronly.checkset
@@ -62,6 +62,7 @@
 5505_nfsv4_max_session_slots
 5510_nfsv3_rpc_slots_netapp
 5530_nfs_mount_nconnect
+5540_fs_hana_mount
 7010_corosync_version
 7015_pacemaker_version
 7018_pacemaker_attributes

--- a/scripts/lib/checkset/RHELonX64only.checkset
+++ b/scripts/lib/checkset/RHELonX64only.checkset
@@ -81,6 +81,7 @@
 5521_nfs_mount_rwsize_azure
 5522_nfs_mount_rwsize_amazon
 5530_nfs_mount_nconnect
+5540_fs_hana_mount
 7010_corosync_version
 7015_pacemaker_version
 7018_pacemaker_attributes

--- a/scripts/lib/checkset/SLESonPoweronly.checkset
+++ b/scripts/lib/checkset/SLESonPoweronly.checkset
@@ -64,6 +64,7 @@
 5505_nfsv4_max_session_slots
 5510_nfsv3_rpc_slots_netapp
 5530_nfs_mount_nconnect
+5540_fs_hana_mount
 7010_corosync_version
 7015_pacemaker_version
 7018_pacemaker_attributes

--- a/scripts/lib/checkset/SLESonX64only.checkset
+++ b/scripts/lib/checkset/SLESonX64only.checkset
@@ -84,6 +84,7 @@
 5521_nfs_mount_rwsize_azure
 5522_nfs_mount_rwsize_amazon
 5530_nfs_mount_nconnect
+5540_fs_hana_mount
 7010_corosync_version
 7015_pacemaker_version
 7018_pacemaker_attributes

--- a/scripts/tests/check/5540_fs_hana_mount_test.sh
+++ b/scripts/tests/check/5540_fs_hana_mount_test.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -u  # treat unset variables as an error
+
+PROGRAM_DIR="$( cd "${BASH_SOURCE[0]%/*}" && pwd )"
+readonly PROGRAM_DIR
+
+# mock PREREQUISITE functions
+LIB_FUNC_STRINGCONTAIN() { [[ -z "${1##*"$2"*}" ]] && [[ -z "$2" || -n "$1" ]]; }
+
+# override grep to simulate /proc/mounts
+grep() {
+    case "$*" in
+        *'/proc/mounts'* )
+            printf -- '%s\n' "${hana_mounts[@]}" | command grep "$1" "$2"
+            ;;
+        *)
+            command grep "$@"
+            ;;
+    esac
+}
+
+hana_mounts=()
+
+test_no_hana_mounts() {
+
+    # arrange
+    hana_mounts=()
+    hana_mounts+=('/mnt/cpsapnfsstoracc01 cifs nofail,vers=3.0,credentials=/etc/smbcredentials/cpsapnfsstoracc01.cred,dir_mode=0777')
+
+    # act
+    check_5540_fs_hana_mount
+
+    # assert
+    assertEquals "CheckSkipped? RC" '3' "$?"
+}
+
+test_all_supported_fs() {
+
+    # arrange
+    hana_mounts=()
+    hana_mounts+=('server:/vol /hana/data xfs rw,noatime')
+    hana_mounts+=('server:/vol /hana/data gpfs rw,noatime')
+    hana_mounts+=('server:/vol /hana/data nfs rw,noatime')
+    hana_mounts+=('server:/vol /hana/log xfs rw,noatime')
+    hana_mounts+=('server:/vol /hana/log gpfs rw,noatime')
+    hana_mounts+=('server:/vol /hana/log nfs rw,noatime')
+    hana_mounts+=('server:/vol /hana/shared nfs ro,noexec,nosuid')
+    hana_mounts+=('server:/vol /hana/shared gpfs ro,noexec,nosuid')
+    hana_mounts+=('server:/vol /hana/shared xfs ro,noexec,nosuid')
+    hana_mounts+=('0.0.0.0:/vol /hana/data/OQL xfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/data/OQL gpfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/data/OQL nfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/log/OQL xfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/log/OQL nfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/log/OQL gpfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/shared/OQL xfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/shared/OQL nfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/shared/OQL gpfs rw,noatime')
+
+    # act
+    check_5540_fs_hana_mount
+
+    # assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_expired_certification_fs() {
+
+    # arrange
+    hana_mounts=()
+    hana_mounts+=('0.0.0.0:/vol /hana/log ext3 rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/log ocfs2 rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/log mpfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/data ext3 rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/data ocfs2 rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/data mpfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/shared ext3 rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/shared ocfs2 rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/shared mpfs rw,noatime')
+
+    # act
+    check_5540_fs_hana_mount
+
+    # assert
+    assertEquals "CheckWarn? RC" '1' "$?"
+}
+
+test_unsupported_fs() {
+
+    # arrange
+    hana_mounts=()
+    hana_mounts+=('server:/vol /hana/data ext4 rw,noatime')
+    hana_mounts+=('server:/vol /hana/log ext4 defaults')
+    hana_mounts+=('server:/vol /hana/shared ext4 ro,noexec,nosuid')
+    hana_mounts+=('server:/vol /hana/data btrfs rw,noatime')
+    hana_mounts+=('server:/vol /hana/log btrfs defaults')
+    hana_mounts+=('server:/vol /hana/shared btrfs ro,noexec,nosuid')
+
+    # act
+    check_5540_fs_hana_mount
+
+    # assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+oneTimeSetUp() {
+
+    #shellcheck source=../saphana-logger-stubs
+    source "${PROGRAM_DIR}/../saphana-logger-stubs"
+
+    #shellcheck source=../../lib/check/5540_fs_hana_mount.check
+    source "${PROGRAM_DIR}/../../lib/check/5540_fs_hana_mount.check"
+}
+
+setUp() {
+    hana_mounts=()
+}
+
+# Load shUnit2
+#shellcheck source=../shunit2
+source "${PROGRAM_DIR}/../shunit2"


### PR DESCRIPTION
New PR for check 5540_fs_hana_mount along with 5540_fs_hana_mount_test.sh

Adapted code as per reviewer:

(1) Redundant regex matching
The code filters for HANA mounts with grep, then filters again with [[ "$_mount_point" =~ $_rxHANAmounts ]] inside the loop. - **DONE**

(2) Unnecessary variable assignments
what about ?
is_supported_fs "${_type,,}" - **DONE**

(3) Unnecessary variable assignments - **DONE**

(4) missing empty lines - please look into other checks for format
also true for next lines R64-R74 - **DONE**

(5) should be boolean variables .. just true and false is required - **DONE**