### PR TITLE
Add IBM POWER11 platform support

### DIFF
--- a/scripts/bin/lib_platf_power
+++ b/scripts/bin/lib_platf_power
@@ -24,31 +24,20 @@ function LIB_FUNC_TRANSFORM_POWER_POWERMODE {
 
     logTrace "<${BASH_SOURCE[0]}:${FUNCNAME[*]}>"
 
-    # P7,P8                                             P9,P10
-    # 0x0001: "Dynamic, Favor Performance"              0x0001: "Maximum Performance"
-    # 0x0002: "None"                                    0x0002: "None"
-    # 0x0003: "Static"                                  0x0003: "Static"
-    # 0x00ff: "Dynamic, Favor Power"                    0x0004: "Dynamic Performance"
-    # default: "Unknown"                                default: "Unknown"
+    # P9,P10,?P11
+    # 0x0001: "Maximum Performance"
+    # 0x0002: "None"
+    # 0x0003: "Static"
+    # 0x0004: "Dynamic Performance"
+    # default: "Unknown"
 
-    if [[ "${LIB_PLATF_POWER_PLATFORM_BASE:-}" =~ POWER(10|9) ]]; then
+    if [[ "${LIB_PLATF_POWER_PLATFORM_BASE:-}" =~ POWER(11|10|9) ]]; then
 
         case "${powermode}" in
             '0001')  : 'Maximum Performance' ;;
             '0002')  : 'None' ;;
             '0003')  : 'Static' ;;
             '0004')  : 'Dynamic Performance' ;;
-            *)       : 'Unknown';;
-        esac
-        powermode="$_"
-
-    elif [[ "${LIB_PLATF_POWER_PLATFORM_BASE:-}" =~ POWER8 ]]; then
-
-        case "${powermode}" in
-            '0001')  : 'Dynamic, Favor Performance' ;;
-            '0002')  : 'None' ;;
-            '0003')  : 'Static' ;;
-            '00ff')  : 'Dynamic, Favor Power' ;;
             *)       : 'Unknown';;
         esac
         powermode="$_"

