### PR TITLE
Enhance check 0090 to log tainting kernel modules

### DIFF
--- a/scripts/lib/check/0090_os_kernel_tainted.check
+++ b/scripts/lib/check/0090_os_kernel_tainted.check
@@ -14,6 +14,7 @@ function check_0090_os_kernel_tainted {
 
     #tweaked by unit-test
     local path_to_kernel_tainted="${path_to_kernel_tainted:-/proc/sys/kernel/tainted}"
+    local path_to_module_taint="${path_to_module_taint:-/sys/module/*/taint}"
 
     # PRECONDITIONS
 
@@ -55,6 +56,25 @@ function check_0090_os_kernel_tainted {
             [[ $((kernel_tainted &  65536)) -ne 0 ]] && _tainted_flag+='X'
             [[ $((kernel_tainted & 131072)) -ne 0 ]] && _tainted_flag+='T'
             : "${_tainted_flag:=-}"
+
+            local _module_taint_line _module_name _module_taint
+            local -a _module_taint_lines
+
+            # shellcheck disable=SC2086
+            mapfile -t _module_taint_lines < <(grep . -rs ${path_to_module_taint})
+            for _module_taint_line in "${_module_taint_lines[@]}"; do
+                _module_name="${_module_taint_line%%/taint:*}"
+                _module_name="${_module_name##*/}"
+                _module_taint="${_module_taint_line##*:}"
+
+                if [[ -n "${_module_taint}" ]]; then
+                    if [[ ${_retval} -eq 2 ]]; then
+                        logCheckError "Kernel tainting module with severe flags (is: ${_module_name}:${_module_taint})"
+                    else
+                        logCheckWarning "Kernel tainting module with non-severe flags (is: ${_module_name}:${_module_taint})"
+                    fi
+                fi
+            done
 
             if [[ ${_retval} -eq 2 ]]; then
                 logCheckError "OS kernel is NOT un-tainted as required - severe flags set (SAP Note ${sapnote:-}) (is: ${kernel_tainted}, Flags:${_tainted_flag})"

--- a/scripts/tests/check/0090_os_kernel_tainted.bashunit.sh
+++ b/scripts/tests/check/0090_os_kernel_tainted.bashunit.sh
@@ -13,6 +13,8 @@ fi
 
 # Mock path for kernel tainted
 path_to_kernel_tainted=''
+path_to_module_taint=''
+mock_module_taint_dir=''
 
 
 function test_kernel_tainted_set0_untainted_ok() {
@@ -90,6 +92,45 @@ function test_kernel_tainted_set15_tainted_error() {
     assert_true true
 }
 
+function test_kernel_tainted_set1_lists_tainting_modules() {
+
+    #arrange
+    local captured_error=''
+
+    echo 1 > "${path_to_kernel_tainted}"
+
+    mkdir -p "${mock_module_taint_dir}/hv_netvsc" "${mock_module_taint_dir}/hv_storvsc" "${mock_module_taint_dir}/livepatch_1"
+    echo X > "${mock_module_taint_dir}/hv_netvsc/taint"
+    echo X > "${mock_module_taint_dir}/hv_storvsc/taint"
+    echo OK > "${mock_module_taint_dir}/livepatch_1/taint"
+
+    # shellcheck disable=SC2329
+    logCheckError() {
+        captured_error+="${captured_error:+$'\n'}$*"
+    }
+
+    #act
+    check_0090_os_kernel_tainted
+
+    #assert
+    if [[ $? -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) for tainted kernel (flag 1)"
+    fi
+    if [[ "${captured_error}" != *"hv_netvsc:X"* ]]; then
+        bashunit::fail "Expected tainting module to be listed in output"
+    fi
+    if [[ "${captured_error}" != *"hv_storvsc:X"* ]]; then
+        bashunit::fail "Expected each tainting module to be listed in separate output lines"
+    fi
+    if [[ "${captured_error}" != *"livepatch_1:OK"* ]]; then
+        bashunit::fail "Expected OK module taint flags to be listed in output"
+    fi
+    if [[ "${captured_error}" == *"hv_netvsc:X,hv_storvsc:X"* ]]; then
+        bashunit::fail "Expected modules to be logged separately, not as a combined list"
+    fi
+    assert_true true
+}
+
 
 function set_up_before_script() {
 
@@ -114,6 +155,9 @@ function set_up() {
     path_to_kernel_tainted="${PROGRAM_DIR}/mock_kernel_tainted"
     echo 0 > "${path_to_kernel_tainted}"
 
+    mock_module_taint_dir="${PROGRAM_DIR}/mock_sys_module"
+    path_to_module_taint="${mock_module_taint_dir}/*/taint"
+
 }
 
 function tear_down() {
@@ -121,6 +165,10 @@ function tear_down() {
     # Clean up mock file
     if [[ -f "${path_to_kernel_tainted}" ]]; then
         rm -f "${path_to_kernel_tainted}"
+    fi
+
+    if [[ -d "${mock_module_taint_dir}" ]]; then
+        rm -rf "${mock_module_taint_dir}"
     fi
 
 }


### PR DESCRIPTION
Extend `check_0090_os_kernel_tainted` to inspect `/sys/module/*/taint` and emit per-module messages when module taint flags are present.

- add configurable `path_to_module_taint` (default: `/sys/module/*/taint`)
- collect and parse module taint entries via `grep`/`mapfile`
- log each tainting module separately as:
  - error when severe kernel taint flags are set (RC=2 path)
  - warning when only non-severe flags are present (RC=1 path)
- keep existing kernel taint severity evaluation and final RC behavior

Add/extend unit tests for check 0090:
- mock module taint files under a test directory
- verify tainting modules are listed in log output
- verify modules are logged on separate lines
- verify teardown cleans mock module taint directory