### PR TITLE
fix: Use wildcard pattern for SLES4SAP detection in lib_linux_release

### DIFF
--- a/scripts/bin/lib_linux_release
+++ b/scripts/bin/lib_linux_release
@@ -318,7 +318,7 @@ function __lib_func_get_sles4sap {
 
         _baseproduct=$(readlink /etc/products.d/baseproduct)
 
-        [[ ${_baseproduct} == 'SLES_SAP.prod' ]] && lib_release_sles4sap=true
+        [[ ${_baseproduct} == *'SLES_SAP.prod' ]] && lib_release_sles4sap=true
 
     fi
 


### PR DESCRIPTION
## Overview
This pull request fixes the SLES4SAP detection logic in the `lib_linux_release` library by improving the pattern matching for the SLES_SAP.prod file.

## Problem Statement
The current SLES4SAP detection logic uses an exact string match when checking the baseproduct symlink:
```bash
[[ ${_baseproduct} == 'SLES_SAP.prod' ]] && lib_release_sles4sap=true
```

This approach fails when the baseproduct path contains directory prefixes or full paths, which can occur in different system configurations.

## Solution
Changed the exact match to a wildcard pattern match:
```bash
[[ ${_baseproduct} == *'SLES_SAP.prod' ]] && lib_release_sles4sap=true
```

### Key Benefits
1. **Improved Robustness**: Handles baseproduct paths with prefixes or full directory paths
2. **Consistent Detection**: Works across different SLES4SAP installation configurations
3. **Backward Compatibility**: Still works with existing exact matches while supporting new scenarios

## Technical Details

### Files Changed
- `scripts/bin/lib_linux_release` - Line 321: Updated SLES4SAP detection pattern

### Testing Implications
- The `LIB_FUNC_IS_SLES4SAP()` function will now correctly identify SLES4SAP systems where the baseproduct symlink contains path prefixes
- No impact on existing functionality for systems with exact matches

### Code Quality
- Follows existing Bash best practices in the codebase
- Maintains the same return value semantics
- No breaking changes to the API

## Impact Assessment
- **Risk Level**: Low - This is a targeted fix that only affects the pattern matching logic
- **Scope**: Improves reliability of SLES4SAP detection across different system configurations
- **Dependencies**: No changes to function signatures or external dependencies

## Validation
This change improves the reliability of SLES4SAP detection without affecting:
- Other OS detection functions (RHEL, OLS, etc.)
- SAP HANA validation checks that depend on `LIB_FUNC_IS_SLES4SAP()`
- Overall framework functionality

## Related Work
This fix ensures consistent OS detection across the SAP HANA validation framework, supporting the reliability requirements of checks that depend on accurate SLES4SAP identification.