--- a/scripts/lib/check/0004_os_hana_support_sles_ibmpower.check
+++ b/scripts/lib/check/0004_os_hana_support_sles_ibmpower.check
@@ -11,16 +11,18 @@ function check_0004_os_hana_support_sles_ibmpower {
 
     # array                 'Platform'      'maj'   '01234567' (Minor Release)
     local -ar _sles_matrix_onprem=(\
-                            'POWER10'       '15'    '---34567'   \
-                            'POWER9'        '15'    '-1234567'   \
+                            'POWER11'       '15'    '------67'  \
+                            'POWER10'       '15'    '---34567'  \
+                            'POWER9'        '15'    '-1234567'  \
+                            'POWER11'       '12'    '------'    \
                             'POWER10'       '12'    '------'    \
                             'POWER9'        '12'    '----45'    \
                         )
 
     local -ar _sles_matrix_ibmcloud=(\
-                            'POWER11'       '15'    '------6-'   \
-                            'POWER10'       '15'    '----456-'   \
-                            'POWER9'        '15'    '----456-'   \
+                            'POWER11'       '15'    '------6-'  \
+                            'POWER10'       '15'    '----456-'  \
+                            'POWER9'        '15'    '----456-'  \
                             'POWER11'       '12'    '------'    \
                             'POWER10'       '12'    '------'    \
                             'POWER9'        '12'    '-----5'    \

--- a/scripts/lib/check/0005_os_hana_support_rhel_ibmpower.check
+++ b/scripts/lib/check/0005_os_hana_support_rhel_ibmpower.check
@@ -11,9 +11,11 @@ function check_0005_os_hana_support_rhel_ibmpower {
 
     #                       'Platform'      'maj'  '0123456789A' (Minor Release)
     local -a _rhel_matrix=(\
+                            'POWER11'       '9'    '------6'     \
                             'POWER10'       '9'    '0-2-4-6'     \
-                            'POWER10'       '8'    '------6-8-A' \
                             'POWER9'        '9'    '0-2-4-6'     \
+                            'POWER10'       '8'    '------6-8-A' \
+                            'POWER11'       '8'    '-----------' \
                             'POWER9'        '8'    '------6-8-A' \
                             'POWER9'        '7'    '----------'  \
                             )

--- a/scripts/lib/check/0106_supported_instances_ibmcloud.check
+++ b/scripts/lib/check/0106_supported_instances_ibmcloud.check
@@ -73,8 +73,14 @@ function check_0106_supported_instances_ibmcloud {
                         'sr2-165x22000' 'sr2-165x24000' 'sr2-165x26000' 'sr2-165x28000' \
                         'sr2-165x30500' \
 
-                        #IBM Power11 Systems
-                        'sr3-6x256'     'sr3-11x512'    'sr3-19x1024'   'sr3-76x6144'   'sr3-229x30500' \
+                        #IBM Power11 System S1122 in SMT8 mode
+                        'sr3-6x256'     'sr3-11x512'    'sr3-19x1024'   \
+
+                        #IBM Power11 System E1150 in SMT8 mode
+                        'sr3-76x6144'   \
+
+                        #IBM Power11 System E1180 in SMT8 mode
+                        'sr3-229x30500' \
 
                         )
 

--- a/scripts/lib/check/0120_supported_powersystems_ibmpower.check
+++ b/scripts/lib/check/0120_supported_powersystems_ibmpower.check
@@ -9,6 +9,8 @@ function check_0120_supported_powersystems_ibmpower {
     # MODIFICATION SECTION>>
     # array             'System ID' 'System'
     local -ar _power_systems=(\
+                        #POWER11
+                        '9080-HEU'  'E1180' \
                         #POWER10
                         '9080-HEX'  'E1080' \
                         '9043-MRX'  'E1050' \
@@ -32,7 +34,7 @@ function check_0120_supported_powersystems_ibmpower {
     local -r sapnote='#2188482'
     # MODIFICATION SECTION<<
 
-    #2188482 - SAP HANA on IBM Power Systems: Allowed Hardware
+    #2188482 - SAP HANA on IBM Power Systems: Supported hardware and features
     #https://www.sap.com/dmc/exp/2014-09-02-hana-hardware/enEN/#/solutions?filters=power
 
     # PRECONDITIONS

--- a/scripts/lib/check/1260_cpu_smthreading_ibmpower.check
+++ b/scripts/lib/check/1260_cpu_smthreading_ibmpower.check
@@ -8,17 +8,17 @@ function check_1260_cpu_smthreading_ibmpower {
 
     # MODIFICATION SECTION>>
     local -r sapnote='#2055470,2188482'
-                                            #lt     #SMT-range
+                                            #ge     #SMT-range
         local -ar _smt_matrix=(\
-                            'POWER10'       '96'    '4'     \
+                            'POWER11'       '0'     '8|4(ScaleOut)'   \
                             'POWER10'       '0'     '4'     \
-                            'POWER9'        '96'    '4-8'   \
-                            'POWER9'        '0'     '4-8'   \
+                            'POWER9'        '96'    '4|8'   \
+                            'POWER9'        '0'     '4|8'   \
                         )
     # MODIFICATION SECTION<<
 
     #2055470 - HANA on POWER Planning and Installation Specifics - Central Note
-    #2188482 - SAP HANA on IBM Power Systems: Supported hardware and features - (Version: 90, Released On: 12.01.2024)
+    #2188482 - SAP HANA on IBM Power Systems: Supported hardware and features - (Version: 97, Released On: 25.11.2025)
 
     # PRECONDITIONS
     if ! LIB_FUNC_IS_IBMPOWER ; then
@@ -69,7 +69,7 @@ function check_1260_cpu_smthreading_ibmpower {
 
             if LIB_FUNC_STRINGCONTAIN "${_smt_range}" "${LIB_PLATF_CPU_THREADSPERCORE}"; then
 
-                logCheckOk "Simultaneous Multithreading mode set as recommended (SAP Note ${sapnote:-}) (is: SMT-${LIB_PLATF_CPU_THREADSPERCORE})"
+                logCheckOk "Simultaneous Multithreading mode set as recommended (SAP Note ${sapnote:-}) (is: SMT-${LIB_PLATF_CPU_THREADSPERCORE}, should be: SMT-${_smt_range})"
                 _retval=0
 
             else
@@ -84,7 +84,7 @@ function check_1260_cpu_smthreading_ibmpower {
 
         if ! ${_handled}; then
 
-            logCheckError "POWER platform with total cores not handled by check (SAP Note ${sapnote:-}) (is: ${LIB_PLATF_POWER_PLATFORM_BASE}-SMT${LIB_PLATF_CPU_THREADSPERCORE})"
+            logCheckError "POWER platform NOT handled by check (SAP Note ${sapnote:-}) (is: ${LIB_PLATF_POWER_PLATFORM_BASE}-SMT${LIB_PLATF_CPU_THREADSPERCORE})"
             _retval=2
         fi
 

--- a/scripts/lib/check/1310_cpu_powersavings_ibmpower.check
+++ b/scripts/lib/check/1310_cpu_powersavings_ibmpower.check
@@ -7,13 +7,10 @@ function check_1310_cpu_powersavings_ibmpower {
     local -i _retval=99
 
     # MODIFICATION SECTION>>
-    local -r sapnote='#2055470'
+    local -r sapnote='#3684765'
     # MODIFICATION SECTION<<
 
-    #2055470 - HANA on POWER Planning and Installation Specifics - Central Note
-    ## HWCCT + IBM Documentation "HANA operations guide"
-    #2684254 - SAP HANA DB: Recommended OS settings for SLES 15 / SLES for SAP Applications 15
-    #2777782 - SAP HANA DB: Recommended OS Settings for RHEL 8
+    #3684765 - IBM Power Systems: Recommended IBM EnergyScale settings
 
     # PRECONDITIONS
     if ! LIB_FUNC_IS_IBMPOWER ; then
@@ -67,23 +64,23 @@ function check_1310_cpu_powersavings_ibmpower {
 
         fi
 
-        if [[ "${LIB_PLATF_POWER_PLATFORM_BASE:-}" =~ POWER(10|9) ]]; then
+        if [[ "${LIB_PLATF_POWER_PLATFORM_BASE:-}" == 'POWER11' ]]; then
 
-            if [[ "${pwr_system_mode}" =~ ^(0001|0002|0004)$ ]];then
+            if [[ "${pwr_system_mode}" == '0001' ]];then
 
                 logCheckOk "Power Savings Mode set as recommended (SAP Note ${sapnote:-}) (is: ${pwr_system_txt})"
                 _retval=0
 
             else
 
-                logCheckError "Power Savings Mode NOT set as recommended (SAP Note ${sapnote:-}) (is: ${pwr_system_txt}, should be: None, *Perf mode)"
+                logCheckError "Power Savings Mode NOT set as recommended (SAP Note ${sapnote:-}) (is: ${pwr_system_txt}, should be: Maximum Performance)"
                 _retval=2
 
             fi
 
-        else
+        elif [[ "${LIB_PLATF_POWER_PLATFORM_BASE:-}" =~ POWER(10|9) ]]; then
 
-            if [[ "${pwr_system_mode}" =~ ^(0001|0002)$ ]]; then
+            if [[ "${pwr_system_mode}" =~ ^(0001|0002|0004)$ ]];then
 
                 logCheckOk "Power Savings Mode set as recommended (SAP Note ${sapnote:-}) (is: ${pwr_system_txt})"
                 _retval=0

--- a/scripts/tests/check/1260_cpu_smthreading_ibmpower_test.sh
+++ b/scripts/tests/check/1260_cpu_smthreading_ibmpower_test.sh
@@ -145,7 +145,7 @@ test_power10_threadspercore_smt4_ok() {
     assertEquals "CheckOk? RC" '0' "$?"
 }
 
-test_power10_threadspercore_warning() {
+test_power10_threadspercore_smt8_warning() {
 
     #arrange
     LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
@@ -160,6 +160,20 @@ test_power10_threadspercore_warning() {
     assertEquals "CheckWarn? RC" '1' "$?"
 }
 
+test_power10_corestotalhigh_covered() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
+    LIB_PLATF_CPU_SOCKETS=8
+    LIB_PLATF_CPU_CORESPERSOCKET=14
+    LIB_PLATF_CPU_THREADSPERCORE=4
+
+    #act
+    check_1260_cpu_smthreading_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
 
 # test_template() {
 

--- a/scripts/tests/check/1310_cpu_powersavings_ibmpower_test.sh
+++ b/scripts/tests/check/1310_cpu_powersavings_ibmpower_test.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+set -u  # treat unset variables as an error
+
+PROGRAM_DIR="${BASH_SOURCE[0]%/*}"
+[[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
+readonly PROGRAM_DIR
+
+#mock PREREQUISITE functions
+LIB_FUNC_IS_IBMPOWER() { return 0 ; }
+
+# Mock the transform function
+LIB_FUNC_TRANSFORM_POWER_POWERMODE() {
+    local powermode="$1"
+
+    if [[ "${LIB_PLATF_POWER_PLATFORM_BASE:-}" =~ POWER(11|10|9) ]]; then
+        case "${powermode}" in
+            '0001')  powermode='Maximum Performance' ;;
+            '0002')  powermode='None' ;;
+            '0003')  powermode='Static' ;;
+            '0004')  powermode='Dynamic Performance' ;;
+            *)       powermode='Unknown';;
+        esac
+    else
+        powermode='Unknown'
+    fi
+
+    printf -v RETURN_POWER_POWERMODE '%s' "${powermode}"
+}
+
+# Variables to mock
+# LIB_PLATF_POWER_POWERMODE=
+# LIB_PLATF_POWER_PLATFORM_BASE=
+# RETURN_POWER_POWERMODE=
+
+# ========================================
+# PRECONDITION TESTS
+# ========================================
+
+test_precondition_not_ibmpower_skipped() {
+
+    #arrange
+    LIB_FUNC_IS_IBMPOWER() { return 1 ; }
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
+    LIB_PLATF_POWER_POWERMODE='0002000200020002'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckSkipped? RC" '3' "$?"
+
+    #cleanup
+    # shellcheck disable=SC2329
+    LIB_FUNC_IS_IBMPOWER() { return 0 ; }
+}
+
+test_precondition_powermode_unknown() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
+    LIB_PLATF_POWER_POWERMODE=
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+# ========================================
+# POWER11 TESTS
+# ========================================
+
+test_power11_maximum_performance_ok() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER11'
+    LIB_PLATF_POWER_POWERMODE='0001000100010001'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_power11_maximum_performance_system_diff_partition_ok() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER11'
+    LIB_PLATF_POWER_POWERMODE='0001000100010002'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_power11_none_error() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER11'
+    LIB_PLATF_POWER_POWERMODE='0002000200020002'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_power11_static_error() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER11'
+    LIB_PLATF_POWER_POWERMODE='0003000300030003'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_power11_dynamic_performance_error() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER11'
+    LIB_PLATF_POWER_POWERMODE='0004000400040004'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_power11_unknown_mode_error() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER11'
+    LIB_PLATF_POWER_POWERMODE='00ff00ff00ff00ff'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+# ========================================
+# POWER10 TESTS
+# ========================================
+
+test_power10_maximum_performance_ok() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
+    LIB_PLATF_POWER_POWERMODE='0001000100010001'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_power10_none_ok() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
+    LIB_PLATF_POWER_POWERMODE='0002000200020002'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_power10_dynamic_performance_ok() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
+    LIB_PLATF_POWER_POWERMODE='0004000400040004'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_power10_static_error() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
+    LIB_PLATF_POWER_POWERMODE='0003000300030003'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_power10_unknown_mode_error() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
+    LIB_PLATF_POWER_POWERMODE='00ff00ff00ff00ff'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_power10_system_partition_mode_diff_ok() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
+    LIB_PLATF_POWER_POWERMODE='0001000100010002'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+# ========================================
+# POWER9 TESTS
+# ========================================
+
+test_power9_maximum_performance_ok() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER9'
+    LIB_PLATF_POWER_POWERMODE='0001000100010001'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_power9_none_ok() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER9'
+    LIB_PLATF_POWER_POWERMODE='0002000200020002'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_power9_dynamic_performance_ok() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER9'
+    LIB_PLATF_POWER_POWERMODE='0004000400040004'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_power9_static_error() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER9'
+    LIB_PLATF_POWER_POWERMODE='0003000300030003'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_power9_unknown_mode_error() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER9'
+    LIB_PLATF_POWER_POWERMODE='00ff00ff00ff00ff'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_power9_system_partition_mode_diff_ok() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER9'
+    LIB_PLATF_POWER_POWERMODE='0001000100010004'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+# ========================================
+# EDGE CASE TESTS
+# ========================================
+
+test_real_world_mixed_mode_power10() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
+    LIB_PLATF_POWER_POWERMODE='0002000200020004'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_real_world_mixed_mode_power9() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER9'
+    LIB_PLATF_POWER_POWERMODE='0004000400040002'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+test_system_mode_invalid_partition_valid_power10() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
+    LIB_PLATF_POWER_POWERMODE='0003000300030001'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckError? RC" '2' "$?"
+}
+
+test_system_mode_valid_partition_invalid_power11() {
+
+    #arrange
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER11'
+    LIB_PLATF_POWER_POWERMODE='0001000100010003'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    assertEquals "CheckOk? RC" '0' "$?"
+}
+
+# ========================================
+# SETUP AND TEARDOWN
+# ========================================
+
+oneTimeSetUp() {
+
+    #shellcheck source=../saphana-logger-stubs
+    source "${PROGRAM_DIR}/../saphana-logger-stubs"
+
+    #shellcheck source=../../lib/check/1310_cpu_powersavings_ibmpower.check
+    source "${PROGRAM_DIR}/../../lib/check/1310_cpu_powersavings_ibmpower.check"
+
+}
+
+# oneTimeTearDown
+
+setUp() {
+
+    LIB_PLATF_POWER_POWERMODE=
+    LIB_PLATF_POWER_PLATFORM_BASE=
+    RETURN_POWER_POWERMODE=
+
+}
+
+# tearDown
+
+#Import Libraries
+# - order is important - sourcing shunit triggers testing
+# - that's also the reason, why it could not be done during oneTimeSetup
+
+#Load and run shUnit2
+#shellcheck source=../shunit2
+source "${PROGRAM_DIR}/../shunit2"


### PR DESCRIPTION
- Update OS support matrices for SLES and RHEL on POWER11
  - SLES 15.6/15.7 support added
  - RHEL 9.6 support added
- Add POWER11 system hardware validation (E1180)
- Update SMT threading recommendations for POWER11
  - SMT-8 for scale-up, SMT-4 for scale-out scenarios
- Update power savings mode validation for POWER11
  - Requires Maximum Performance mode (stricter than POWER9/10)
- Remove obsolete POWER8 power mode handling
- Add comprehensive unit tests for checks 1260 and 1310
- Update SAP Note references to latest versions (#2188482 v97)

All changes align with SAP Note #2188482 (Released: 25.11.2025) and SAP Note #3684765 for IBM EnergyScale settings.