### PR TITLE
New CHECK - NVMe enabled on Hyperscalers (#5200)

### DIFF
--- a/scripts/lib/check/5200_io_nvme_enabled_hyperscaler.check
+++ b/scripts/lib/check/5200_io_nvme_enabled_hyperscaler.check
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+function check_5200_io_nvme_enabled_hyperscaler {
+
+    logTrace "<${BASH_SOURCE[0]}:${FUNCNAME[*]}>"
+
+    local -i _retval=99
+
+    # MODIFICATION SECTION>>
+    local -r sapnote_aws='#1656250'
+    local -r sapnote_azure='#2015553'
+    local -r sapnote_gcp='#2456406'
+    # MODIFICATION SECTION<<
+
+    # 1656250 - SAP on AWS: Support prerequisites
+    # 2015553 - SAP on Microsoft Azure: Support prerequisites
+    # 2456406 - SAP on Google Cloud Platform: Support Prerequisites
+
+    #tweaked by unit-test
+    local path_to_nvme_module="${path_to_nvme_module:-/sys/module/nvme_core}"
+
+    local sapnote
+
+    # PRECONDITIONS
+    if ! LIB_FUNC_IS_CLOUD_AMAZON && ! LIB_FUNC_IS_CLOUD_MICROSOFT && ! LIB_FUNC_IS_CLOUD_GOOGLE; then
+
+        logCheckSkipped "Not running on an affected hyperscaler. Skipping" "<${FUNCNAME[0]}>"
+        _retval=3
+
+    else
+    # CHECK
+
+        # Determine which cloud platform and set appropriate SAP note
+        if LIB_FUNC_IS_CLOUD_AMAZON; then
+            sapnote="${sapnote_aws}"
+
+        elif LIB_FUNC_IS_CLOUD_MICROSOFT; then
+            sapnote="${sapnote_azure}"
+
+        elif LIB_FUNC_IS_CLOUD_GOOGLE; then
+            sapnote="${sapnote_gcp}"
+
+        fi
+
+        if [[ -d "${path_to_nvme_module}" ]]; then
+
+            logCheckOk "nvme is enabled as recommended (SAP Note ${sapnote:-})"
+            _retval=0
+
+        else
+
+            logCheckWarning "nvme is NOT enabled as recommended (SAP Note ${sapnote:-})"
+            _retval=1
+
+        fi
+
+    fi
+
+    logDebug "<${BASH_SOURCE[0]}:${FUNCNAME[0]}> # RC=${_retval}"
+    return ${_retval}
+
+}

--- a/scripts/lib/checkset/RHELonX64only.checkset
+++ b/scripts/lib/checkset/RHELonX64only.checkset
@@ -77,6 +77,7 @@
 4500_ibm-gpfs_version_intel
 5000_io_parameter
 5010_io_scheduler_blockdevices
+5200_io_nvme_enabled_hyperscaler
 5210_io_nvme_parameter_hyperscaler
 5300_pvscsi_hostadapter_vmware
 5301_pvscsi_parameter_vmware

--- a/scripts/lib/checkset/SLESonX64only.checkset
+++ b/scripts/lib/checkset/SLESonX64only.checkset
@@ -80,6 +80,7 @@
 5010_io_scheduler_blockdevices
 5050_vm_dirty_bytes_sles
 5100_pagecache_limit_sles
+5200_io_nvme_enabled_hyperscaler
 5210_io_nvme_parameter_hyperscaler
 5300_pvscsi_hostadapter_vmware
 5301_pvscsi_parameter_vmware

--- a/scripts/tests/check/5200_io_nvme_enabled_hyperscaler.bashunit.sh
+++ b/scripts/tests/check/5200_io_nvme_enabled_hyperscaler.bashunit.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#------------------------------------------------------------------
+# bashunit migration: 5200_io_nvme_module_hyperscaler_test.sh
+# Tests for NVMe module loaded check on hyperscalers
+#------------------------------------------------------------------
+set -u
+
+if [[ -z "${PROGRAM_DIR:-}" ]]; then
+    PROGRAM_DIR="${BASH_SOURCE[0]%/*}"
+    [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
+fi
+
+# Guard to avoid reloading
+[[ -n "${_5200_io_nvme_module_test_loaded:-}" ]] && return 0
+_5200_io_nvme_module_test_loaded=true
+
+# Variables to control cloud platform simulation
+is_amazon_cloud=1
+is_microsoft_cloud=1
+is_google_cloud=1
+
+#mock PREREQUISITE functions
+LIB_FUNC_IS_CLOUD_AMAZON() { return ${is_amazon_cloud} ; }
+LIB_FUNC_IS_CLOUD_MICROSOFT() { return ${is_microsoft_cloud} ; }
+LIB_FUNC_IS_CLOUD_GOOGLE() { return ${is_google_cloud} ; }
+
+function test_not_on_hyperscaler() {
+    #arrange
+    is_amazon_cloud=1
+    is_microsoft_cloud=1
+    is_google_cloud=1
+
+    #act
+    check_5200_io_nvme_enabled_hyperscaler
+    local rc=$?
+
+    #assert
+    if [[ "$rc" != '3' ]]; then
+        bashunit::fail "Expected CheckSkip RC=3 but got RC=$rc"
+    fi
+    assert_true true
+}
+
+function test_on_hyperscaler_module_loaded() {
+    #arrange
+    is_microsoft_cloud=0
+    mkdir -p "${PROGRAM_DIR}/mock_nvme_module_5200"
+    path_to_nvme_module="${PROGRAM_DIR}/mock_nvme_module_5200"
+
+    #act
+    check_5200_io_nvme_enabled_hyperscaler
+    local rc=$?
+
+    #assert
+    if [[ "$rc" != '0' ]]; then
+        bashunit::fail "Expected CheckOk RC=0 but got RC=$rc"
+    fi
+    assert_true true
+}
+
+function test_on_hyperscaler_module_not_loaded() {
+    #arrange
+    is_microsoft_cloud=0
+    path_to_nvme_module="${PROGRAM_DIR}/nonexistent_nvme_module_5200"
+
+    #act
+    check_5200_io_nvme_enabled_hyperscaler
+    local rc=$?
+
+    #assert
+    if [[ "$rc" != '1' ]]; then
+        bashunit::fail "Expected CheckWarning RC=1 but got RC=$rc"
+    fi
+    assert_true true
+}
+
+function set_up_before_script() {
+    set +eE
+
+    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+
+    #shellcheck source=../saphana-logger-stubs
+    source "${PROGRAM_DIR}/../saphana-logger-stubs"
+
+    #shellcheck source=../../lib/check/5200_io_nvme_enabled_hyperscaler.check
+    source "${PROGRAM_DIR}/../../lib/check/5200_io_nvme_enabled_hyperscaler.check"
+}
+
+function set_up() {
+    # Default path - can be overridden by individual tests
+    path_to_nvme_module="/sys/module/nvme_core"
+    is_amazon_cloud=1
+    is_microsoft_cloud=1
+    is_google_cloud=1
+
+    # Clean up any existing mock directories
+    rm -rf "${PROGRAM_DIR}/mock_nvme_module_5200"
+}
+
+function tear_down_after_script() {
+    rm -rf "${PROGRAM_DIR}/mock_nvme_module_5200"
+}


### PR DESCRIPTION
## Changes

- New check `5200_io_nvme_enabled_hyperscaler`: verify NVMe module is loaded on hyperscalers (AWS, Azure, GCP)
- Add check 5200 to `SLESonX64only` and `RHELonX64only` checksets
- Unit tests for check 5200

## Details

This check validates that the NVMe kernel module (nvme_core) is enabled on supported hyperscaler platforms (Amazon, Microsoft Azure, Google Cloud).
If not loaded, it raises a warning (RC=1). On non-hyperscaler systems the check is skipped (RC=3).

References:
- SAP Note #1656250 (AWS)
- SAP Note #2015553 (Azure)
- SAP Note #2456406 (GCP)