### PR TITLE
Add check 2330: Validate swap space configuration

### DIFF
--- a/scripts/lib/check/2330_swap_space.check
+++ b/scripts/lib/check/2330_swap_space.check
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+function check_2330_swap_space {
+
+    logTrace "<${BASH_SOURCE[0]}:${FUNCNAME[*]}>"
+
+    local -i _retval=99
+
+    # MODIFICATION SECTION>>
+    local -r sapnote='#1999997'
+    local -ir minimum_swap_gib=10
+    # MODIFICATION SECTION<<
+
+    # 1999997 - FAQ: SAP HANA Memory
+    # SAP HANA requires swap space to be configured
+
+    #tweaked by unit-test
+    local -r path_to_proc_swaps="${path_to_proc_swaps:-/proc/swaps}"
+
+    # PRECONDITIONS
+    if [[ -z "${mock_proc_swaps_content:-}" && ! -f "${path_to_proc_swaps}" ]]; then
+
+        logCheckError "Swap information not available (SAP Note ${sapnote:-}). ${path_to_proc_swaps} not found"
+        _retval=2
+
+    else
+        # CHECK
+
+        local -i total_swap_kb=0
+        local -i line_count=0
+
+        # Read content into variable (from mock or real file)
+        local proc_swaps_content
+        if [[ -n "${mock_proc_swaps_content:-}" ]]; then
+            proc_swaps_content="${mock_proc_swaps_content}"
+        else
+            proc_swaps_content=$(<"${path_to_proc_swaps}")
+        fi
+
+        while read -r filename _type size _used _priority; do
+
+            # Skip header line
+            [[ "${filename}" == "Filename" ]] && continue
+
+            # Skip empty lines
+            [[ -z "${filename}" ]] && continue
+
+            # Validate that size is numeric
+            if [[ ! "${size}" =~ ^[0-9]+$ ]]; then
+                logCheckError "Invalid swap size data in ${path_to_proc_swaps} (SAP Note ${sapnote:-}) (non-numeric value: ${size})"
+                _retval=2
+                break
+            fi
+
+            total_swap_kb=$(( total_swap_kb + size ))
+            line_count=$(( line_count + 1 ))
+
+        done <<< "${proc_swaps_content}"
+
+        # Only evaluate if no error occurred during parsing
+        if [[ ${_retval} -eq 99 ]]; then
+
+            # Convert KiB to GiB (1 GiB = 1048576 KiB)
+            local -i total_swap_gib=$(( total_swap_kb / 1048576 ))
+
+            if [[ ${line_count} -eq 0 ]]; then
+
+                logCheckError "No swap space configured (SAP Note ${sapnote:-}) (found: 0GiB, required: ${minimum_swap_gib}GiB)"
+                _retval=2
+
+            elif [[ ${total_swap_gib} -lt ${minimum_swap_gib} ]]; then
+
+                logCheckError "Insufficient swap space configured (SAP Note ${sapnote:-}) (found: ${total_swap_gib}GiB, required: ${minimum_swap_gib}GiB)"
+                _retval=2
+
+            else
+
+                logCheckOk "Sufficient swap space configured (SAP Note ${sapnote:-}) (found: ${total_swap_gib}GiB, required: ${minimum_swap_gib}GiB)"
+                _retval=0
+
+            fi
+
+        fi
+
+    fi
+
+    logDebug "<${BASH_SOURCE[0]}:${FUNCNAME[0]}> # RC=${_retval}"
+    return ${_retval}
+
+}

--- a/scripts/lib/checkset/RHELonPoweronly.checkset
+++ b/scripts/lib/checkset/RHELonPoweronly.checkset
@@ -42,6 +42,7 @@
 2315_vm_zone_reclaim_mode
 2320_vm_overcommit_memory
 2325_vm_swappiness
+2330_swap_space
 2400_samepage_merging
 2500_kernel_sharedmemory
 2510_kernel_semaphores

--- a/scripts/lib/checkset/RHELonX64only.checkset
+++ b/scripts/lib/checkset/RHELonX64only.checkset
@@ -49,6 +49,7 @@
 2315_vm_zone_reclaim_mode
 2320_vm_overcommit_memory
 2325_vm_swappiness
+2330_swap_space
 2400_samepage_merging
 2500_kernel_sharedmemory
 2510_kernel_semaphores

--- a/scripts/lib/checkset/SLESonPoweronly.checkset
+++ b/scripts/lib/checkset/SLESonPoweronly.checkset
@@ -42,6 +42,7 @@
 2315_vm_zone_reclaim_mode
 2320_vm_overcommit_memory
 2325_vm_swappiness
+2330_swap_space
 2400_samepage_merging
 2500_kernel_sharedmemory
 2510_kernel_semaphores

--- a/scripts/lib/checkset/SLESonX64only.checkset
+++ b/scripts/lib/checkset/SLESonX64only.checkset
@@ -50,6 +50,7 @@
 2315_vm_zone_reclaim_mode
 2320_vm_overcommit_memory
 2325_vm_swappiness
