### PR TITLE
feat: add check 7032 for sap-hana-ha HA resource agent on RHEL

### DIFF
--- a/scripts/lib/check/7032_ha_resource_agent_hana_rhel.check
+++ b/scripts/lib/check/7032_ha_resource_agent_hana_rhel.check
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+function check_7032_ha_resource_agent_hana_rhel {
+
+    logTrace "<${BASH_SOURCE[0]}:${FUNCNAME[*]}>"
+
+    local -i _retval=99
+
+    # MODIFICATION SECTION>>
+    local sapnote='#1552925'
+    local -r _rpm_package='sap-hana-ha'
+
+    local -ar _rpm_versions=(\
+                            '10.0'  '1.2.12-1' \
+                            '9.6'   '1.2.12-1' \
+                            '9.4'   '1.2.12-1' \
+                            )
+    # MODIFICATION SECTION<<
+
+    #1552925 - Linux: High Availability Cluster Solutions
+    #https://access.redhat.com/articles/3397471
+    #https://access.redhat.com/downloads/content/sap-hana-ha/noarch/package-latest
+
+    # PRECONDITIONS
+    if ! LIB_FUNC_IS_RHEL; then
+
+        logCheckSkipped 'Linux distribution is not RHEL. Skipping' "<${FUNCNAME[0]}>"
+        _retval=3
+
+    elif ! rpm -q --quiet ${_rpm_package}; then
+
+        logCheckSkipped "HA Resource Agent ${_rpm_package} not installed (SAP Note ${sapnote:-}). Skipping <${FUNCNAME[0]}>"
+        _retval=3
+
+    fi
+
+    # CHECK
+    if [[ ${_retval} -eq 99 ]]; then
+
+        local _rhel_release
+        local _exp_version
+        local _curr_version
+        local _exp_version_normalized
+        local _curr_version_normalized
+
+        local _handled=false
+
+        _curr_version=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}" "${_rpm_package}")
+        #normalize curr version - e.g. 4.1.10-33.5.2
+        LIB_FUNC_NORMALIZE_RPM "${_curr_version}"
+        _curr_version_normalized="${LIB_FUNC_NORMALIZE_RPM_RETURN}"
+
+        # i+=2 --> every 2nd item
+        for ((i=0; i < ${#_rpm_versions[@]}; i+=2)); do
+
+            _rhel_release="${_rpm_versions[$i]}"
+
+            logTrace "<${FUNCNAME[0]}> # ${_rhel_release}>"
+
+            [[ ! "${OS_VERSION}" =~ ${_rhel_release} ]] && continue
+
+            _handled=true
+
+            _exp_version="${_rpm_versions[$i+1]}"
+
+            #normalize expected version
+            LIB_FUNC_NORMALIZE_RPM "${_exp_version}"
+            _exp_version_normalized="${LIB_FUNC_NORMALIZE_RPM_RETURN}"
+
+            # returns 0 if equal, 1 if first is higher, 2 if second is higher
+            LIB_FUNC_COMPARE_VERSIONS "${_curr_version_normalized}" "${_exp_version_normalized}"
+            if [[ $? -eq 2 ]]; then
+
+                logCheckWarning "HA Resource Agent ${_rpm_package} should be updated (SAP Note ${sapnote:-}) (is: ${_curr_version}, should be: >=${_exp_version})"
+                _retval=1
+
+            else
+
+                logCheckOk "HA Resource Agent ${_rpm_package} version seems to be ok (SAP Note ${sapnote:-}) (is: ${_curr_version})"
+                _retval=0
+
+            fi
+
+            break
+        done
+
+        if ! ${_handled}; then
+
+            logCheckWarning "CHECK does not handle RHEL version (SAP Note ${sapnote:-}) (is: ${OS_VERSION}, ${_curr_version})"
+            _retval=1
+
+        fi
+
+    fi
+
+    logDebug "<${BASH_SOURCE[0]}:${FUNCNAME[0]}> # RC=${_retval}"
+    return ${_retval}
+
+}

--- a/scripts/lib/checkset/RHELonPoweronly.checkset
+++ b/scripts/lib/checkset/RHELonPoweronly.checkset
@@ -70,5 +70,6 @@
 7018_pacemaker_attributes
 7030_ha_resource_agent_scaleup_rhel
 7031_ha_resource_agent_scaleout_rhel
+7032_ha_resource_agent_hana_rhel
 8050_hana_revision_infra_issues
 8500_sap_hana_client

--- a/scripts/lib/checkset/RHELonX64only.checkset
+++ b/scripts/lib/checkset/RHELonX64only.checkset
@@ -90,6 +90,7 @@
 7018_pacemaker_attributes
 7030_ha_resource_agent_scaleup_rhel
 7031_ha_resource_agent_scaleout_rhel
+7032_ha_resource_agent_hana_rhel
 8050_hana_revision_infra_issues
 8500_sap_hana_client
 8702_sap_hana_backint_amazon

--- a/scripts/tests/check/7031_ha_resource_agent_scaleout_rhel.bashunit.sh
+++ b/scripts/tests/check/7031_ha_resource_agent_scaleout_rhel.bashunit.sh
@@ -111,8 +111,6 @@ function test_rhel10_rpm_ok() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
-
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"
 

--- a/scripts/tests/check/7032_ha_resource_agent_hana_rhel.bashunit.sh
+++ b/scripts/tests/check/7032_ha_resource_agent_hana_rhel.bashunit.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 #------------------------------------------------------------------
-# bashunit migration: 7030_ha_resource_agent_scaleup_rhel_test.sh
-# Tests for HA resource agent check on RHEL (scale-up)
+# Tests for HA resource agent (HANA) check on RHEL
 #------------------------------------------------------------------
 set -u
 
@@ -11,8 +10,8 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
 fi
 
 # Guard to avoid reloading
-[[ -n "${_7030_ha_resource_agent_rhel_test_loaded:-}" ]] && return 0
-_7030_ha_resource_agent_rhel_test_loaded=true
+[[ -n "${_7032_ha_resource_agent_hana_rhel_test_loaded:-}" ]] && return 0
+_7032_ha_resource_agent_hana_rhel_test_loaded=true
 
 #mock PREREQUISITE functions
 LIB_FUNC_IS_RHEL() { return 0 ; }
@@ -26,12 +25,27 @@ LIB_FUNC_NORMALIZE_RPM_RETURN=''
 declare -i compare_version_rc=0
 declare -i rpm_rc=0
 
+function test_not_rhel() {
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 1 ; }
+
+    #act
+    check_7032_ha_resource_agent_hana_rhel
+    local rc=$?
+
+    #assert
+    if [[ "$rc" != '3' ]]; then
+        bashunit::fail "Expected CheckSkipped RC=3 but got RC=$rc"
+    fi
+    assert_true true
+}
+
 function test_rpm_not_installed() {
     #arrange
     rpm_rc=1
 
     #act
-    check_7030_ha_resource_agent_scaleup_rhel
+    check_7032_ha_resource_agent_hana_rhel
     local rc=$?
 
     #assert
@@ -44,10 +58,10 @@ function test_rpm_not_installed() {
 function test_OS_not_listed() {
     #arrange
     rpm_rc=0
-    OS_VERSION='6.5'
+    OS_VERSION='8.10'
 
     #act
-    check_7030_ha_resource_agent_scaleup_rhel
+    check_7032_ha_resource_agent_hana_rhel
     local rc=$?
 
     #assert
@@ -60,11 +74,11 @@ function test_OS_not_listed() {
 function test_rpm_ok() {
     #arrange
     rpm_rc=0
-    OS_VERSION='7.9'
+    OS_VERSION='9.4'
     compare_version_rc=1
 
     #act
-    check_7030_ha_resource_agent_scaleup_rhel
+    check_7032_ha_resource_agent_hana_rhel
     local rc=$?
 
     #assert
@@ -77,11 +91,11 @@ function test_rpm_ok() {
 function test_rpm_old() {
     #arrange
     rpm_rc=0
-    OS_VERSION='8.10'
+    OS_VERSION='9.6'
     compare_version_rc=2
 
     #act
-    check_7030_ha_resource_agent_scaleup_rhel
+    check_7032_ha_resource_agent_hana_rhel
     local rc=$?
 
     #assert
@@ -95,10 +109,10 @@ function test_rhel10_rpm_ok() {
     #arrange
     rpm_rc=0
     OS_VERSION='10.0'
-    compare_version_rc=1
+    compare_version_rc=0
 
     #act
-    check_7030_ha_resource_agent_scaleup_rhel
+    check_7032_ha_resource_agent_hana_rhel
     local rc=$?
 
     #assert
@@ -114,12 +128,13 @@ function set_up_before_script() {
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"
 
-    #shellcheck source=../../lib/check/7030_ha_resource_agent_scaleup_rhel.check
-    source "${PROGRAM_DIR}/../../lib/check/7030_ha_resource_agent_scaleup_rhel.check"
+    #shellcheck source=../../lib/check/7032_ha_resource_agent_hana_rhel.check
+    source "${PROGRAM_DIR}/../../lib/check/7032_ha_resource_agent_hana_rhel.check"
 }
 
 function set_up() {
     OS_VERSION=''
     rpm_rc=0
     compare_version_rc=0
+    LIB_FUNC_IS_RHEL() { return 0 ; }
 }


### PR DESCRIPTION
Add new check 7032_ha_resource_agent_hana_rhel to validate the sap-hana-ha package version on RHEL 9.4, 9.6 and 10.0 systems, following SAP Note #1552925.

- Add scripts/lib/check/7032_ha_resource_agent_hana_rhel.check
- Register 7032 in RHELonX64only.checkset and RHELonPoweronly.checkset
- Add unit tests for 7032 (not-RHEL, pkg missing, OS unlisted, version ok, version old, RHEL 10 ok)
- Fix 7030/7031 unit tests: remove erroneous HANA_HELPER_PROGVERSION guard in set_up_before_script that caused those tests to be skipped when run together with other test files in the same session