### PR TITLE
Update HANA SPS Version Guidance in Timer and Clocksource Check 0300

### DIFF
--- a/scripts/lib/check/0300_timer_and_clocksource_intel.check
+++ b/scripts/lib/check/0300_timer_and_clocksource_intel.check
@@ -93,18 +93,18 @@ function check_0300_timer_and_clocksource_intel {
                 #evaluate RC
                 if [[ ${_retval} -ne 99 ]]; then
 
+                    logCheckInfo 'HANA2 SPS7+8 should use OS clocksource'
                     logCheckInfo 'HANA2 SPS4+5 will NOT use internal timer and fall back to OS clocksource'
                     logCheckInfo 'Check indexserver trace files for <Fallback to system call for HR timer> messages'
                     logCheckInfo 'The trace message can be suppressed by setting variable <HDB_TIMER=system>'
-                    logCheckInfo 'HANA2 SPS6+7 should use OS clocksource'
 
                     logCheckWarning "OS clocksource is NOT set as recommended as unintended fallback might happen (SAP Note ${sapnote:-}) (is: ${current_clocksource})"
                     _retval=1
 
                 else
 
+                    logCheckInfo 'HANA2 SPS7+8 should use OS clocksource'
                     logCheckInfo 'HANA2 SPS4+5 should use internal timer'
-                    logCheckInfo 'HANA2 SPS6+7 should use OS clocksource'
                     logCheckOk "OS clocksource is set as recommended (SAP Note ${sapnote:-}) (is: ${current_clocksource})"
                     _retval=0
 
@@ -125,10 +125,10 @@ function check_0300_timer_and_clocksource_intel {
             _retval=2
 
         else
+            logCheckInfo 'HANA2 SPS7+8 should use OS clocksource'
             logCheckInfo 'HANA2 SPS4+5 will NOT use internal timer and fall back to OS clocksource'
             logCheckInfo 'Check indexserver trace files for <Fallback to system call for HR timer> messages'
             logCheckInfo 'The trace message can be suppressed by setting variable <HDB_TIMER=system>'
-            logCheckInfo 'HANA2 SPS6+7 should use OS clocksource'
 
             logCheckOk "OS clocksource is set as recommended (SAP Note ${sapnote:-}) (is: ${current_clocksource})"
             _retval=0


### PR DESCRIPTION
# Update HANA SPS Version Guidance in Timer and Clocksource Check 0300

## Overview
This pull request updates the SAP HANA SPS version guidance in the timer and clocksource check (0300) to reflect current best practices and recommendations for OS clocksource usage.

## Problem Statement
The existing check contained outdated HANA SPS version references (SPS6+7) in the informational messages, which could mislead users about current SAP HANA timer configuration best practices.

## Solution
Updated all references from "HANA2 SPS6+7" to "HANA2 SPS7+8" to align with current SAP HANA recommendations for OS clocksource usage.

### Key Changes

#### 1. Updated Informational Messages
Replaced outdated version references in three locations within the check:
- TSC validation success path
- TSC validation warning path  
- System/fallback clocksource validation path

#### 2. Consistent Guidance Updates
**Before:**
```bash
logCheckInfo 'HANA2 SPS6+7 should use OS clocksource'
```

**After:**
```bash
logCheckInfo 'HANA2 SPS7+8 should use OS clocksource'
```

#### 3. Maintained Consistency
- **HANA2 SPS4+5**: Guidance unchanged - should use internal timer with fallback behavior
- **HANA2 SPS7+8**: Updated guidance - should use OS clocksource

## Technical Details

### Files Modified
- `scripts/lib/check/0300_timer_and_clocksource_intel.check`
  - Line 96: Updated SPS guidance in TSC warning path
  - Line 106: Updated SPS guidance in TSC success path
  - Line 128: Updated SPS guidance in fallback path

### Affected Scenarios
1. **TSC Clocksource with Issues**: Users see updated SPS7+8 guidance when TSC flags are missing
2. **TSC Clocksource Success**: Users get current information about SPS7+8 OS clocksource usage
3. **Non-TSC Clocksources**: Fallback scenarios display updated SPS guidance

### Impact on Check Logic
- **No Functional Changes**: Check validation logic remains unchanged
- **Informational Only**: Updates only affect user-facing guidance messages
- **Consistent Framework**: Maintains established check patterns and return codes

## Benefits

### Updated Best Practices
- **Current Information**: Users receive accurate HANA SPS version guidance
- **Consistent Messaging**: All three message locations now reflect the same version recommendations
- **Clear Guidance**: Users understand which HANA versions should use OS clocksource vs internal timer

### Operational Impact
- **Improved Decision Making**: System administrators get current information for timer configuration
- **Reduced Confusion**: Eliminates outdated version references that could mislead users
- **Better Compliance**: Helps ensure systems follow current SAP HANA best practices

## Quality Assurance

### Message Consistency
- All three informational message locations updated consistently
- SPS4+5 guidance maintained for backward compatibility
- SPS7+8 guidance updated to reflect current recommendations

### Testing Impact
- **No Unit Test Changes Required**: Functional logic unchanged
- **Message Validation**: Informational messages reflect updated guidance
- **Backward Compatibility**: Existing behavior preserved for all validation paths

## Risk Assessment
- **Risk Level**: Very Low - Informational message updates only
- **Scope**: Only affects user-facing guidance messages
- **Functional Impact**: None - check validation logic unchanged

## Related Work
This update aligns the timer and clocksource check with current SAP HANA documentation and best practices, ensuring users receive accurate guidance for their HANA SPS version planning and system configuration.