### PR TITLE
feat: Update IBM Power11 support matrix for SLES and RHEL on IBM Cloud

### DIFF
--- a/scripts/lib/check/0004_os_hana_support_sles_ibmpower.check
+++ b/scripts/lib/check/0004_os_hana_support_sles_ibmpower.check
@@ -18,7 +18,7 @@ function check_0004_os_hana_support_sles_ibmpower {
                         )
 
     local -ar _sles_matrix_ibmcloud=(\
-                            'POWER11'       '15'    '----456-'   \
+                            'POWER11'       '15'    '------6-'   \
                             'POWER10'       '15'    '----456-'   \
                             'POWER9'        '15'    '----456-'   \
                             'POWER11'       '12'    '------'    \

--- a/scripts/lib/check/0005_os_hana_support_rhel_ibmpower.check
+++ b/scripts/lib/check/0005_os_hana_support_rhel_ibmpower.check
@@ -18,10 +18,10 @@ function check_0005_os_hana_support_rhel_ibmpower {
                             'POWER9'        '7'    '----------'  \
                             )
     local -ar _rhel_matrix_ibmcloud=(\
-                            'POWER11'       '9'    '--2-4-6'        \
+                            'POWER11'       '9'    '-------'        \
                             'POWER10'       '9'    '--2-4'          \
                             'POWER9'        '9'    '--2-4'          \
-                            'POWER11'       '8'    '------6-8-A'    \
+                            'POWER11'       '8'    '-----------'    \
                             'POWER10'       '8'    '------6-8-A'    \
                             'POWER9'        '8'    '------6-8-A'    \
                         )


### PR DESCRIPTION
- Update SLES on IBM Power11 support (0004): Remove support for SLES 15.4, 15.5 on IBM Cloud, only support SLES 15.6
- Update RHEL on IBM Power11 support (0005): Remove support for RHEL 9.2-9.6 and RHEL 8.6-8.10 on IBM Cloud
- Changes reflect updated SAP support matrix for POWER11 on IBM Cloud
- All existing unit tests continue to pass

Changes to IBM Cloud support matrix:
- POWER11 + SLES 15: '----456-'  '------6-' (only 15.6 supported)
- POWER11 + RHEL 9: '--2-4-6'  '-------' (no support)
- POWER11 + RHEL 8: '------6-8-A'  '-----------' (no support)