### PR TITLE
Update SAP HANA filesystem validation check (5540)

### DIFF
--- a/scripts/lib/check/5540_fs_hana_mount.check
+++ b/scripts/lib/check/5540_fs_hana_mount.check
@@ -8,12 +8,12 @@ function check_5540_fs_hana_mount {
     local -r sapnote='#2972496'
 
     # String declaration
-    local -r fs_list_supported='xfs|gpfs|nfs'
+    local -r fs_list_supported='xfs|gpfs|nfs|nfs4'
     local -r fs_list_supported_expiredCertification='ext3|mpfs|ocfs2'
-    local -r fs_list_all_supported='xfs|gpfs|nfs|ext3*|mpfs*|ocfs2*'
+    local -r fs_list_all_supported='xfs|gpfs|nfs|nfs4|ext3*|mpfs*|ocfs2*'
 
     local _rxHANAmounts
-    _rxHANAmounts='/hana/(data|log|shared).*'
+    _rxHANAmounts='/hana/(data|log).*'  #also backup
 
     # MODIFICATION SECTION<<
 

--- a/scripts/tests/check/5540_fs_hana_mount_test.sh
+++ b/scripts/tests/check/5540_fs_hana_mount_test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -u  # treat unset variables as an error
 
-PROGRAM_DIR="$( cd "${BASH_SOURCE[0]%/*}" && pwd )"
+PROGRAM_DIR="${BASH_SOURCE[0]%/*}"
+[[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 readonly PROGRAM_DIR
 
 # mock PREREQUISITE functions
@@ -41,21 +42,19 @@ test_all_supported_fs() {
     hana_mounts+=('server:/vol /hana/data xfs rw,noatime')
     hana_mounts+=('server:/vol /hana/data gpfs rw,noatime')
     hana_mounts+=('server:/vol /hana/data nfs rw,noatime')
+    hana_mounts+=('server:/vol /hana/data nfs4 rw,noatime')
     hana_mounts+=('server:/vol /hana/log xfs rw,noatime')
     hana_mounts+=('server:/vol /hana/log gpfs rw,noatime')
     hana_mounts+=('server:/vol /hana/log nfs rw,noatime')
-    hana_mounts+=('server:/vol /hana/shared nfs ro,noexec,nosuid')
-    hana_mounts+=('server:/vol /hana/shared gpfs ro,noexec,nosuid')
-    hana_mounts+=('server:/vol /hana/shared xfs ro,noexec,nosuid')
+    hana_mounts+=('server:/vol /hana/log nfs4 rw,noatime')
     hana_mounts+=('0.0.0.0:/vol /hana/data/OQL xfs rw,noatime')
     hana_mounts+=('0.0.0.0:/vol /hana/data/OQL gpfs rw,noatime')
     hana_mounts+=('0.0.0.0:/vol /hana/data/OQL nfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/data/OQL nfs4 rw,noatime')
     hana_mounts+=('0.0.0.0:/vol /hana/log/OQL xfs rw,noatime')
     hana_mounts+=('0.0.0.0:/vol /hana/log/OQL nfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/vol /hana/log/OQL nfs4 rw,noatime')
     hana_mounts+=('0.0.0.0:/vol /hana/log/OQL gpfs rw,noatime')
-    hana_mounts+=('0.0.0.0:/vol /hana/shared/OQL xfs rw,noatime')
-    hana_mounts+=('0.0.0.0:/vol /hana/shared/OQL nfs rw,noatime')
-    hana_mounts+=('0.0.0.0:/vol /hana/shared/OQL gpfs rw,noatime')
 
     # act
     check_5540_fs_hana_mount
@@ -74,9 +73,6 @@ test_expired_certification_fs() {
     hana_mounts+=('0.0.0.0:/vol /hana/data ext3 rw,noatime')
     hana_mounts+=('0.0.0.0:/vol /hana/data ocfs2 rw,noatime')
     hana_mounts+=('0.0.0.0:/vol /hana/data mpfs rw,noatime')
-    hana_mounts+=('0.0.0.0:/vol /hana/shared ext3 rw,noatime')
-    hana_mounts+=('0.0.0.0:/vol /hana/shared ocfs2 rw,noatime')
-    hana_mounts+=('0.0.0.0:/vol /hana/shared mpfs rw,noatime')
 
     # act
     check_5540_fs_hana_mount
@@ -91,10 +87,8 @@ test_unsupported_fs() {
     hana_mounts=()
     hana_mounts+=('server:/vol /hana/data ext4 rw,noatime')
     hana_mounts+=('server:/vol /hana/log ext4 defaults')
-    hana_mounts+=('server:/vol /hana/shared ext4 ro,noexec,nosuid')
     hana_mounts+=('server:/vol /hana/data btrfs rw,noatime')
     hana_mounts+=('server:/vol /hana/log btrfs defaults')
-    hana_mounts+=('server:/vol /hana/shared btrfs ro,noexec,nosuid')
 
     # act
     check_5540_fs_hana_mount


### PR DESCRIPTION
- Enhanced 5540_fs_hana_mount.check with NFS4 support and refined scope:
  * Added nfs4 to supported filesystem types (xfs|gpfs|nfs|nfs4)
  * Updated scope to validate only /hana/data and /hana/log paths (removed /hana/shared)
  * Maintained support for expired certification filesystems (ext3, mpfs, ocfs2)
  * Updated error messages to reflect expanded supported filesystem list

- Updated comprehensive unit test suite in 5540_fs_hana_mount_test.sh:
  * Added nfs4 test cases across all /hana/data and /hana/log scenarios
  * Removed /hana/shared test cases to match updated check scope
  * Fixed PROGRAM_DIR calculation using pure bash parameter expansion
  * Enhanced path resolution with edge case handling for current directory
  * All 4 test scenarios pass: no-mounts, supported-fs, expired-cert-fs, unsupported-fs

Implements SAP Note 2972496 requirements with expanded NFS4 support. Maintains backward compatibility while focusing validation on critical HANA data/log paths.