+2330_swap_space
 2400_samepage_merging
 2500_kernel_sharedmemory
 2510_kernel_semaphores

--- a/scripts/tests/check/2330_swap_space_test.sh
+++ b/scripts/tests/check/2330_swap_space_test.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -u  # treat unset variables as an error
+
+PROGRAM_DIR="${BASH_SOURCE[0]%/*}"
+[[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
+readonly PROGRAM_DIR
+
+test_proc_swaps_not_found() {
+
+    #arrange
+    path_to_proc_swaps="${PROGRAM_DIR}/nonexistent_swaps_file"
+    unset mock_proc_swaps_content
+
+    #act
+    check_2330_swap_space
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_no_swap_configured() {
+
+    #arrange
+    mock_proc_swaps_content=$'Filename Type Size Used Priority'
+
+    #act
+    check_2330_swap_space
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_insufficient_swap_single_area() {
+
+    #arrange
+    # 9 GiB = 9437184 KiB
+    mock_proc_swaps_content=$'Filename Type Size Used Priority\n/dev/dm-1 partition 9437184 0 -2'
+
+    #act
+    check_2330_swap_space
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_sufficient_swap_single_area() {
+
+    #arrange
+    # 11 GiB = 11534336 KiB
+    mock_proc_swaps_content=$'Filename Type Size Used Priority\n/dev/dm-1 partition 11534336 0 -2'
+
+    #act
+    check_2330_swap_space
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_sufficient_swap_exact_threshold() {
+
+    #arrange
+    # Exactly 10 GiB = 10485760 KiB
+    mock_proc_swaps_content=$'Filename  Type Size Used Priority\n/dev/dm-1 partition 10485760 0 -2'
+
+    #act
+    check_2330_swap_space
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_sufficient_swap_multiple_areas() {
+
+    #arrange
+    # 6 GiB + 5 GiB = 11 GiB total
+    mock_proc_swaps_content=$'Filename Type Size Used Priority\n/dev/dm-1 partition 6291456 0 -2\n/swapfile file 5242880 100 -3'
+
+    #act
+    check_2330_swap_space
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_insufficient_swap_multiple_areas() {
+
+    #arrange
+    # 4 GiB + 5 GiB = 9 GiB total (below threshold)
+    mock_proc_swaps_content=$'Filename Type Size Used Priority\n/dev/dm-1 partition 4194304 0 -2\n/swapfile file 5242880 100 -3'
+
+    #act
+    check_2330_swap_space
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_corrupted_non_numeric_size() {
+
+    #arrange
+    mock_proc_swaps_content=$'Filename Type Size Used Priority\n/dev/dm-1 partition INVALID 0 -2'
+
+    #act
+    check_2330_swap_space
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_empty_lines_ignored() {
+
+    #arrange
+    # 11 GiB with empty lines
+    mock_proc_swaps_content=$'Filename Type Size Used Priority\n/dev/dm-1 partition 11534336 0 -2\n\n'
+
+    #act
+    check_2330_swap_space
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_zero_swap_space() {
+
+    #arrange
+    mock_proc_swaps_content=$'Filename Type Size Used Priority\n/dev/dm-1 partition 0 0 -2'
+
+    #act
+    check_2330_swap_space
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+oneTimeSetUp() {
+
+    #shellcheck source=../saphana-logger-stubs
+    source "${PROGRAM_DIR}/../saphana-logger-stubs"
+
+    #shellcheck source=../../lib/check/2330_swap_space.check
+    source "${PROGRAM_DIR}/../../lib/check/2330_swap_space.check"
+}
+
+# oneTimeTearDown
+
+# setUp
+# tearDown
+
+#Import Libraries
+# - order is important - sourcing shunit triggers testing
+# - that's also the reason, why it could not be done during oneTimeSetup
+
+#Load and run shUnit2
+#shellcheck source=../shunit2
+source "${PROGRAM_DIR}/../shunit2"


### PR DESCRIPTION
## Summary
Adds a new check `2330_swap_space` to validate that SAP HANA systems have sufficient swap space configured (minimum 10 GiB).

## Changes
- **New check**: `scripts/lib/check/2330_swap_space.check`
  - Parses `/proc/swaps` to calculate total swap space
  - Validates against 10 GiB threshold
  - Provides detailed error messages with actual vs required values
  - References SAP Note #1999997

- **Platform support**: Added to all four checksets
  - `SLESonX64only.checkset`
  - `SLESonPoweronly.checkset`
  - `RHELonX64only.checkset`
  - `RHELonPoweronly.checkset`

- **Unit tests**: `scripts/tests/check/2330_swap_space_test.sh`
  - 10 comprehensive test scenarios
  - Pure bash approach with mock data (no temporary files)
  - All tests passing

## Implementation Details
- Pure bash implementation using here-strings
- No external command dependencies
- Efficient: reads file content once into variable
- Test-friendly: uses `mock_proc_swaps_content` variable for unit testing
- Handles edge cases: missing file, no swap, invalid data, multiple swap areas

## Testing
```bash
$ 2330_swap_space_test.sh
Ran 10 tests.
OK