### PR TITLE
feat: Add OS override capability for testing

### DIFF
--- a/scripts/bin/lib_linux_release
+++ b/scripts/bin/lib_linux_release
@@ -349,6 +349,40 @@ function _lib_linux_release_main {
 
     __lib_func_get_linux_distrib
 
+    # Apply OS override if global variable is set
+    if [[ -n "${SAPHANA_CHECK_OS_OVERRIDE:-}" ]]; then
+        local _override_os
+        local _override_version
+
+        # Parse format: SLES:15.5 or RHEL:9.2 or OLS:8.6
+        if [[ "${SAPHANA_CHECK_OS_OVERRIDE}" =~ ^(SLES|RHEL|OLS):([0-9]+\.[0-9]+)$ ]]; then
+            _override_os="${BASH_REMATCH[1]}"
+            _override_version="${BASH_REMATCH[2]}"
+
+            case "${_override_os}" in
+                'SLES')
+                    OS_NAME="${lib_release_sles}"
+                    ;;
+                'RHEL')
+                    OS_NAME="${lib_release_rhel}"
+                    ;;
+                'OLS')
+                    OS_NAME="${lib_release_ols}"
+                    ;;
+            esac
+
+            OS_VERSION="${_override_version}"
+            OS_LEVEL=''
+
+            logWarn "Using OS override from --os_override flag: ${OS_NAME} ${OS_VERSION}"
+            logWarn "This override is for testing purposes only and may produce inaccurate results"
+        else
+            logError "Invalid OS override format: '${SAPHANA_CHECK_OS_OVERRIDE}'"
+            logError "Expected format: SLES:15.5 or RHEL:9.2 or OLS:8.6"
+            exit 2
+        fi
+    fi
+
     readonly OS_NAME
     readonly OS_VERSION
     readonly OS_LEVEL

--- a/scripts/bin/saphana-check.sh
+++ b/scripts/bin/saphana-check.sh
@@ -55,6 +55,7 @@ DEFINE_boolean  'trace'     false   'enable trace mode (set loglevel=6)' 't'
 DEFINE_boolean  'color'     false   'enable color mode'
 DEFINE_boolean  'timestamp' false   'show timestamp (default for debug/trace)'
 DEFINE_boolean  'skip_os_validation' false 'skip early OS validation checks (for testing/backward compatibility)'
+DEFINE_string   'os_override' '' 'override detected OS for testing (format: SLES:15.5 or RHEL:9.2)'
 # shellcheck disable=SC2034
 IFS='' read -r -d '' FLAGS_HELP <<<"
 USAGE: ${PROGRAM_NAME} [flags]
@@ -108,6 +109,11 @@ function evaluate_cmdline_options {
     [[ ${FLAGS_timestamp:?} -eq ${FLAGS_TRUE} ]] && LOG_TIMESTAMP=0
 
     [[ ${LOG_VERBOSE_LVL} -ge 5 ]] && LOG_TIMESTAMP=0
+
+    # Set OS override as global variable for lib_linux_release to use
+    if [[ -n "${FLAGS_os_override:-}" ]]; then
+        SAPHANA_CHECK_OS_OVERRIDE="${FLAGS_os_override}"
+    fi
 
     logDebug "<${BASH_SOURCE[0]}:${FUNCNAME[0]}> # LOG_VERBOSE_LVL=${LOG_VERBOSE_LVL}"
 }

