### PR TITLE
refactor(3304): rename gvnic check, add interface counting and unit t…

### DIFF
--- a/scripts/lib/check/3304_gvnic_interfaces_gcp.check
+++ b/scripts/lib/check/3304_gvnic_interfaces_gcp.check
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-function check_3304_network_interface_gvnic_gcp {
+function check_3304_gvnic_interfaces_gcp {
 
     logTrace "<${BASH_SOURCE[0]}:${FUNCNAME[*]}>"
 
@@ -11,6 +11,7 @@ function check_3304_network_interface_gvnic_gcp {
     # MODIFICATION SECTION<<
 
     # 2456406 - SAP on Google Cloud Platform: Support Prerequisites
+    # https://docs.cloud.google.com/sap/docs/sap-hana-planning-guide#network_configuration
     # https://cloud.google.com/compute/docs/networking/using-gvnic
     # https://github.com/GoogleCloudPlatform/compute-virtual-ethernet-linux#manual-configuration
     # https://github.com/GoogleCloudPlatform/compute-virtual-ethernet-linux
@@ -31,15 +32,25 @@ function check_3304_network_interface_gvnic_gcp {
     # CHECK
     if [[ ${_retval} -eq 99 ]]; then
 
-        if grep -qs 'DRIVER=gve' /sys/class/net/**/device/uevent; then
+        mapfile -t gvnic_interfaces < <(grep DRIVER=gve -rsH /sys/class/net/**/device/uevent)
 
-            logCheckOk "GCP network interface gvnic enabled as recommended (SAP Note ${sapnote:-})"
+        if [[ ${#gvnic_interfaces[@]} -ge 2 ]]; then
+
+            logCheckOk "GCP network interface gvnic enabled as recommended (SAP Note ${sapnote:-}) (is: ${#gvnic_interfaces[@]})"
             _retval=0
+
+        elif [[ ${#gvnic_interfaces[@]} -eq 1 ]]; then
+
+            logCheckInfo 'In case of HANA Scale-Out or HANA SystemReplication at least 2 gvnic adapters should be configured'
+            logCheckInfo '---'
+
+            logCheckWarning "GCP network interface gvnic NOT as recommended (SAP Note ${sapnote:-}) (is: ${#gvnic_interfaces[@]}, should be: >=2)"
+            _retval=1
 
         else
 
-            logCheckWarning "GCP network interface gvnic NOT enabled (SAP Note ${sapnote:-})"
-            _retval=1
+            logCheckError "GCP network interface gvnic NOT configured (SAP Note ${sapnote:-})"
+            _retval=2
 
         fi
 

--- a/scripts/lib/checkset/RHELonX64only.checkset
+++ b/scripts/lib/checkset/RHELonX64only.checkset
@@ -68,7 +68,7 @@
 3202_mtu_jumbo_amazon
 3301_aan_interfaces_azure
 3302_ena_interfaces_amazon
-3304_network_interface_gvnic_gcp
+3304_gvnic_interfaces_gcp
 3309_vmxnet3_interfaces_vmware
 3411_network_tuning_azure
 3412_network_ringbuffer_azure

--- a/scripts/lib/checkset/SLESonX64only.checkset
+++ b/scripts/lib/checkset/SLESonX64only.checkset
@@ -69,7 +69,7 @@
 3202_mtu_jumbo_amazon
 3301_aan_interfaces_azure
 3302_ena_interfaces_amazon
-3304_network_interface_gvnic_gcp
+3304_gvnic_interfaces_gcp
 3309_vmxnet3_interfaces_vmware
 3411_network_tuning_azure
 3412_network_ringbuffer_azure

--- a/scripts/tests/check/3304_gvnic_interfaces_gcp.bashunit.sh
+++ b/scripts/tests/check/3304_gvnic_interfaces_gcp.bashunit.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#------------------------------------------------------------------
+# bashunit migration notes:
+# 1. PROGRAM_DIR not readonly - bashunit runs all tests in same session
+# 2. Guard check skips if already loaded to avoid readonly variable conflicts
+#------------------------------------------------------------------
+set -u  # treat unset variables as an error
+
+if [[ -z "${PROGRAM_DIR:-}" ]]; then
+    PROGRAM_DIR="${BASH_SOURCE[0]%/*}"
+    [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
+fi
+
+# Mock variables
+if_gvnic=()
+
+# Mock functions
+LIB_FUNC_IS_CLOUD_GOOGLE() { return 0 ; }
+LIB_FUNC_IS_VIRT_KVM() { return 0 ; }
+
+grep() {
+
+    #we fake (grep DRIVER=gve -rsH /sys/class/net/**/device/uevent)
+    case "$*" in
+        *'DRIVER=gve'*'uevent')  [[ ${#if_gvnic[@]} -eq 0 ]] && : || printf "%s\n" "${if_gvnic[@]}" ;;
+
+        *)          command grep "$@" ;; # bashunit requires grep
+    esac
+}
+
+
+function test_0interface_error() {
+
+    #arrange
+    if_gvnic=()
+
+    #act
+    check_3304_gvnic_interfaces_gcp
+
+    #assert
+    if [[ $? -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) for 0 gvnic interfaces"
+    fi
+    assert_true true
+}
+
+function test_1interface_warning() {
+
+    #arrange
+    if_gvnic=()
+    if_gvnic+=('/sys/class/net/eth0/device/uevent:DRIVER=gve')
+
+    #act
+    check_3304_gvnic_interfaces_gcp
+
+    #assert
+    if [[ $? -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for 1 gvnic interface"
+    fi
+    assert_true true
+}
+
+function test_2interfaces_ok() {
+
+    #arrange
+    if_gvnic=()
+    if_gvnic+=('/sys/class/net/eth0/device/uevent:DRIVER=gve')
+    if_gvnic+=('/sys/class/net/eth1/device/uevent:DRIVER=gve')
+
+    #act
+    check_3304_gvnic_interfaces_gcp
+
+    #assert
+    if [[ $? -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for 2 gvnic interfaces"
+    fi
+    assert_true true
+}
+
+function test_4interfaces_ok() {
+
+    #arrange
+    if_gvnic=()
+    if_gvnic+=('/sys/class/net/eth0/device/uevent:DRIVER=gve')
+    if_gvnic+=('/sys/class/net/eth1/device/uevent:DRIVER=gve')
+    if_gvnic+=('/sys/class/net/eth2/device/uevent:DRIVER=gve')
+    if_gvnic+=('/sys/class/net/eth3/device/uevent:DRIVER=gve')
+
+    #act
+    check_3304_gvnic_interfaces_gcp
+
+    #assert
+    if [[ $? -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for 4 gvnic interfaces"
+    fi
+    assert_true true
+}
+
+function test_not_gcp_skip() {
+
+    #arrange
+    LIB_FUNC_IS_CLOUD_GOOGLE() { return 1 ; }
+
+    #act
+    check_3304_gvnic_interfaces_gcp
+
+    #assert
+    if [[ $? -ne 3 ]]; then
+        bashunit::fail "Expected RC=3 (skip) for non-GCP"
+    fi
+    assert_true true
+}
+
+function test_not_kvm_skip() {
+
+    #arrange
+    LIB_FUNC_IS_CLOUD_GOOGLE() { return 0 ; }
+    LIB_FUNC_IS_VIRT_KVM() { return 1 ; }
+
+    #act
+    check_3304_gvnic_interfaces_gcp
+
+    #assert
+    if [[ $? -ne 3 ]]; then
+        bashunit::fail "Expected RC=3 (skip) for non-KVM"
+    fi
+    assert_true true
+}
+
+
+function set_up_before_script() {
+
+    # Disable errexit - bashunit enables it but sourced files may return non-zero
+    set +eE
+
+    # Skip if already loaded (bashunit runs all tests in same session)
+    [[ -n "${_3304_test_loaded:-}" ]] && return 0
+    _3304_test_loaded=true
+
+    #shellcheck source=../saphana-logger-stubs
+    source "${PROGRAM_DIR}/../saphana-logger-stubs"
+
+    #shellcheck source=../../lib/check/3304_gvnic_interfaces_gcp.check
+    source "${PROGRAM_DIR}/../../lib/check/3304_gvnic_interfaces_gcp.check"
+
+}
+
+function set_up() {
+
+    # Reset mock variables
+    if_gvnic=()
+    LIB_FUNC_IS_CLOUD_GOOGLE() { return 0 ; }
+    LIB_FUNC_IS_VIRT_KVM() { return 0 ; }
+
+}


### PR DESCRIPTION
…ests

Align check 3304 with the naming convention and logic used in 3301/3302.

- rename check file to 3304_gvnic_interfaces_gcp.check
- rename check function to check_3304_gvnic_interfaces_gcp
- update checkset entries in SLESonX64only and RHELonX64only
- replace single boolean gvnic detection with interface count (mapfile + grep)
- apply same RC logic as 3302: >=2 ok, ==1 warning, ==0 error
- add info hint for Scale-Out/SystemReplication when only 1 adapter found
- add unit tests: 0/1/2/4 interfaces, non-GCP skip, non-KVM skip