### PR TITLE
refactor: Eliminate redundancy in 8050 check by extracting SAP Note d…

### DIFF
--- a/scripts/lib/check/8050_hana_revision_infra_issues.check
+++ b/scripts/lib/check/8050_hana_revision_infra_issues.check
@@ -7,80 +7,83 @@ function check_8050_hana_revision_infra_issues {
     local -i _retval=99
 
     # MODIFICATION SECTION>>
-    # array             'SPSP'  'lower bound'    'upper bound'  'SAP Note'  'Description'
+    # SAP Note descriptions lookup table
+    declare -rA _sapnote_descriptions=(
+        ['2044468']='Partitioning redo log'
+        ['2222110']='Problem with timer thread'
+        ['3312868']='Script hdbenv.sh takes a long time to complete'
+        ['3343278']='Nameserver is Unresponsive due to blocked Asynchronous Requests'
+        ['3356185']='Long Critical Phase For Savepoint'
+        ['3366673']='landscapeHostConfiguration.py fails with Python runtime (spawn)'
+        ['3434285']='Nameserver Unresponsive due to Failing Disk Polling (getDiskInfo)'
+        ['3435077']='Nameserver Hangs (ClockMonitor)'
+        ['3466826']='Savepoint Slowness With FRO/PMEM'
+        ['3499670']='DML Statements Adding LOBs Hanging in Thread_State Resource Load Wait'
+        ['3528623']='Slow in table load/reload due to load trace writing'
+        ['3555251']='Data Volume Encryption / Decryption is Hanging in TouchOldPagesJob'
+        ['3573023']='HANA DB Sessions Remain in Status Running (Cancel Requested)'
+        ['3600754']='Slow logreplay performance on HANA 2 SPS08 of redo log created on HANA 2 <= SPS07'
+        ['3608008']='CPU Spikes and Blocked Savepoints ... on Exhausted TMPFS (NVM-FRO)'
+        ['3610237']='Indexserver Crash on virtualized Intel Ice Lake hosts'
+        ['3665521']='Unresponsive System due to Memory Reclaim of Huge Alignment Pages'
+    )
+
+    # array             'SPSP'  'lower bound'    'upper bound'  'SAP Note'
     local -a _hana_all=(\
-                        '5'     '2.00.056.00'    '2.00.059.06'  '3312868'  'Script hdbenv.sh takes a long time to complete'     \
+                        '5'     '2.00.056.00'    '2.00.059.06'  '3312868'   \
 
-                        '5'     '2.00.050.00'    '2.00.059.09'  '3356185'  'Long Critical Phase For Savepoint'     \
-                        '7'     '2.00.070.00'    '2.00.071.00'  '3356185'  'Long Critical Phase For Savepoint'     \
+                        '5'     '2.00.050.00'    '2.00.059.09'  '3356185'   \
+                        '7'     '2.00.070.00'    '2.00.071.00'  '3356185'   \
 
-                        '5'     '2.00.050.00'    '2.00.059.12'  '3466826'  'Savepoint Slowness With FRO/PMEM'      \
-                        '7'     '2.00.070.00'    '2.00.077.00'  '3466826'  'Savepoint Slowness With FRO/PMEM'      \
+                        '5'     '2.00.050.00'    '2.00.059.12'  '3466826'   \
+                        '7'     '2.00.070.00'    '2.00.077.00'  '3466826'   \
 
-                        '5'     '2.00.050.00'    '2.00.059.14'  '3499670'  'DML Statements Adding LOBs Hanging in Thread_State Resource Load Wait'   \
-                        '7'     '2.00.070.00'    '2.00.079.00'  '3499670'  'DML Statements Adding LOBs Hanging in Thread_State Resource Load Wait'   \
+                        '5'     '2.00.050.00'    '2.00.059.14'  '3499670'   \
+                        '7'     '2.00.070.00'    '2.00.079.00'  '3499670'   \
 
-                        '5'     '2.00.050.00'    '2.00.059.09'  '2222110'  'Problem with timer thread'  \
-                        '7'     '2.00.070.00'    '2.00.071.00'  '2222110'  'Problem with timer thread'  \
+                        '5'     '2.00.050.00'    '2.00.059.09'  '2222110'   \
+                        '7'     '2.00.070.00'    '2.00.071.00'  '2222110'   \
 
-                        '7'     '2.00.070.00'    '2.00.076.00'  '3435077'  'Nameserver Hangs (ClockMonitor)'  \
+                        '7'     '2.00.070.00'    '2.00.076.00'  '3435077'   \
 
-                        '5'     '2.00.050.00'    '2.00.059.14'  '3434285'  'Nameserver Unresponsive due to Failing Disk Polling (getDiskInfo)'   \
-                        '7'     '2.00.070.00'    '2.00.079.01'  '3434285'  'Nameserver Unresponsive due to Failing Disk Polling (getDiskInfo)'   \
+                        '5'     '2.00.050.00'    '2.00.059.14'  '3434285'   \
+                        '7'     '2.00.070.00'    '2.00.079.01'  '3434285'   \
 
-                        '5'     '2.00.050.00'    '2.00.059.12'  '2044468'  'Partitioning redo log'   \
-                        '7'     '2.00.070.00'    '2.00.076.00'  '2044468'  'Partitioning redo log'   \
+                        '5'     '2.00.050.00'    '2.00.059.12'  '2044468'   \
+                        '7'     '2.00.070.00'    '2.00.076.00'  '2044468'   \
 
-                        '5'     '2.00.050.00'    '2.00.059.14'  '3528623'  'Slow in table load/reload due to load trace writing'   \
-                        '7'     '2.00.070.00'    '2.00.079.02'  '3528623'  'Slow in table load/reload due to load trace writing'   \
+                        '5'     '2.00.050.00'    '2.00.059.14'  '3528623'   \
+                        '7'     '2.00.070.00'    '2.00.079.02'  '3528623'   \
 
-                        '5'     '2.00.050.00'    '2.00.059.09'  '3343278'  'Nameserver is Unresponsive due to blocked Asynchronous Requests'   \
-                        '7'     '2.00.070.00'    '2.00.072.00'  '3343278'  'Nameserver is Unresponsive due to blocked Asynchronous Requests'   \
+                        '5'     '2.00.050.00'    '2.00.059.09'  '3343278'   \
+                        '7'     '2.00.070.00'    '2.00.072.00'  '3343278'   \
 
-                        '5'     '2.00.050.00'    '2.00.059.10'  '3366673'  'landscapeHostConfiguration.py fails with Python runtime (spawn)'   \
-                        '7'     '2.00.070.00'    '2.00.073.00'  '3366673'  'landscapeHostConfiguration.py fails with Python runtime (spawn)'   \
+                        '5'     '2.00.050.00'    '2.00.059.10'  '3366673'   \
+                        '7'     '2.00.070.00'    '2.00.073.00'  '3366673'   \
 
-                        '7'     '2.00.070.00'    '2.00.079.02'  '3555251'  'Data Volume Encryption / Decryption is Hanging in TouchOldPagesJob' \
+                        '7'     '2.00.070.00'    '2.00.079.02'  '3555251'   \
 
-                        '8'     '2.00.080.00'    '2.00.084.00'  '3600754'  'Slow logreplay performance on HANA 2 SPS08 of redo log created on HANA 2 <= SPS07'  \
+                        '8'     '2.00.080.00'    '2.00.084.00'  '3600754'   \
 
-                        '7'     '2.00.070.00'    '2.00.079.04'  '3608008'  'CPU Spikes and Blocked Savepoints ... on Exhausted TMPFS (NVM-FRO)' \
-                        '8'     '2.00.080.00'    '2.00.085.00'  '3608008'  'CPU Spikes and Blocked Savepoints ... on Exhausted TMPFS (NVM-FRO)' \
+                        '7'     '2.00.070.00'    '2.00.079.04'  '3608008'   \
+                        '8'     '2.00.080.00'    '2.00.085.00'  '3608008'   \
 
-                        '5'     '2.00.050.00'    '2.00.059.99'  '3665521'  'Unresponsive System due to Memory Reclaim of Huge Alignment Pages' \
-                        '7'     '2.00.070.00'    '2.00.079.06'  '3665521'  'Unresponsive System due to Memory Reclaim of Huge Alignment Pages' \
-                        '8'     '2.00.080.00'    '2.00.087.00'  '3665521'  'Unresponsive System due to Memory Reclaim of Huge Alignment Pages' \
+                        '5'     '2.00.050.00'    '2.00.059.99'  '3665521'   \
+                        '7'     '2.00.070.00'    '2.00.079.06'  '3665521'   \
+                        '8'     '2.00.080.00'    '2.00.087.00'  '3665521'   \
                         )
 
     local -ar _hana_intel=(\
-                        '7'     '2.00.070.00'    '2.00.079.05'  '3610237'  'Indexserver Crash on virtualized Intel Ice Lake hosts'   \
-                        '8'     '2.00.080.00'    '2.00.085.00'  '3610237'  'Indexserver Crash on virtualized Intel Ice Lake hosts'   \
+                        '7'     '2.00.070.00'    '2.00.079.05'  '3610237'   \
+                        '8'     '2.00.080.00'    '2.00.085.00'  '3610237'   \
                         )
 
     local -ar _hana_ibmpower=(\
-                        '8'     '2.00.080.00'    '2.00.082.00'  '3573023'  'HANA DB Sessions Remain in Status Running (Cancel Requested)'   \
+                        '8'     '2.00.080.00'    '2.00.082.00'  '3573023'   \
                         )
 
     local sapnote=''
     # MODIFICATION SECTION<<
-
-    # 3312868 - Script hdbenv.sh takes a long time to complete
-    # 3356185 - Long Critical Phase For Savepoint
-    # 3466826 - Savepoint Slowness With Persistent Memory or Fast Restart Option Enabled
-    # 3499670 - DML Statements Adding LOBs Hanging in Thread_State Resource Load Wait
-    # 2222110 - FAQ: SAP HANA Load History #12 Problem with timer thread
-    # 3435077 - Nameserver Hangs or Experiences Unexpected Shutdown by Cluster Manager - clockmonitor (cgroup)
-    # 3434285 - Nameserver Unresponsive due to Failing Disk Polling Caused by Faulty NFS Filesystem
-    # 2044468 - FAQ: SAP HANA Partitioning #43 Log
-    # 3528623 - Slow in table load/reload due to load trace writing
-    # 3343278 - HANA Nameserver is Unresponsive due to blocked Asynchronous Requests
-    # 3366673 - landscapeHostConfiguration.py fails with Python runtime error "can't start new thread"
-    # 3555251 - Data Volume Encryption / Decryption is Hanging in TouchOldPagesJob::run()
-    # 3573023 - HANA DB Sessions Remain in Status Running (Cancel Requested)
-    # 3600754 - Slow logreplay performance on HANA 2 SPS08 of redo log created on HANA 2 <= SPS07
-    # 3608008 - CPU Spikes and Blocked Savepoints Due to Expensive Fallocate() Syscalls on Exhausted TMPFS (NVM-FRO)
-    # 3610237 - Indexserver Crash at PageAccess::LogicalPageControlBlock::notifyPotentialReusable
-    # 3665521 - Unresponsive System due to Memory Reclaim of Huge Alignment Pages
 
     # PRECONDITIONS
     if [[ ${#HANA_SIDS[@]} -eq 0 ]]; then
@@ -115,8 +118,8 @@ function check_8050_hana_revision_infra_issues {
 
             _sid_listed=false
 
-            # i+=5 --> every 5th item
-            for ((i=0; i < ${#_hana_all[@]}; i+=5)); do
+            # i+=4 --> every 4th item
+            for ((i=0; i < ${#_hana_all[@]}; i+=4)); do
 
                 logTrace "<${FUNCNAME[0]}> # ${_hana_all[$i]}>"
 
@@ -135,7 +138,7 @@ function check_8050_hana_revision_infra_issues {
                     if [[ $? -le 1 ]]; then
 
                         sapnote="${_hana_all[$i + 3]}"
-                        _descr="${_hana_all[$i + 4]}"
+                        _descr="${_sapnote_descriptions[${sapnote}]}"
 
                         if [[ ${_sid_listed} == false ]]; then
 


### PR DESCRIPTION
…escriptions

- Add SAP Note descriptions lookup table (_sapnote_descriptions) with 17 entries
- Remove duplicate descriptions from _hana_all, _hana_intel, and _hana_ibmpower arrays
- Reduce array elements from 5 to 4 per entry (SPSP, lower bound, upper bound, SAP Note)
- Update main loop logic from i+=5 to i+=4 and use dictionary lookup for descriptions
- Order SAP Note descriptions by note number for better maintainability

Benefits:
- Eliminates redundant storage of descriptions across multiple arrays
- Reduces memory usage by ~20% (array size reduction)
- Single source of truth for SAP Note descriptions
- Improved maintainability - descriptions updated in one place
- Cleaner architecture with separation of data and descriptions

Technical changes:
- Changed loop increment from i+=5 to i+=4
- Replaced _hana_all[i+4] with _sapnote_descriptions[sapnote] lookup
- All existing functionality preserved, unit tests passing