### PR TITLE
feat: Update RHEL support matrices for IBM Cloud

### DIFF
--- a/scripts/lib/check/0003_os_hana_support_rhel_intel.check
+++ b/scripts/lib/check/0003_os_hana_support_rhel_intel.check
@@ -39,7 +39,7 @@ function check_0003_os_hana_support_rhel_intel {
     local -ar _rhel_9=(\
                         'Microsoft Azure'       '0-2-4-6----'   \
                         'Amazon EC2'            '0-2-4-6----'   \
-                        'IBM Cloud'             '0-2-4------'   \
+                        'IBM Cloud'             '0-2-4-6----'   \
                         'Google GCP'            '0-2-4-6----'   \
                         'Alibaba Cloud ECS'     '-----------'   \
                         'Huawei Cloud'          '-----------'   \

--- a/scripts/lib/check/0005_os_hana_support_rhel_ibmpower.check
+++ b/scripts/lib/check/0005_os_hana_support_rhel_ibmpower.check
@@ -18,7 +18,7 @@ function check_0005_os_hana_support_rhel_ibmpower {
                             'POWER9'        '7'    '----------'  \
                             )
     local -ar _rhel_matrix_ibmcloud=(\
-                            'POWER11'       '9'    '-------'        \
+                            'POWER11'       '9'    '------6'        \
                             'POWER10'       '9'    '--2-4'          \
                             'POWER9'        '9'    '--2-4'          \
                             'POWER11'       '8'    '-----------'    \


### PR DESCRIPTION
- Add RHEL 9.6 support for IBM Cloud Intel platforms (check 0003)
- Add RHEL 9.6 support for IBM Power11 on IBM Cloud (check 0005)

References:
- SAP Note #2947579: SAP HANA on IBM Power Virtual Servers