### PR TITLE
Add Power11 support for IBM Power OS checks

### DIFF
--- a/scripts/lib/check/0004_os_hana_support_sles_ibmpower.check
+++ b/scripts/lib/check/0004_os_hana_support_sles_ibmpower.check
@@ -7,7 +7,7 @@ function check_0004_os_hana_support_sles_ibmpower {
     local -i _retval=99
 
     # MODIFICATION SECTION>>
-    local -r platform_rx='POWER(10|9|8)'
+    local -r platform_rx='POWER(11|10|9)'
 
     # array                 'Platform'      'maj'   '01234567' (Minor Release)
     local -ar _sles_matrix_onprem=(\
@@ -18,8 +18,10 @@ function check_0004_os_hana_support_sles_ibmpower {
                         )
 
     local -ar _sles_matrix_ibmcloud=(\
+                            'POWER11'       '15'    '----456-'   \
                             'POWER10'       '15'    '----456-'   \
                             'POWER9'        '15'    '----456-'   \
+                            'POWER11'       '12'    '------'    \
                             'POWER10'       '12'    '------'    \
                             'POWER9'        '12'    '-----5'    \
                         )

--- a/scripts/lib/check/0005_os_hana_support_rhel_ibmpower.check
+++ b/scripts/lib/check/0005_os_hana_support_rhel_ibmpower.check
@@ -7,7 +7,7 @@ function check_0005_os_hana_support_rhel_ibmpower {
     local -i _retval=99
 
     # MODIFICATION SECTION>>
-    local -r platform_rx='POWER(10|9|8)'
+    local -r platform_rx='POWER(11|10|9)'
 
     #                       'Platform'      'maj'  '0123456789A' (Minor Release)
     local -a _rhel_matrix=(\
@@ -18,8 +18,10 @@ function check_0005_os_hana_support_rhel_ibmpower {
                             'POWER9'        '7'    '----------'  \
                             )
     local -ar _rhel_matrix_ibmcloud=(\
+                            'POWER11'       '9'    '--2-4-6'        \
                             'POWER10'       '9'    '--2-4'          \
                             'POWER9'        '9'    '--2-4'          \
+                            'POWER11'       '8'    '------6-8-A'    \
                             'POWER10'       '8'    '------6-8-A'    \
                             'POWER9'        '8'    '------6-8-A'    \
                         )

--- a/scripts/tests/check/0004_os_hana_support_sles_ibmpower_test.sh
+++ b/scripts/tests/check/0004_os_hana_support_sles_ibmpower_test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -u  # treat unset variables as an error
 
-PROGRAM_DIR="$( cd "${BASH_SOURCE[0]%/*}" && pwd )"
+PROGRAM_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 readonly PROGRAM_DIR
 
 #mock PREREQUISITE functions
@@ -88,7 +88,7 @@ test_power9_littleendian_sles_supported() {
     #arrange
     LIB_PLATF_ARCHITECTURE='ppc64le'
     LIB_PLATF_POWER_PLATFORM_BASE='POWER9'
-    OS_VERSION='15.3'
+    OS_VERSION='15.6'
 
     #act
     check_0004_os_hana_support_sles_ibmpower


### PR DESCRIPTION
- Updated 0004_os_hana_support_sles_ibmpower.check:
  * Added Power11 to platform regex: POWER(11|10|9)
  * Added Power11 entries to SLES IBM Cloud matrix for versions 15 and 12
  * Power11 SLES 15: Support for minor versions 4,5,6 on IBM Cloud
  * Power11 SLES 12: Currently no supported minor versions on IBM Cloud

- Updated 0005_os_hana_support_rhel_ibmpower.check:
  * Added Power11 to platform regex: POWER(11|10|9)
  * Added Power11 entries to RHEL IBM Cloud matrix for versions 9 and 8
  * Power11 RHEL 9: Support for minor versions 2,4,6 on IBM Cloud
  * Power11 RHEL 8: Support for minor versions 6,8,10 on IBM Cloud

- Updated 0004_os_hana_support_sles_ibmpower_test.sh:
  * Fixed PROGRAM_DIR calculation for better path resolution
  * Updated test case OS version from 15.3 to 15.6

This enables SAP HANA checks to properly recognize and validate Power11 systems running SLES and RHEL in IBM Cloud environments.