--- a/scripts/tests/OSOverride_test.sh
+++ b/scripts/tests/OSOverride_test.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+set -u      # treat unset variables as an error
+
+PROGRAM_DIR="${BASH_SOURCE[0]%/*}"
+[[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
+readonly PROGRAM_DIR
+
+testOSOverride_SLES_Valid() {
+    # Test valid SLES override
+    
+    export SAPHANA_CHECK_OS_OVERRIDE='SLES:15.5'
+    
+    # Test in subshell to avoid affecting global state
+    local result
+    result=$(
+        unset LIB_LINUX_RELEASE
+        source "${PROGRAM_DIR}/../bin/lib_linux_release" 2>&1 >/dev/null
+        echo "${OS_NAME}|${OS_VERSION}"
+    )
+    
+    local os_name="${result%%|*}"
+    local os_version="${result##*|}"
+    
+    assertEquals "OS_NAME should be Linux SLES" 'Linux SLES' "${os_name}"
+    assertEquals "OS_VERSION should be 15.5" '15.5' "${os_version}"
+    
+    unset SAPHANA_CHECK_OS_OVERRIDE
+}
+
+testOSOverride_RHEL_Valid() {
+    # Test valid RHEL override
+    
+    export SAPHANA_CHECK_OS_OVERRIDE='RHEL:9.2'
+    
+    # Test in subshell to avoid affecting global state
+    local result
+    result=$(
+        unset LIB_LINUX_RELEASE
+        source "${PROGRAM_DIR}/../bin/lib_linux_release" 2>&1 >/dev/null
+        echo "${OS_NAME}|${OS_VERSION}"
+    )
+    
+    local os_name="${result%%|*}"
+    local os_version="${result##*|}"
+    
+    assertEquals "OS_NAME should be Linux RHEL" 'Linux RHEL' "${os_name}"
+    assertEquals "OS_VERSION should be 9.2" '9.2' "${os_version}"
+    
+    unset SAPHANA_CHECK_OS_OVERRIDE
+}
+
+testOSOverride_OLS_Valid() {
+    # Test valid Oracle Linux override
+    
+    export SAPHANA_CHECK_OS_OVERRIDE='OLS:8.6'
+    
+    # Test in subshell to avoid affecting global state
+    local result
+    result=$(
+        unset LIB_LINUX_RELEASE
+        source "${PROGRAM_DIR}/../bin/lib_linux_release" 2>&1 >/dev/null
+        echo "${OS_NAME}|${OS_VERSION}"
+    )
+    
+    local os_name="${result%%|*}"
+    local os_version="${result##*|}"
+    
+    assertEquals "OS_NAME should be Linux OLS" 'Linux OLS' "${os_name}"
+    assertEquals "OS_VERSION should be 8.6" '8.6' "${os_version}"
+    
+    unset SAPHANA_CHECK_OS_OVERRIDE
+}
+
+testOSOverride_InvalidFormat_MissingColon() {
+    # Test invalid format without colon
+    
+    export SAPHANA_CHECK_OS_OVERRIDE='SLES15.5'
+    
+    # This should exit with error code 2, so we need to test in a subshell
+    local _rc=0
+    (
+        unset LIB_LINUX_RELEASE
+        source "${PROGRAM_DIR}/../bin/lib_linux_release" 2>/dev/null
+    ) || _rc=$?
+    
+    assertEquals "Invalid format should exit with code 2" 2 ${_rc}
+    
+    unset SAPHANA_CHECK_OS_OVERRIDE
+}
+
+testOSOverride_InvalidFormat_WrongDistribution() {
+    # Test invalid distribution name
+    
+    export SAPHANA_CHECK_OS_OVERRIDE='Ubuntu:22.04'
+    
+    # This should exit with error code 2
+    local _rc=0
+    (
+        unset LIB_LINUX_RELEASE
+        source "${PROGRAM_DIR}/../bin/lib_linux_release" 2>/dev/null
+    ) || _rc=$?
+    
+    assertEquals "Invalid distribution should exit with code 2" 2 ${_rc}
+    
+    unset SAPHANA_CHECK_OS_OVERRIDE
+}
+
+testOSOverride_InvalidFormat_BadVersion() {
+    # Test invalid version format (missing minor version)
+    
+    export SAPHANA_CHECK_OS_OVERRIDE='SLES:15'
+    
+    # This should exit with error code 2
+    local _rc=0
+    (
+        unset LIB_LINUX_RELEASE
+        source "${PROGRAM_DIR}/../bin/lib_linux_release" 2>/dev/null
+    ) || _rc=$?
+    
+    assertEquals "Invalid version format should exit with code 2" 2 ${_rc}
+    
+    unset SAPHANA_CHECK_OS_OVERRIDE
+}
+
+testOSOverride_InvalidFormat_ExtraFields() {
+    # Test invalid format with extra fields
+    
+    export SAPHANA_CHECK_OS_OVERRIDE='SLES:15.5:extra'
+    
+    # This should exit with error code 2
+    local _rc=0
+    (
+        unset LIB_LINUX_RELEASE
+        source "${PROGRAM_DIR}/../bin/lib_linux_release" 2>/dev/null
+    ) || _rc=$?
+    
+    assertEquals "Extra fields should exit with code 2" 2 ${_rc}
+    
+    unset SAPHANA_CHECK_OS_OVERRIDE
+}
+
+testOSOverride_ValidFormats_Various() {
+    # Test various valid version formats
+    
+    local -a valid_overrides=(
+        'SLES:12.5'
+        'SLES:15.3'
+        'SLES:15.10'
+        'RHEL:7.9'
+        'RHEL:8.0'
+        'RHEL:9.99'
+        'OLS:7.9'
+        'OLS:8.10'
+    )
+    
+    for override in "${valid_overrides[@]}"; do
+        export SAPHANA_CHECK_OS_OVERRIDE="${override}"
+        
+        # Reload lib_linux_release with override
+        local _rc=0
+        (
+            unset LIB_LINUX_RELEASE
+            source "${PROGRAM_DIR}/../bin/lib_linux_release" 2>/dev/null
+        ) || _rc=$?
+        
+        assertEquals "Override ${override} should be valid" 0 ${_rc}
+    done
+    
+    unset SAPHANA_CHECK_OS_OVERRIDE
+}
+
+testOSOverride_NoOverride() {
+    # Test that without override, normal detection works
+    
+    unset SAPHANA_CHECK_OS_OVERRIDE
+    
+    # Reload lib_linux_release without override
+    # Note: This will actually detect the real OS, so we just verify it doesn't crash
+    local _rc=0
+    (
+        unset LIB_LINUX_RELEASE
+        source "${PROGRAM_DIR}/../bin/lib_linux_release" 2>/dev/null
+        # Just verify the variables are set
+        [[ -n "${OS_NAME}" ]] || exit 1
+        [[ -n "${OS_VERSION}" ]] || exit 1
+    ) || _rc=$?
+    
+    assertEquals "Without override, normal detection should work" 0 ${_rc}
+}
+
+oneTimeSetUp () {
+
+    # Store original values to restore later
+    ORIGINAL_OS_NAME="${OS_NAME:-}"
+    ORIGINAL_OS_VERSION="${OS_VERSION:-}"
+    ORIGINAL_OS_LEVEL="${OS_LEVEL:-}"
+
+    #shellcheck source=./saphana-logger-stubs
+    source "${PROGRAM_DIR}/./saphana-logger-stubs"
+
+}
+
+oneTimeTearDown() {
+    # Restore original values
+    OS_NAME="${ORIGINAL_OS_NAME}"
+    OS_VERSION="${ORIGINAL_OS_VERSION}"
+    OS_LEVEL="${ORIGINAL_OS_LEVEL}"
+    
+    unset SAPHANA_CHECK_OS_OVERRIDE
+}
+
+# setUp - runs before each test
+setUp() {
+    # Ensure clean state for each test
+    unset SAPHANA_CHECK_OS_OVERRIDE
+}
+
+# tearDown - runs after each test
+tearDown() {
+    # Clean up
+    unset SAPHANA_CHECK_OS_OVERRIDE
+}
+
+#Import Libraries
+# - order is important - sourcing shunit triggers testing
+# - that's also the reason, why it could not be done during oneTimeSetup
+
+#shellcheck source=./shunit2
+source "${PROGRAM_DIR}/shunit2"


### PR DESCRIPTION
- Add --os_override command-line flag for overriding detected OS
- Parse format: SLES:15.5, RHEL:9.2, or OLS:8.6
- Set SAPHANA_CHECK_OS_OVERRIDE as global variable (not exported)
- Implement override logic in lib_linux_release before making OS readonly
- Add comprehensive unit tests in OSOverride_test.sh
- Display warnings when override is active
- Validate override format and exit with error code 2 on invalid format

This allows testing checks against different OS versions without requiring actual system changes or multiple test environments.