### PR TITLE
refactor(3301): rename Azure AAN check and adjust 1-pair result

### DIFF
--- a/scripts/lib/check/3301_aan_interfaces_azure.check
+++ b/scripts/lib/check/3301_aan_interfaces_azure.check
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-function check_3301_network_accelerated_azure {
+function check_3301_aan_interfaces_azure {
 
     logTrace "<${BASH_SOURCE[0]}:${FUNCNAME[*]}>"
 
@@ -68,10 +68,18 @@ function check_3301_network_accelerated_azure {
 
         done
 
-        if [[ ${_count_AAN} -gt 0 ]] && [[ ${_count_AAN} -eq ${_count_nonAAN} ]]; then
+        if [[ ${_count_AAN} -ge 2 ]] && [[ ${_count_AAN} -eq ${_count_nonAAN} ]]; then
 
             logCheckOk "Azure Accelerated Networking enabled as recommended (SAP Note ${sapnote:-})"
             _retval=0
+
+        elif [[ ${_count_AAN} -eq 1 ]] && [[ ${_count_AAN} -eq ${_count_nonAAN} ]]; then
+
+            logCheckInfo 'In case of HANA Scale-Out or HANA SystemReplication at least 2 AAN adapters should be configured'
+            logCheckInfo '---'
+
+            logCheckWarning "Azure Accelerated Networking NOT enabled as recommended (SAP Note ${sapnote:-})  (is: 1, should be: >=2)"
+            _retval=1
 
         elif [[ ${_count_AAN} -eq 0 ]]; then
 

--- a/scripts/lib/checkset/RHELonX64only.checkset
+++ b/scripts/lib/checkset/RHELonX64only.checkset
@@ -66,7 +66,7 @@
 3110_ip_port_range_parity
 3120_ip_port_hostagent
 3202_mtu_jumbo_amazon
-3301_network_accelerated_azure
+3301_aan_interfaces_azure
 3302_ena_interfaces_amazon
 3304_network_interface_gvnic_gcp
 3309_vmxnet3_interfaces_vmware

--- a/scripts/lib/checkset/SLESonX64only.checkset
+++ b/scripts/lib/checkset/SLESonX64only.checkset
@@ -67,7 +67,7 @@
 3110_ip_port_range_parity
 3120_ip_port_hostagent
 3202_mtu_jumbo_amazon
-3301_network_accelerated_azure
+3301_aan_interfaces_azure
 3302_ena_interfaces_amazon
 3304_network_interface_gvnic_gcp
 3309_vmxnet3_interfaces_vmware

--- a/scripts/tests/check/3301_aan_interfaces_azure.bashunit.sh
+++ b/scripts/tests/check/3301_aan_interfaces_azure.bashunit.sh
@@ -34,7 +34,7 @@ function test_0interface_error() {
     if_aan=()
 
     #act
-    check_3301_network_accelerated_azure
+    check_3301_aan_interfaces_azure
 
     #assert
     if [[ $? -ne 2 ]]; then
@@ -43,7 +43,7 @@ function test_0interface_error() {
     assert_true true
 }
 
-function test_1pair_ok() {
+function test_1pair_warning() {
 
     #arrange
     if_aan=()
@@ -51,11 +51,28 @@ function test_1pair_ok() {
     if_aan+=('/sys/class/net/eth1/device/uevent:DRIVER=mana')
 
     #act
-    check_3301_network_accelerated_azure
+    check_3301_aan_interfaces_azure
+    local rc=$?
 
     #assert
-    if [[ $? -ne 0 ]]; then
-        bashunit::fail "Expected RC=0 (ok) for 1 AAN + 1 synthetic pair"
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for 1 AAN + 1 synthetic pair"
+    fi
+    assert_true true
+}
+
+function test_single_aan_without_pair_error() {
+
+    #arrange
+    if_aan=()
+    if_aan+=('/sys/class/net/eth0/device/uevent:DRIVER=mana')
+
+    #act
+    check_3301_aan_interfaces_azure
+
+    #assert
+    if [[ $? -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) for single AAN without synthetic pair"
     fi
     assert_true true
 }
@@ -70,7 +87,7 @@ function test_2pairs_ok() {
     if_aan+=('/sys/class/net/eth3/device/uevent:DRIVER=mlx')
 
     #act
-    check_3301_network_accelerated_azure
+    check_3301_aan_interfaces_azure
 
     #assert
     if [[ $? -ne 0 ]]; then
@@ -93,7 +110,7 @@ function test_4pairs_ok() {
     if_aan+=('/sys/class/net/eth7/device/uevent:DRIVER=mana')
 
     #act
-    check_3301_network_accelerated_azure
+    check_3301_aan_interfaces_azure
 
     #assert
     if [[ $? -ne 0 ]]; then
@@ -110,7 +127,7 @@ function test_only_synthetic_error() {
     if_aan+=('/sys/class/net/eth1/device/uevent:DRIVER=hv_netvsc')
 
     #act
-    check_3301_network_accelerated_azure
+    check_3301_aan_interfaces_azure
 
     #assert
     if [[ $? -ne 2 ]]; then
@@ -128,7 +145,7 @@ function test_partial_aan_error() {
     if_aan+=('/sys/class/net/eth2/device/uevent:DRIVER=hv_netvsc')
 
     #act
-    check_3301_network_accelerated_azure
+    check_3301_aan_interfaces_azure
 
     #assert
     if [[ $? -ne 2 ]]; then
@@ -144,7 +161,7 @@ function test_not_azure_skip() {
     LIB_FUNC_IS_CLOUD_MICROSOFT() { return 1 ; }
 
     #act
-    check_3301_network_accelerated_azure
+    check_3301_aan_interfaces_azure
 
     #assert
     if [[ $? -ne 3 ]]; then
@@ -166,8 +183,8 @@ function set_up_before_script() {
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"
 
-    #shellcheck source=../../lib/check/3301_network_accelerated_azure.check
-    source "${PROGRAM_DIR}/../../lib/check/3301_network_accelerated_azure.check"
+    #shellcheck source=../../lib/check/3301_aan_interfaces_azure.check
+    source "${PROGRAM_DIR}/../../lib/check/3301_aan_interfaces_azure.check"
 
 }
 


### PR DESCRIPTION
Rename check 3301 to use the new AAN-focused naming and align all references.

- add check file: 3301_aan_interfaces_azure.check
- rename check function to check_3301_aan_interfaces_azure
- update checkset entries in SLESonX64only and RHELonX64only
- update 3301 bashunit test calls/source path to new check name
- adjust 1 AAN + 1 synthetic interface expectation to warning (RC=1)
- add test case for single AAN interface without synthetic pair (RC=2)