### PR TITLE
Update SAP HANA Infrastructure Issue Check 8050

### DIFF
--- a/scripts/lib/check/8050_hana_revision_infra_issues.check
+++ b/scripts/lib/check/8050_hana_revision_infra_issues.check
@@ -27,6 +27,7 @@ function check_8050_hana_revision_infra_issues {
         ['3610237']='Indexserver Crash on virtualized Intel Ice Lake hosts'
         ['3665521']='Unresponsive System due to Memory Reclaim of Huge Alignment Pages'
         ['3669696']='Unresponsive System due to late Memory Reclaim cause of gc_unused_memory_threshold-*'
+        ['3680406']='Optimizing Memory Allocation for SAP HANA Services by Adjusting min_segment_size'
     )
 
     # array             'SPSP'  'lower bound'    'upper bound'  'SAP Note'
@@ -76,6 +77,10 @@ function check_8050_hana_revision_infra_issues {
                         '5'     '2.00.050.00'    '2.00.059.99'  '3669696'   \
                         '7'     '2.00.070.00'    '2.00.079.07'  '3669696'   \
                         '8'     '2.00.080.00'    '2.00.087.00'  '3669696'   \
+
+                        '5'     '2.00.050.00'    '2.00.059.99'  '3680406'   \
+                        '7'     '2.00.070.00'    '2.00.079.99'  '3680406'   \
+                        '8'     '2.00.080.00'    '2.00.089.99'  '3680406'   \
                         )
 
     local -ar _hana_intel=(\


### PR DESCRIPTION
## Summary

This PR enhances check `8050_hana_revision_infra_issues` by adding new SAP Note detection capabilities and updating existing version ranges for better coverage of known SAP HANA infrastructure issues.

## Changes Made

### Check 8050: SAP HANA Infrastructure Issues

#### Added New SAP Note 3669696
- **Description**: "Unresponsive System due to late Memory Reclaim cause of gc_unused_memory_threshold-*"
- **Affected Versions**: SPS 5/7/8 (2.00.050.00-2.00.087.00)

#### Added New SAP Note 3680406  
- **Description**: "Optimizing Memory Allocation for SAP HANA Services by Adjusting min_segment_size"
- **Affected Versions**: SPS 5/7/8 (2.00.050.00-2.00.089.99)
- **Impact**: Helps identify HANA instances that may benefit from min_segment_size tuning

#### Updated SAP Note 3528623 Version Ranges
- **Issue**: "Slow in table load/reload due to load trace writing"
- **Extended Coverage**: SPS 5 now covers all revisions (2.00.059.99)
- **Refined Range**: SPS 7 upper bound adjusted to 2.00.079.01

## Technical Details

### Check 8050 Overview
This check identifies SAP HANA instances that may be affected by known infrastructure-related issues. It:
- Scans all detected HANA SIDs and their release versions
- Compares versions against known problematic ranges
- Reports warnings for potentially affected instances
- Provides SAP Note references for remediation

### Validation
- ✅ Follows project coding standards
- ✅ Maintains existing check structure and pattern
- ✅ Proper SAP Note referencing format
- ✅ Version range logic is consistent with framework

### Files Modified
- `scripts/lib/check/8050_hana_revision_infra_issues.check`

## Impact

- **Low Risk**: Only adds new detection capabilities and refines existing ranges
- **No Breaking Changes**: Existing functionality remains intact
- **Enhanced Coverage**: Better detection of HANA infrastructure issues

## SAP Notes Referenced

- **3669696**: Memory reclaim with gc_unused_memory_threshold (NEW)
- **3680406**: Memory allocation optimization with min_segment_size (NEW)  
- **3528623**: Load trace performance (UPDATED ranges)

## Commit Information

### Commit 1: Initial SAP Note Updates
```
feat: Add SAP Note 3669696 and update 3528623 ranges in check 8050

- Add new SAP Note 3669696: 'Unresponsive System due to late Memory Reclaim cause of gc_unused_memory_threshold-*'
- Update SAP Note 3528623 ranges to cover all revisions in SPS5 and extend SPS7 coverage
- Affects HANA SPS 5 (2.00.050.00-2.00.059.99), SPS 7 (2.00.070.00-2.00.079.07), and SPS 8 (2.00.080.00-2.00.087.00)
```

### Commit 2: Additional SAP Note
```
feat: Add SAP Note 3680406 to check 8050

- Add SAP Note 3680406: 'Optimizing Memory Allocation for SAP HANA Services by Adjusting min_segment_size'
- Affects HANA SPS 5 (2.00.050.00-2.00.059.99), SPS 7 (2.00.070.00-2.00.079.99), and SPS 8 (2.00.080.00-2.00.089.99)
```