### PR TITLE
feat: Update SAP Host Agent version requirements in check 0800

### DIFF
--- a/scripts/lib/check/0800_sap_host_agent.check
+++ b/scripts/lib/check/0800_sap_host_agent.check
@@ -12,13 +12,13 @@ function check_0800_sap_host_agent {
     local -r sapnote_deprecated='#2130510'
     local -r hostagent_kernel_deprecated='721'
 
-    local -r sapnote_latest='#3598486'
-    local -r hostagent_version_expected='722.68.0'
+    local -r sapnote_latest='#3633527'
+    local -r hostagent_version_expected='722.69.0'
     # MODIFICATION SECTION<<
 
     #1113545 - Problems with SAP Host Agent
     #2130510 - SAP Host Agent 7.21
-    #3598486 - SAP Host Agent 7.22 PL68
+    #3633527 - SAP Host Agent 7.22 PL69
 
     local -r saphostexec_path='/usr/sap/hostctrl/exe/saphostexec'
 


### PR DESCRIPTION
- Updated sapnote_latest from #3598486 to #3633527
- Updated hostagent_version_expected from 722.68.0 to 722.69.0
- Updated comment from 'SAP Host Agent 7.22 PL68' to 'SAP Host Agent 7.22 PL69'
- Reflects latest SAP Host Agent requirements as per SAP Note #3633527

This ensures the check validates against the most current SAP Host Agent version recommendations.