### PR TITLE
check 2010: adapt THP defrag check for kernels with fix (SAP Note #21…

### DIFF
--- a/scripts/lib/check/2010_transparent_hugepages_defrag.check
+++ b/scripts/lib/check/2010_transparent_hugepages_defrag.check
@@ -9,10 +9,21 @@ function check_2010_transparent_hugepages_defrag {
     # MODIFICATION SECTION>>
     local -r sapnote='#2131662'     # Transparent Huge Pages (THP) on SAP HANA Servers
 
-    #                              file                                                         recommended_value
+    #                              file                                                         reco_unfixed    reco_fixed
     local -ar _thp_defrag_parameter=(\
-                                    '/sys/kernel/mm/transparent_hugepage/defrag'                'never' \
-                                    '/sys/kernel/mm/transparent_hugepage/khugepaged/defrag'     '0'     \
+                                    '/sys/kernel/mm/transparent_hugepage/defrag'                'never'         'madvise'   \
+                                    '/sys/kernel/mm/transparent_hugepage/khugepaged/defrag'     '0'             '1'         \
+    )
+
+    # SLES kernel versions with THP defrag fix - defrag defaults (madvise/1) are recommended
+    # Versions >= _sles_fixed_from contain the fix from the start (no kernel check needed)
+    # Older versions require at least the listed kernel version
+    local -r  _sles_fixed_from='15.8'
+    #                              OS_VERSION   fixed_kernel_version
+    local -ar _sles_fixed_kernels=(\
+                                    '15.5'      '5.14.21-150500.55.136.1'   \
+                                    '15.6'      '6.4.0-150600.23.87.1'      \
+                                    '15.7'      '6.4.0-150700.53.31.1'      \
     )
     # MODIFICATION SECTION<<
 
@@ -44,6 +55,47 @@ function check_2010_transparent_hugepages_defrag {
 
     fi
 
+    # Check if running on SLES with a fixed kernel - defaults (madvise/1) are recommended
+    local -i _kernel_fixed=0
+    if [[ ${_retval} -eq 99 ]] && LIB_FUNC_IS_SLES ; then
+
+        # SLES versions >= _sles_fixed_from contain the fix from the start
+        LIB_FUNC_COMPARE_VERSIONS "${OS_VERSION}" "${_sles_fixed_from}"
+        if [[ $? -ne 2 ]]; then
+            _kernel_fixed=1
+            logCheckInfo "SLES ${OS_VERSION} includes THP defrag fix (SAP Note ${sapnote:-})"
+        else
+
+            local _kernel_curr
+            local _kernel_fixed_ver
+            local _release
+
+            _kernel_curr="${OS_LEVEL}"
+            LIB_FUNC_NORMALIZE_KERNELn _kernel_curr
+
+            # i+=2 --> every 2nd item
+            for ((i=0; i < ${#_sles_fixed_kernels[@]}; i+=2)); do
+
+                _release="${_sles_fixed_kernels[$i]}"
+                [[ "${OS_VERSION}" != "${_release}"* ]] && continue
+
+                _kernel_fixed_ver="${_sles_fixed_kernels[$i+1]}"
+                LIB_FUNC_NORMALIZE_KERNELn _kernel_fixed_ver
+
+                # returns 0 if equal, 1 if first is higher, 2 if second is higher
+                LIB_FUNC_COMPARE_VERSIONS "${_kernel_curr}" "${_kernel_fixed_ver}"
+                if [[ $? -ne 2 ]]; then
+                    _kernel_fixed=1
+                    logCheckInfo "Kernel includes THP defrag fix (SAP Note ${sapnote:-}) (is: ${OS_LEVEL}, fixed: >=${_sles_fixed_kernels[$i+1]})"
+                fi
+                break
+
+            done
+
+        fi
+
+    fi
+
     # CHECK
     if [[ ${_retval} -eq 99 ]]; then
 
@@ -51,11 +103,16 @@ function check_2010_transparent_hugepages_defrag {
         local _reco_value
         local _parameter
 
-        # i+=2 --> every 2nd item
-        for ((i=0; i < ${#_thp_defrag_parameter[@]}; i+=2)); do
+        # i+=3 --> every 3rd item (file, reco_unfixed, reco_fixed)
+        for ((i=0; i < ${#_thp_defrag_parameter[@]}; i+=3)); do
 
             _parameter=${_thp_defrag_parameter[$i]}
-            _reco_value=${_thp_defrag_parameter[$i+1]}
+
+            if [[ ${_kernel_fixed} -eq 1 ]]; then
+                _reco_value=${_thp_defrag_parameter[$i+2]}
+            else
+                _reco_value=${_thp_defrag_parameter[$i+1]}
+            fi
 
             logTrace "<${FUNCNAME[0]}> # '${_parameter}'>"
 

--- a/scripts/tests/check/2010_transparent_hugepages_defrag.bashunit.sh
+++ b/scripts/tests/check/2010_transparent_hugepages_defrag.bashunit.sh
@@ -14,6 +14,15 @@ fi
 # Mock directory for test files
 _mock_dir=''
 
+# Mock variables for kernel version check
+OS_VERSION=''
+OS_LEVEL=''
+
+# Mock functions - defaults: not SLES, no kernel normalization/comparison
+LIB_FUNC_IS_SLES() { return 1; }
+LIB_FUNC_NORMALIZE_KERNELn() { :; }
+LIB_FUNC_COMPARE_VERSIONS() { return 0; }
+
 function test_thp_defrag_not_configurable() {
 
     #arrange - no mock files created
@@ -177,6 +186,15 @@ function set_up() {
     # Create a temporary mock directory for each test
     _mock_dir=$(mktemp -d)
 
+    # Reset mock variables
+    OS_VERSION=''
+    OS_LEVEL=''
+
+    # Default: not SLES (existing tests don't need kernel version logic)
+    LIB_FUNC_IS_SLES() { return 1; }
+    LIB_FUNC_NORMALIZE_KERNELn() { :; }
+    LIB_FUNC_COMPARE_VERSIONS() { return 0; }
+
     # Override the check function to use mock paths using bash parameter expansion
     local _func_def
     local _orig_path='/sys/kernel/mm/transparent_hugepage'
@@ -198,5 +216,304 @@ function tear_down() {
     # Restore original check function
     source "${PROGRAM_DIR}/../../lib/check/2010_transparent_hugepages_defrag.check"
 
+}
+
+#------------------------------------------------------------------
+# Tests for SLES fixed kernel - checks against madvise/1 defaults
+#------------------------------------------------------------------
+
+function test_sles15sp5_fixed_kernel_defaults_ok() {
+
+    #arrange - SLES 15.5 with fixed kernel, defaults madvise/1
+    LIB_FUNC_IS_SLES() { return 0; }
+    OS_VERSION='15.5'
+    OS_LEVEL='5.14.21-150500.55.136.1-default'
+    LIB_FUNC_NORMALIZE_KERNELn() { :; }
+    # 1st call: OS_VERSION 15.5 < 15.8 -> 2, 2nd call: kernel equal -> 0
+    local -i _cmp_call=0
+    LIB_FUNC_COMPARE_VERSIONS() { ((_cmp_call++)); [[ ${_cmp_call} -eq 1 ]] && return 2; return 0; }
+
+    mkdir -p "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged"
+    echo 'always [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/enabled"
+    echo 'always defer defer+madvise [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/defrag"
+    echo '1' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged/defrag"
+
+    #act
+    check_2010_transparent_hugepages_defrag
+    local rc=$?
+
+    #assert - should pass (RC=0) because fixed kernel defaults madvise/1 are correct
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) when SLES 15.5 fixed kernel has defaults, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_sles15sp6_fixed_kernel_defaults_ok() {
+
+    #arrange - SLES 15.6 with newer-than-fixed kernel, defaults madvise/1
+    LIB_FUNC_IS_SLES() { return 0; }
+    OS_VERSION='15.6'
+    OS_LEVEL='6.4.0-150600.23.90.1-default'
+    LIB_FUNC_NORMALIZE_KERNELn() { :; }
+    # 1st call: OS_VERSION 15.6 < 15.8 -> 2, 2nd call: kernel higher -> 1
+    local -i _cmp_call=0
+    LIB_FUNC_COMPARE_VERSIONS() { ((_cmp_call++)); [[ ${_cmp_call} -eq 1 ]] && return 2; return 1; }
+
+    mkdir -p "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged"
+    echo 'always [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/enabled"
+    echo 'always defer defer+madvise [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/defrag"
+    echo '1' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged/defrag"
+
+    #act
+    check_2010_transparent_hugepages_defrag
+    local rc=$?
+
+    #assert - should pass because kernel is newer than fix and defaults are correct
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) when SLES 15.6 kernel is newer than fix, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_sles15sp5_fixed_kernel_wrong_defrag_always() {
+
+    #arrange - SLES 15.5 with fixed kernel, but defrag set to always instead of madvise
+    LIB_FUNC_IS_SLES() { return 0; }
+    OS_VERSION='15.5'
+    OS_LEVEL='5.14.21-150500.55.136.1-default'
+    LIB_FUNC_NORMALIZE_KERNELn() { :; }
+    # 1st call: OS_VERSION 15.5 < 15.8 -> 2, 2nd call: kernel equal -> 0
+    local -i _cmp_call=0
+    LIB_FUNC_COMPARE_VERSIONS() { ((_cmp_call++)); [[ ${_cmp_call} -eq 1 ]] && return 2; return 0; }
+
+    mkdir -p "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged"
+    echo 'always [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/enabled"
+    echo '[always] defer defer+madvise madvise never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/defrag"
+    echo '1' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged/defrag"
+
+    #act
+    check_2010_transparent_hugepages_defrag
+    local rc=$?
+
+    #assert - should fail because defrag is always, should be madvise on fixed kernel
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) when fixed kernel has defrag=always, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_sles15sp5_fixed_kernel_wrong_defrag_never() {
+
+    #arrange - SLES 15.5 with fixed kernel, but defrag still set to never (old recommendation)
+    LIB_FUNC_IS_SLES() { return 0; }
+    OS_VERSION='15.5'
+    OS_LEVEL='5.14.21-150500.55.136.1-default'
+    LIB_FUNC_NORMALIZE_KERNELn() { :; }
+    # 1st call: OS_VERSION 15.5 < 15.8 -> 2, 2nd call: kernel equal -> 0
+    local -i _cmp_call=0
+    LIB_FUNC_COMPARE_VERSIONS() { ((_cmp_call++)); [[ ${_cmp_call} -eq 1 ]] && return 2; return 0; }
+
+    mkdir -p "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged"
+    echo 'always [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/enabled"
+    echo 'always defer defer+madvise madvise [never]' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/defrag"
+    echo '0' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged/defrag"
+
+    #act
+    check_2010_transparent_hugepages_defrag
+    local rc=$?
+
+    #assert - should fail because defrag=never/0 is wrong on fixed kernel (should be madvise/1)
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) when fixed kernel still has old defrag=never, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_sles15sp5_old_kernel_checks_defrag() {
+
+    #arrange - SLES 15.5 with old kernel (before fix)
+    LIB_FUNC_IS_SLES() { return 0; }
+    OS_VERSION='15.5'
+    OS_LEVEL='5.14.21-150500.55.100.1-default'
+    LIB_FUNC_NORMALIZE_KERNELn() { :; }
+    # Both calls return 2: OS_VERSION < 15.8, kernel < fixed
+    LIB_FUNC_COMPARE_VERSIONS() { return 2; }
+
+    mkdir -p "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged"
+    echo 'always [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/enabled"
+    echo '[always] defer defer+madvise madvise never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/defrag"
+    echo '1' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged/defrag"
+
+    #act
+    check_2010_transparent_hugepages_defrag
+    local rc=$?
+
+    #assert - should fail (RC=2) because old kernel requires defrag=never
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) when SLES 15.5 kernel is old, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_sles15sp7_fixed_kernel_defaults_ok() {
+
+    #arrange - SLES 15.7 with exact fixed kernel, defaults madvise/1
+    LIB_FUNC_IS_SLES() { return 0; }
+    OS_VERSION='15.7'
+    OS_LEVEL='6.4.0-150700.53.31.1-default'
+    LIB_FUNC_NORMALIZE_KERNELn() { :; }
+    # 1st call: OS_VERSION 15.7 < 15.8 -> 2, 2nd call: kernel equal -> 0
+    local -i _cmp_call=0
+    LIB_FUNC_COMPARE_VERSIONS() { ((_cmp_call++)); [[ ${_cmp_call} -eq 1 ]] && return 2; return 0; }
+
+    mkdir -p "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged"
+    echo 'always [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/enabled"
+    echo 'always defer defer+madvise [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/defrag"
+    echo '1' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged/defrag"
+
+    #act
+    check_2010_transparent_hugepages_defrag
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) when SLES 15.7 fixed kernel has defaults, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_sles_unknown_version_checks_defrag() {
+
+    #arrange - SLES version not in fixed kernel list and below fixed_from
+    LIB_FUNC_IS_SLES() { return 0; }
+    OS_VERSION='15.4'
+    OS_LEVEL='5.14.21-150400.24.100.1-default'
+    LIB_FUNC_NORMALIZE_KERNELn() { :; }
+    # OS_VERSION 15.4 < 15.8 -> 2, no matching version in list so no 2nd call
+    LIB_FUNC_COMPARE_VERSIONS() { return 2; }
+
+    mkdir -p "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged"
+    echo 'always [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/enabled"
+    echo '[always] defer defer+madvise madvise never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/defrag"
+    echo '1' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged/defrag"
+
+    #act
+    check_2010_transparent_hugepages_defrag
+    local rc=$?
+
+    #assert - should fail because SLES 15.4 has no fixed kernel, falls through to defrag check
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) when SLES version not in fixed kernel list, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_sles15sp5_old_kernel_defrag_ok() {
+
+    #arrange - SLES 15.5 with old kernel but defrag correctly configured
+    LIB_FUNC_IS_SLES() { return 0; }
+    OS_VERSION='15.5'
+    OS_LEVEL='5.14.21-150500.55.100.1-default'
+    LIB_FUNC_NORMALIZE_KERNELn() { :; }
+    # Both calls return 2: OS_VERSION < 15.8, kernel < fixed
+    LIB_FUNC_COMPARE_VERSIONS() { return 2; }
+
+    mkdir -p "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged"
+    echo 'always [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/enabled"
+    echo 'always defer defer+madvise madvise [never]' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/defrag"
+    echo '0' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged/defrag"
+
+    #act
+    check_2010_transparent_hugepages_defrag
+    local rc=$?
+
+    #assert - should pass because defrag is correctly set even on old kernel
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) when defrag is correct on old SLES kernel, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+#------------------------------------------------------------------
+# Tests for future SLES versions (>= fixed_from) - always fixed
+#------------------------------------------------------------------
+
+function test_sles15sp8_always_fixed_defaults_ok() {
+
+    #arrange - SLES 15.8 (>= fixed_from), defaults madvise/1
+    LIB_FUNC_IS_SLES() { return 0; }
+    OS_VERSION='15.8'
+    OS_LEVEL='6.4.0-150800.10.1.1-default'
+    LIB_FUNC_NORMALIZE_KERNELn() { :; }
+    # OS_VERSION 15.8 == 15.8 -> 0 (equal, not less), no kernel check
+    LIB_FUNC_COMPARE_VERSIONS() { return 0; }
+
+    mkdir -p "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged"
+    echo 'always [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/enabled"
+    echo 'always defer defer+madvise [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/defrag"
+    echo '1' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged/defrag"
+
+    #act
+    check_2010_transparent_hugepages_defrag
+    local rc=$?
+
+    #assert - should pass because SLES 15.8 always has the fix
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) when SLES 15.8 has defaults, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_sles16_always_fixed_defaults_ok() {
+
+    #arrange - SLES 16.0 (>= fixed_from), defaults madvise/1
+    LIB_FUNC_IS_SLES() { return 0; }
+    OS_VERSION='16.0'
+    OS_LEVEL='6.6.0-160000.1.1-default'
+    LIB_FUNC_NORMALIZE_KERNELn() { :; }
+    # OS_VERSION 16.0 > 15.8 -> 1 (first higher, not less), no kernel check
+    LIB_FUNC_COMPARE_VERSIONS() { return 1; }
+
+    mkdir -p "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged"
+    echo 'always [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/enabled"
+    echo 'always defer defer+madvise [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/defrag"
+    echo '1' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged/defrag"
+
+    #act
+    check_2010_transparent_hugepages_defrag
+    local rc=$?
+
+    #assert - should pass because SLES 16.0 always has the fix
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) when SLES 16.0 has defaults, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_sles15sp8_wrong_defrag_always() {
+
+    #arrange - SLES 15.8 (>= fixed_from) but defrag wrongly set to always
+    LIB_FUNC_IS_SLES() { return 0; }
+    OS_VERSION='15.8'
+    OS_LEVEL='6.4.0-150800.10.1.1-default'
+    LIB_FUNC_NORMALIZE_KERNELn() { :; }
+    # OS_VERSION 15.8 == 15.8 -> 0
+    LIB_FUNC_COMPARE_VERSIONS() { return 0; }
+
+    mkdir -p "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged"
+    echo 'always [madvise] never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/enabled"
+    echo '[always] defer defer+madvise madvise never' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/defrag"
+    echo '1' > "${_mock_dir}/sys/kernel/mm/transparent_hugepage/khugepaged/defrag"
+
+    #act
+    check_2010_transparent_hugepages_defrag
+    local rc=$?
+
+    #assert - should fail because defrag=always is wrong even on fixed SLES 15.8
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) when SLES 15.8 has defrag=always, got RC=${rc}"
+    fi
+    assert_true true
 }
 


### PR DESCRIPTION
…31662)

SUSE has released fixed kernel versions for SLES 15 SP5/SP6/SP7 that address the THP defrag issue. On these kernels the OS defaults (madvise/1) are the recommended settings instead of the previous hardening (never/0).

Changes:
- Add _sles_fixed_kernels table with minimum fixed kernel per SLES version: SLES 15 SP5: kernel-default >= 5.14.21-150500.55.136.1 SLES 15 SP6: kernel-default >= 6.4.0-150600.23.87.1 SLES 15 SP7: kernel-default >= 6.4.0-150700.53.31.1
- Add _sles_fixed_from='15.8': versions >= 15.8 ship with the fix from the start and require no kernel version check
- Extend _thp_defrag_parameter array with a third column for the fixed recommended value (madvise / 1)
- Detect fixed kernel at runtime and select the appropriate recommended value per parameter before running the check loop

Tests:
- Update existing SLES tests to account for the two LIB_FUNC_COMPARE_VERSIONS calls (OS_VERSION vs fixed_from, kernel vs fixed version)
- Add tests for fixed kernel with correct defaults (madvise/1) → RC=0
- Add tests for fixed kernel with wrong values (always, never/0) → RC=2
- Add tests for future SLES versions (15.8, 16.0) always treated as fixed
- Add test for old kernel with correct hardened values (never/0) → RC=0