### PR TITLE
Add Azure network tuning and ring buffer checks (#3411, #3412)

### DIFF
--- a/scripts/lib/check/3411_network_tuning_azure.check
+++ b/scripts/lib/check/3411_network_tuning_azure.check
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+function check_3411_network_tuning_azure {
+
+    logTrace "<${BASH_SOURCE[0]}:${FUNCNAME[*]}>"
+
+    local -i _retval=99
+
+    # MODIFICATION SECTION>>
+    local -r sapnote='#2015553'
+
+    local -r reco_tcp_congestion_control='bbr'
+    local -r reco_default_qdisc='fq'
+    local -ir reco_tcp_frto=0
+    local -ir reco_netdev_budget=1000
+    # MODIFICATION SECTION<<
+
+    # 2015553 - SAP on Microsoft Azure: Support prerequisites
+    # https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-optimize-network-bandwidth
+    # https://github.com/mabicca/azure-linux-tuning/tree/main/azure-nic-setup/bash
+
+    # Override paths for testing
+    local path_to_tcp_congestion_control="${path_to_tcp_congestion_control:-/proc/sys/net/ipv4/tcp_congestion_control}"
+    local path_to_default_qdisc="${path_to_default_qdisc:-/proc/sys/net/core/default_qdisc}"
+    local path_to_tcp_frto="${path_to_tcp_frto:-/proc/sys/net/ipv4/tcp_frto}"
+    local path_to_netdev_budget="${path_to_netdev_budget:-/proc/sys/net/core/netdev_budget}"
+
+    # PRECONDITIONS
+    if ! LIB_FUNC_IS_CLOUD_MICROSOFT; then
+
+        logCheckSkipped 'Not running on Microsoft Azure. Skipping' "<${FUNCNAME[0]}>"
+        _retval=3
+
+    fi
+
+    # CHECK
+    if [[ ${_retval} -eq 99 ]]; then
+
+        # tcp_congestion_control
+        local _tcp_congestion_control
+        _tcp_congestion_control=$(<"${path_to_tcp_congestion_control}")
+
+        if [[ "${_tcp_congestion_control}" == "${reco_tcp_congestion_control}" ]]; then
+
+            logCheckOk "net.ipv4.tcp_congestion_control set as recommended (is: ${_tcp_congestion_control})"
+
+        else
+
+            logCheckWarning "net.ipv4.tcp_congestion_control NOT set as recommended (is: ${_tcp_congestion_control}, should be: ${reco_tcp_congestion_control})"
+            _retval=1
+
+        fi
+
+        # default_qdisc
+        local _default_qdisc
+        _default_qdisc=$(<"${path_to_default_qdisc}")
+
+        if [[ "${_default_qdisc}" == "${reco_default_qdisc}" ]]; then
+
+            logCheckOk "net.core.default_qdisc set as recommended (is: ${_default_qdisc})"
+
+        else
+
+            logCheckWarning "net.core.default_qdisc NOT set as recommended (is: ${_default_qdisc}, should be: ${reco_default_qdisc})"
+            _retval=1
+
+        fi
+
+        # netdev_budget
+        local -i _netdev_budget
+        _netdev_budget=$(<"${path_to_netdev_budget}")
+
+        if [[ ${_netdev_budget} -ge ${reco_netdev_budget} ]]; then
+
+            logCheckOk "net.core.netdev_budget set as recommended (is: ${_netdev_budget})"
+
+        else
+
+            logCheckWarning "net.core.netdev_budget NOT set as recommended (is: ${_netdev_budget}, should be: >= ${reco_netdev_budget})"
+            _retval=1
+
+        fi
+
+        # tcp_frto
+        local -i _tcp_frto
+        _tcp_frto=$(<"${path_to_tcp_frto}")
+
+        if [[ ${_tcp_frto} -eq ${reco_tcp_frto} ]]; then
+
+            logCheckOk "net.ipv4.tcp_frto set as recommended (is: ${_tcp_frto})"
+
+        else
+
+            logCheckWarning "net.ipv4.tcp_frto NOT set as recommended (is: ${_tcp_frto}, should be: ${reco_tcp_frto})"
+            _retval=1
+
+        fi
+
+    fi
+
+    # FINAL RESULT
+    if [[ ${_retval} -eq 99 ]]; then
+
+        logCheckOk "Azure network tuning parameters set as recommended (SAP Note ${sapnote:-})"
+        _retval=0
+
+    elif [[ ${_retval} -eq 1 ]]; then
+
+        logCheckWarning "NOT all Azure network tuning parameters set as recommended (SAP Note ${sapnote:-})"
+
+    fi
+
+    logDebug "<${BASH_SOURCE[0]}:${FUNCNAME[0]}> # RC=${_retval}"
+    return ${_retval}
+
+}

--- a/scripts/lib/check/3412_network_ringbuffer_azure.check
+++ b/scripts/lib/check/3412_network_ringbuffer_azure.check
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+function check_3412_network_ringbuffer_azure {
+
+    logTrace "<${BASH_SOURCE[0]}:${FUNCNAME[*]}>"
+
+    local -i _retval=99
+
+    # MODIFICATION SECTION>>
+    local -r sapnote='#2015553'
+
+    local -ir reco_ring_rx=1024
+    local -ir reco_ring_tx=1024
+    # MODIFICATION SECTION<<
+
+    # 2015553 - SAP on Microsoft Azure: Support prerequisites
+    # https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-optimize-network-bandwidth
+    # https://github.com/mabicca/azure-linux-tuning/tree/main/azure-nic-setup/bash
+
+    # PRECONDITIONS
+    if ! LIB_FUNC_IS_CLOUD_MICROSOFT; then
+
+        logCheckSkipped 'Not running on Microsoft Azure. Skipping' "<${FUNCNAME[0]}>"
+        _retval=3
+
+    fi
+
+    # CHECK - ring buffers
+    if [[ ${_retval} -eq 99 ]]; then
+
+        # Get all accelerated and synthetic interfaces
+        mapfile -t _all_interfaces < <(grep -soHE -m1 'DRIVER=(hv_netvsc|mana|mlx)' /sys/class/net/**/device/uevent)
+
+        local _rx_intf='net/(.+)/device.*DRIVER=(.*)$'
+        local -i _ring_issues=0
+
+        for _single_intf in "${_all_interfaces[@]}"; do
+
+            if [[ ${_single_intf} =~ ${_rx_intf} ]]; then
+
+                local _intf_name="${BASH_REMATCH[1]}"
+                local _intf_driver="${BASH_REMATCH[2]}"
+
+                # Get current ring buffer settings via ethtool
+                local _ethtool_output
+                _ethtool_output=$(ethtool -g "${_intf_name}" 2>/dev/null) || continue
+
+                # Parse current RX and TX ring sizes from "Current hardware settings" section
+                local -i _curr_rx=0
+                local -i _curr_tx=0
+                local -i _in_current=0
+                local _line
+
+                while IFS= read -r _line; do
+
+                    if [[ "${_line}" == *'Current hardware settings'* ]]; then
+                        _in_current=1
+                    elif [[ ${_in_current} -eq 1 ]]; then
+                        if [[ "${_line}" =~ ^RX:[[:space:]]*([0-9]+) ]]; then
+                            _curr_rx=${BASH_REMATCH[1]}
+                        elif [[ "${_line}" =~ ^TX:[[:space:]]*([0-9]+) ]]; then
+                            _curr_tx=${BASH_REMATCH[1]}
+                        elif [[ -z "${_line}" ]]; then
+                            break
+                        fi
+                    fi
+
+                done <<< "${_ethtool_output}"
+
+                if [[ ${_curr_rx} -ge ${reco_ring_rx} ]] && [[ ${_curr_tx} -ge ${reco_ring_tx} ]]; then
+
+                    logCheckOk "Ring buffer for ${_intf_name} (${_intf_driver}) set as recommended (RX: ${_curr_rx}, TX: ${_curr_tx})"
+
+                else
+
+                    logCheckWarning "Ring buffer for ${_intf_name} (${_intf_driver}) NOT set as recommended (RX: ${_curr_rx}/${reco_ring_rx}, TX: ${_curr_tx}/${reco_ring_tx})"
+                    _ring_issues+=1
+
+                fi
+
+            fi
+
+        done
+
+        if [[ ${_ring_issues} -gt 0 ]]; then
+
+            logCheckWarning "NOT all Azure ring buffers set as recommended (SAP Note ${sapnote:-})"
+            _retval=1
+
+        elif [[ ${#_all_interfaces[@]} -eq 0 ]]; then
+
+            logCheckWarning "No accelerated or synthetic interfaces found"
+            _retval=1
+
+        else
+
+            logCheckOk "Azure ring buffers set as recommended (SAP Note ${sapnote:-})"
+            _retval=0
+
+        fi
+
+    fi
+
+    logDebug "<${BASH_SOURCE[0]}:${FUNCNAME[0]}> # RC=${_retval}"
+    return ${_retval}
+
+}

--- a/scripts/lib/checkset/RHELonX64only.checkset
+++ b/scripts/lib/checkset/RHELonX64only.checkset
@@ -70,6 +70,8 @@
 3301_network_accelerated_azure
 3302_ena_interfaces_amazon
 3304_network_interface_gvnic_gcp
+3411_network_tuning_azure
+3412_network_ringbuffer_azure
 4110_xfs_nobarrier
 4150_pmem_xfs_mountoption_dax
 4500_ibm-gpfs_version_intel

--- a/scripts/lib/checkset/SLESonX64only.checkset
+++ b/scripts/lib/checkset/SLESonX64only.checkset
@@ -71,6 +71,8 @@
 3301_network_accelerated_azure
 3302_ena_interfaces_amazon
 3304_network_interface_gvnic_gcp
+3411_network_tuning_azure
+3412_network_ringbuffer_azure
 4110_xfs_nobarrier
 4150_pmem_xfs_mountoption_dax
 4500_ibm-gpfs_version_intel

--- a/scripts/tests/check/3411_network_tuning_azure.bashunit.sh
+++ b/scripts/tests/check/3411_network_tuning_azure.bashunit.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+#------------------------------------------------------------------
+# bashunit test for check_3411_network_tuning_azure
+#------------------------------------------------------------------
+set -u
+
+if [[ -z "${PROGRAM_DIR:-}" ]]; then
+    PROGRAM_DIR="${BASH_SOURCE[0]%/*}"
+    [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
+fi
+
+# CRITICAL: Use a test-specific guard variable
+[[ -n "${_3411_network_tuning_azure_test_loaded:-}" ]] && return 0
+_3411_network_tuning_azure_test_loaded=true
+
+# Mock functions
+LIB_FUNC_IS_CLOUD_MICROSOFT() { return 0 ; }
+
+
+function set_up_before_script() {
+
+    set +eE
+
+    [[ -n "${_3411_test_sourced:-}" ]] && return 0
+    _3411_test_sourced=true
+
+    #shellcheck source=../saphana-logger-stubs
+    source "${PROGRAM_DIR}/../saphana-logger-stubs"
+
+    #shellcheck source=../../lib/check/3411_network_tuning_azure.check
+    source "${PROGRAM_DIR}/../../lib/check/3411_network_tuning_azure.check"
+}
+
+function set_up() {
+    LIB_FUNC_IS_CLOUD_MICROSOFT() { return 0 ; }
+
+    # Override paths for testing using temp files
+    path_to_tcp_congestion_control="${PROGRAM_DIR}/.tmp_tcp_congestion_control"
+    path_to_default_qdisc="${PROGRAM_DIR}/.tmp_default_qdisc"
+    path_to_tcp_frto="${PROGRAM_DIR}/.tmp_tcp_frto"
+    path_to_netdev_budget="${PROGRAM_DIR}/.tmp_netdev_budget"
+
+    echo -n "bbr" > "${path_to_tcp_congestion_control}"
+    echo -n "fq" > "${path_to_default_qdisc}"
+    echo -n "0" > "${path_to_tcp_frto}"
+    echo -n "1000" > "${path_to_netdev_budget}"
+}
+
+function tear_down() {
+    rm -f "${PROGRAM_DIR}/.tmp_tcp_congestion_control" \
+          "${PROGRAM_DIR}/.tmp_default_qdisc" \
+          "${PROGRAM_DIR}/.tmp_tcp_frto" \
+          "${PROGRAM_DIR}/.tmp_netdev_budget"
+}
+
+function test_all_ok() {
+
+    #act
+    check_3411_network_tuning_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok), got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_wrong_congestion_control_warning() {
+
+    #arrange
+    echo -n "cubic" > "${path_to_tcp_congestion_control}"
+
+    #act
+    check_3411_network_tuning_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning), got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_wrong_qdisc_warning() {
+
+    #arrange
+    echo -n "pfifo_fast" > "${path_to_default_qdisc}"
+
+    #act
+    check_3411_network_tuning_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning), got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_wrong_tcp_frto_warning() {
+
+    #arrange
+    echo -n "2" > "${path_to_tcp_frto}"
+
+    #act
+    check_3411_network_tuning_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning), got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_wrong_netdev_budget_warning() {
+
+    #arrange
+    echo -n "300" > "${path_to_netdev_budget}"
+
+    #act
+    check_3411_network_tuning_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning), got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_netdev_budget_higher_ok() {
+
+    #arrange
+    echo -n "2000" > "${path_to_netdev_budget}"
+
+    #act
+    check_3411_network_tuning_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for netdev_budget >= recommended, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_not_azure_skip() {
+
+    #arrange
+    LIB_FUNC_IS_CLOUD_MICROSOFT() { return 1 ; }
+
+    #act
+    check_3411_network_tuning_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 3 ]]; then
+        bashunit::fail "Expected RC=3 (skip) for non-Azure, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_all_wrong_warning() {
+
+    #arrange
+    echo -n "cubic" > "${path_to_tcp_congestion_control}"
+    echo -n "pfifo_fast" > "${path_to_default_qdisc}"
+    echo -n "2" > "${path_to_tcp_frto}"
+    echo -n "300" > "${path_to_netdev_budget}"
+
+    #act
+    check_3411_network_tuning_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) when all settings are wrong, got RC=${rc}"
+    fi
+    assert_true true
+}

--- a/scripts/tests/check/3412_network_ringbuffer_azure.bashunit.sh
+++ b/scripts/tests/check/3412_network_ringbuffer_azure.bashunit.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#------------------------------------------------------------------
+# bashunit test for check_3412_network_ringbuffer_azure
+#------------------------------------------------------------------
+set -u
+
+if [[ -z "${PROGRAM_DIR:-}" ]]; then
+    PROGRAM_DIR="${BASH_SOURCE[0]%/*}"
+    [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
+fi
+
+# CRITICAL: Use a test-specific guard variable
+[[ -n "${_3412_network_ringbuffer_azure_test_loaded:-}" ]] && return 0
+_3412_network_ringbuffer_azure_test_loaded=true
+
+# Mock variables
+TEST_ETHTOOL_OUTPUT=''
+TEST_INTERFACES=()
+
+# Mock functions
+LIB_FUNC_IS_CLOUD_MICROSOFT() { return 0 ; }
+
+grep() {
+    case "$*" in
+        *'uevent')  [[ ${#TEST_INTERFACES[@]} -eq 0 ]] && : || printf "%s\n" "${TEST_INTERFACES[@]}" ;;
+        *)          command grep "$@" ;;
+    esac
+}
+
+ethtool() {
+    echo "${TEST_ETHTOOL_OUTPUT}"
+}
+
+
+function set_up_before_script() {
+
+    set +eE
+
+    [[ -n "${_3412_test_sourced:-}" ]] && return 0
+    _3412_test_sourced=true
+
+    #shellcheck source=../saphana-logger-stubs
+    source "${PROGRAM_DIR}/../saphana-logger-stubs"
+
+    #shellcheck source=../../lib/check/3412_network_ringbuffer_azure.check
+    source "${PROGRAM_DIR}/../../lib/check/3412_network_ringbuffer_azure.check"
+}
+
+function set_up() {
+    TEST_ETHTOOL_OUTPUT='Ring parameters for eth0:
+Pre-set maximums:
+RX:		4096
+TX:		4096
+Current hardware settings:
+RX:		1024
+TX:		1024'
+    TEST_INTERFACES=()
+    TEST_INTERFACES+=('/sys/class/net/eth0/device/uevent:DRIVER=hv_netvsc')
+    TEST_INTERFACES+=('/sys/class/net/eth1/device/uevent:DRIVER=mana')
+
+    LIB_FUNC_IS_CLOUD_MICROSOFT() { return 0 ; }
+}
+
+function test_all_ok() {
+
+    #act
+    check_3412_network_ringbuffer_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok), got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_ring_buffer_too_small_warning() {
+
+    #arrange
+    TEST_ETHTOOL_OUTPUT='Ring parameters for eth0:
+Pre-set maximums:
+RX:		4096
+TX:		4096
+Current hardware settings:
+RX:		256
+TX:		256'
+
+    #act
+    check_3412_network_ringbuffer_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for small ring buffers, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_ring_buffer_larger_ok() {
+
+    #arrange
+    TEST_ETHTOOL_OUTPUT='Ring parameters for eth0:
+Pre-set maximums:
+RX:		4096
+TX:		4096
+Current hardware settings:
+RX:		4096
+TX:		4096'
+
+    #act
+    check_3412_network_ringbuffer_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for ring buffers >= recommended, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_not_azure_skip() {
+
+    #arrange
+    LIB_FUNC_IS_CLOUD_MICROSOFT() { return 1 ; }
+
+    #act
+    check_3412_network_ringbuffer_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 3 ]]; then
+        bashunit::fail "Expected RC=3 (skip) for non-Azure, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_no_interfaces_warning() {
+
+    #arrange
+    TEST_INTERFACES=()
+
+    #act
+    check_3412_network_ringbuffer_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) with no interfaces, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_partial_ring_buffer_warning() {
+
+    #arrange
+    TEST_INTERFACES=()
+    TEST_INTERFACES+=('/sys/class/net/eth0/device/uevent:DRIVER=hv_netvsc')
+    TEST_INTERFACES+=('/sys/class/net/eth1/device/uevent:DRIVER=mana')
+    TEST_INTERFACES+=('/sys/class/net/eth2/device/uevent:DRIVER=hv_netvsc')
+
+    # ethtool mock returns same for all - only RX 256 which is too small
+    TEST_ETHTOOL_OUTPUT='Ring parameters for eth0:
+Pre-set maximums:
+RX:		4096
+TX:		4096
+Current hardware settings:
+RX:		256
+TX:		1024'
+
+    #act
+    check_3412_network_ringbuffer_azure
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for partial ring buffer issue, got RC=${rc}"
+    fi
+    assert_true true
+}


### PR DESCRIPTION
New checks for Azure network optimization per SAP Note #2015553:
- 3411: Validates tcp_congestion_control, default_qdisc, tcp_frto, and netdev_budget settings
- 3412: Validates NIC ring buffer sizes for accelerated/synthetic interfaces via ethtool

Both checks added to SLESonX64only and RHELonX64only checksets. Includes bashunit tests for both checks.