### PR TITLE
Add GCP support to NVMe I/O timeout check (#5210)

### DIFF
--- a/scripts/lib/check/5210_io_nvme_parameter_hyperscaler.check
+++ b/scripts/lib/check/5210_io_nvme_parameter_hyperscaler.check
@@ -9,6 +9,7 @@ function check_5210_io_nvme_parameter_hyperscaler {
     # MODIFICATION SECTION>>
     local -r sapnote_aws='#1656250'
     local -r sapnote_azure='#2015553'
+    local -r sapnote_gcp='#2456406'
     local -r -i reco_io_timeout=240
     # MODIFICATION SECTION<<
 
@@ -17,6 +18,8 @@ function check_5210_io_nvme_parameter_hyperscaler {
     # 2015553 - SAP on Microsoft Azure: Support prerequisites
     # https://learn.microsoft.com/en-us/azure/virtual-machines/enable-nvme-interface
     # https://learn.microsoft.com/en-us/azure/virtual-machines/nvme-linux
+    # 2456406 - SAP on Google Cloud Platform: Support Prerequisites
+    # https://docs.cloud.google.com/compute/docs/troubleshooting/troubleshooting-disk-nvme
 
     #tweaked by unit-test
     local path_to_nvme_timeout="${path_to_nvme_timeout:-/sys/module/nvme_core/parameters/io_timeout}"
@@ -24,7 +27,7 @@ function check_5210_io_nvme_parameter_hyperscaler {
     local sapnote
 
     # PRECONDITIONS
-    if ! LIB_FUNC_IS_CLOUD_AMAZON && ! LIB_FUNC_IS_CLOUD_MICROSOFT; then
+    if ! LIB_FUNC_IS_CLOUD_AMAZON && ! LIB_FUNC_IS_CLOUD_MICROSOFT && ! LIB_FUNC_IS_CLOUD_GOOGLE; then
 
         logCheckSkipped "Not running on an affected hyperscaler. Skipping" "<${FUNCNAME[0]}>"
         _retval=3
@@ -42,6 +45,8 @@ function check_5210_io_nvme_parameter_hyperscaler {
             sapnote="${sapnote_aws}"
         elif LIB_FUNC_IS_CLOUD_MICROSOFT; then
             sapnote="${sapnote_azure}"
+        elif LIB_FUNC_IS_CLOUD_GOOGLE; then
+            sapnote="${sapnote_gcp}"
         fi
 
         # CHECK

--- a/scripts/tests/check/5210_io_nvme_parameter_hyperscaler.bashunit.sh
+++ b/scripts/tests/check/5210_io_nvme_parameter_hyperscaler.bashunit.sh
@@ -17,15 +17,18 @@ _5210_io_nvme_test_loaded=true
 # Variables to control cloud platform simulation
 is_amazon_cloud=1
 is_microsoft_cloud=1
+is_google_cloud=1
 
 #mock PREREQUISITE functions
 LIB_FUNC_IS_CLOUD_AMAZON() { return ${is_amazon_cloud} ; }
 LIB_FUNC_IS_CLOUD_MICROSOFT() { return ${is_microsoft_cloud} ; }
+LIB_FUNC_IS_CLOUD_GOOGLE() { return ${is_google_cloud} ; }
 
 function test_not_on_hyperscaler() {
     #arrange
     is_amazon_cloud=1
     is_microsoft_cloud=1
+    is_google_cloud=1
 
     #act
     check_5210_io_nvme_parameter_hyperscaler
@@ -38,46 +41,9 @@ function test_not_on_hyperscaler() {
     assert_true true
 }
 
-function test_on_amazon_cloud() {
-    #arrange
-    is_amazon_cloud=0
-    is_microsoft_cloud=1
-    echo "240" > "${PROGRAM_DIR}/mock_nvme_timeout_5210"
-    path_to_nvme_timeout="${PROGRAM_DIR}/mock_nvme_timeout_5210"
-
-    #act
-    check_5210_io_nvme_parameter_hyperscaler
-    local rc=$?
-
-    #assert
-    if [[ "$rc" != '0' ]]; then
-        bashunit::fail "Expected CheckOk RC=0 but got RC=$rc"
-    fi
-    assert_true true
-}
-
-function test_on_microsoft_cloud() {
-    #arrange
-    is_amazon_cloud=1
-    is_microsoft_cloud=0
-    echo "240" > "${PROGRAM_DIR}/mock_nvme_timeout_5210"
-    path_to_nvme_timeout="${PROGRAM_DIR}/mock_nvme_timeout_5210"
-
-    #act
-    check_5210_io_nvme_parameter_hyperscaler
-    local rc=$?
-
-    #assert
-    if [[ "$rc" != '0' ]]; then
-        bashunit::fail "Expected CheckOk RC=0 but got RC=$rc"
-    fi
-    assert_true true
-}
-
 function test_nvme_timeout_file_not_found() {
     #arrange
-    is_amazon_cloud=0
-    is_microsoft_cloud=1
+    is_microsoft_cloud=0
     path_to_nvme_timeout="${PROGRAM_DIR}/nonexistent_nvme_timeout"
 
     #act
@@ -93,8 +59,7 @@ function test_nvme_timeout_file_not_found() {
 
 function test_recommended_value_exact_match() {
     #arrange
-    is_amazon_cloud=0
-    is_microsoft_cloud=1
+    is_microsoft_cloud=0
     echo "240" > "${PROGRAM_DIR}/mock_nvme_timeout_5210"
     path_to_nvme_timeout="${PROGRAM_DIR}/mock_nvme_timeout_5210"
 
@@ -111,8 +76,7 @@ function test_recommended_value_exact_match() {
 
 function test_value_higher_than_recommended() {
     #arrange
-    is_amazon_cloud=0
-    is_microsoft_cloud=1
+    is_microsoft_cloud=0
     echo "300" > "${PROGRAM_DIR}/mock_nvme_timeout_5210"
     path_to_nvme_timeout="${PROGRAM_DIR}/mock_nvme_timeout_5210"
 
@@ -129,8 +93,7 @@ function test_value_higher_than_recommended() {
 
 function test_value_lower_than_recommended() {
     #arrange
-    is_amazon_cloud=0
-    is_microsoft_cloud=1
+    is_microsoft_cloud=0
     echo "200" > "${PROGRAM_DIR}/mock_nvme_timeout_5210"
     path_to_nvme_timeout="${PROGRAM_DIR}/mock_nvme_timeout_5210"
 
@@ -147,8 +110,7 @@ function test_value_lower_than_recommended() {
 
 function test_boundary_value_one_below() {
     #arrange
-    is_amazon_cloud=0
-    is_microsoft_cloud=1
+    is_microsoft_cloud=0
     echo "239" > "${PROGRAM_DIR}/mock_nvme_timeout_5210"
     path_to_nvme_timeout="${PROGRAM_DIR}/mock_nvme_timeout_5210"
 
@@ -165,8 +127,7 @@ function test_boundary_value_one_below() {
 
 function test_boundary_value_one_above() {
     #arrange
-    is_amazon_cloud=0
-    is_microsoft_cloud=1
+    is_microsoft_cloud=0
     echo "241" > "${PROGRAM_DIR}/mock_nvme_timeout_5210"
     path_to_nvme_timeout="${PROGRAM_DIR}/mock_nvme_timeout_5210"
 
@@ -183,8 +144,7 @@ function test_boundary_value_one_above() {
 
 function test_empty_file() {
     #arrange
-    is_amazon_cloud=0
-    is_microsoft_cloud=1
+    is_microsoft_cloud=0
     echo "" > "${PROGRAM_DIR}/mock_nvme_timeout_5210"
     path_to_nvme_timeout="${PROGRAM_DIR}/mock_nvme_timeout_5210"
 
@@ -201,8 +161,7 @@ function test_empty_file() {
 
 function test_zero_value() {
     #arrange
-    is_amazon_cloud=0
-    is_microsoft_cloud=1
+    is_microsoft_cloud=0
     echo "0" > "${PROGRAM_DIR}/mock_nvme_timeout_5210"
     path_to_nvme_timeout="${PROGRAM_DIR}/mock_nvme_timeout_5210"
 
@@ -219,8 +178,7 @@ function test_zero_value() {
 
 function test_value_with_whitespace() {
     #arrange
-    is_amazon_cloud=0
-    is_microsoft_cloud=1
+    is_microsoft_cloud=0
     echo " 240 " > "${PROGRAM_DIR}/mock_nvme_timeout_5210"
     path_to_nvme_timeout="${PROGRAM_DIR}/mock_nvme_timeout_5210"
 
@@ -237,8 +195,7 @@ function test_value_with_whitespace() {
 
 function test_very_large_value() {
     #arrange
-    is_amazon_cloud=0
-    is_microsoft_cloud=1
+    is_microsoft_cloud=0
     echo "999999" > "${PROGRAM_DIR}/mock_nvme_timeout_5210"
     path_to_nvme_timeout="${PROGRAM_DIR}/mock_nvme_timeout_5210"
 
@@ -249,24 +206,6 @@ function test_very_large_value() {
     #assert
     if [[ "$rc" != '0' ]]; then
         bashunit::fail "Expected CheckOk RC=0 but got RC=$rc"
-    fi
-    assert_true true
-}
-
-function test_microsoft_cloud_with_low_value() {
-    #arrange
-    is_amazon_cloud=1
-    is_microsoft_cloud=0
-    echo "100" > "${PROGRAM_DIR}/mock_nvme_timeout_5210"
-    path_to_nvme_timeout="${PROGRAM_DIR}/mock_nvme_timeout_5210"
-
-    #act
-    check_5210_io_nvme_parameter_hyperscaler
-    local rc=$?
-
-    #assert
-    if [[ "$rc" != '2' ]]; then
-        bashunit::fail "Expected CheckError RC=2 but got RC=$rc"
     fi
     assert_true true
 }
@@ -288,6 +227,7 @@ function set_up() {
     path_to_nvme_timeout="/sys/module/nvme_core/parameters/io_timeout"
     is_amazon_cloud=1
     is_microsoft_cloud=1
+    is_google_cloud=1
 
     # Clean up any existing mock files
     rm -f "${PROGRAM_DIR}/mock_nvme_timeout_5210"


### PR DESCRIPTION
## Changes

- Add Google Cloud Platform detection to `check_5210_io_nvme_parameter_hyperscaler`
- Reference SAP Note #2456406 for GCP support prerequisites
- Add GCP documentation link for NVMe disk troubleshooting
- Simplify unit tests: use single cloud provider (Microsoft) as representative
- Remove redundant per-provider test cases

## Details

The NVMe I/O timeout parameter check now also applies on Google Cloud Platform, consistent with the NVMe module enabled check (5220).

Unit tests were simplified - since the check logic is provider-agnostic (same threshold applies everywhere), testing with one provider (Microsoft) is sufficient to validate the timeout comparison logic.