### PR TITLE
Fix regex pattern in check 5540 to use positive lookbehind

### DIFF
--- a/scripts/lib/check/5540_fs_hana_mount.check
+++ b/scripts/lib/check/5540_fs_hana_mount.check
@@ -13,14 +13,14 @@ function check_5540_fs_hana_mount {
     local -r fs_list_all_supported='xfs|gpfs|nfs|nfs4|ext3*|mpfs*|ocfs2*'
 
     local _rxHANAmounts
-    _rxHANAmounts='/hana/(data|log).*'  #also backup
+    _rxHANAmounts='(?<= )/hana/(data|log).*'  # require a leading space but don't include it in the match (PCRE)
 
     # MODIFICATION SECTION<<
 
     # SAP Note 2972496 - SAP HANA Filesystem Types
 
     # PRECONDITIONS
-    if ! grep -qsE "${_rxHANAmounts}" /proc/mounts; then
+    if ! grep -qsP "${_rxHANAmounts}" /proc/mounts; then
 
         logCheckSkipped "No HANA filesystem mounted (SAP Note ${sapnote:-}). Skipping" "<${FUNCNAME[0]}>"
         _retval=3
@@ -63,7 +63,7 @@ function check_5540_fs_hana_mount {
                     ;;
             esac
 
-        done <<< "$(grep -soE "${_rxHANAmounts}" /proc/mounts)"
+        done <<< "$(grep -soP "${_rxHANAmounts}" /proc/mounts)"
 
 
         if $is_supported && ! $is_not_supported && ! $is_expired_cert; then

--- a/scripts/tests/check/5540_fs_hana_mount_test.sh
+++ b/scripts/tests/check/5540_fs_hana_mount_test.sh
@@ -55,6 +55,8 @@ test_all_supported_fs() {
     hana_mounts+=('0.0.0.0:/vol /hana/log/OQL nfs rw,noatime')
     hana_mounts+=('0.0.0.0:/vol /hana/log/OQL nfs4 rw,noatime')
     hana_mounts+=('0.0.0.0:/vol /hana/log/OQL gpfs rw,noatime')
+    hana_mounts+=('0.0.0.0:/hana/data /hana/data nfs4 rw,relatime,vers=4.1,rsize=262144,wsize=262144')
+    hana_mounts+=('0.0.0.0:/hana/log /hana/log nfs4 rw,relatime,vers=4.1,rsize=262144,wsize=262144')
 
     # act
     check_5540_fs_hana_mount


### PR DESCRIPTION
## Summary of the Bug Fix
The fix addresses a regex pattern issue in check 5540 that handles SAP HANA filesystem type validation:

### Problem: 

The original regex pattern /hana/(data|log).* would match mount points even when they were part of NFS server volume names, causing incorrect filesystem type extraction.

### Solution:

Used PCRE positive lookbehind (?<= )/hana/(data|log).* to require a leading space but exclude it from the match
Changed grep from -E to -P to support Perl-compatible regex features
Added test cases to verify the corrected behavior