### PR TITLE
fix(tests): replace HANA_HELPER_PROGVERSION guard with test-specific …

### DIFF
--- a/scripts/tests/check/5010_io_scheduler_blockdevices.bashunit.sh
+++ b/scripts/tests/check/5010_io_scheduler_blockdevices.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_5010_io_scheduler_test_loaded:-}" ]] && return 0
-_5010_io_scheduler_test_loaded=true
-
 #mock PREREQUISITE functions
 LIB_FUNC_IS_CLOUD_MICROSOFT() { return 1 ; }
 LIB_FUNC_IS_CLOUD_AMAZON() { return 1 ; }
@@ -160,7 +156,8 @@ function test_4scheduler_1_wrong() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_5010_test_loaded:-}" ]] && return 0
+    _5010_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/5100_pagecache_limit_sles.bashunit.sh
+++ b/scripts/tests/check/5100_pagecache_limit_sles.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_5100_pagecache_limit_test_loaded:-}" ]] && return 0
-_5100_pagecache_limit_test_loaded=true
-
 #mock PREREQUISITE functions
 LIB_FUNC_IS_SLES() { return 0 ; }
 LIB_FUNC_IS_SLES4SAP() {
@@ -167,7 +163,8 @@ function test_pgc_limit_sles_wrong_256G_also_not_supported() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_5100_test_loaded:-}" ]] && return 0
+    _5100_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/5200_io_nvme_enabled_hyperscaler.bashunit.sh
+++ b/scripts/tests/check/5200_io_nvme_enabled_hyperscaler.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_5200_io_nvme_module_test_loaded:-}" ]] && return 0
-_5200_io_nvme_module_test_loaded=true
-
 # Variables to control cloud platform simulation
 is_amazon_cloud=1
 is_microsoft_cloud=1
@@ -77,7 +73,8 @@ function test_on_hyperscaler_module_not_loaded() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_5200_test_loaded:-}" ]] && return 0
+    _5200_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/5210_io_nvme_parameter_hyperscaler.bashunit.sh
+++ b/scripts/tests/check/5210_io_nvme_parameter_hyperscaler.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_5210_io_nvme_test_loaded:-}" ]] && return 0
-_5210_io_nvme_test_loaded=true
-
 # Variables to control cloud platform simulation
 is_amazon_cloud=1
 is_microsoft_cloud=1
@@ -213,7 +209,8 @@ function test_very_large_value() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_5210_test_loaded:-}" ]] && return 0
+    _5210_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/5521_nfs_mount_rwsize_azure.bashunit.sh
+++ b/scripts/tests/check/5521_nfs_mount_rwsize_azure.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_5521_nfs_mount_azure_test_loaded:-}" ]] && return 0
-_5521_nfs_mount_azure_test_loaded=true
-
 #mock PREREQUISITE functions
 LIB_FUNC_IS_CLOUD_MICROSOFT() { return 0 ; }
 LIB_FUNC_STRINGCONTAIN() { [[ -z "${1##*"$2"*}" ]] && [[ -z "$2" || -n "$1" ]]; }
@@ -116,7 +112,8 @@ function test_nfs_wrong_all() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_5521_test_loaded:-}" ]] && return 0
+    _5521_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/5522_nfs_mount_rwsize_amazon.bashunit.sh
+++ b/scripts/tests/check/5522_nfs_mount_rwsize_amazon.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_5522_nfs_mount_amazon_test_loaded:-}" ]] && return 0
-_5522_nfs_mount_amazon_test_loaded=true
-
 #mock PREREQUISITE functions
 LIB_FUNC_IS_CLOUD_AMAZON() { return 0 ; }
 LIB_FUNC_STRINGCONTAIN() { [[ -z "${1##*"$2"*}" ]] && [[ -z "$2" || -n "$1" ]]; }
@@ -116,7 +112,8 @@ function test_nfs_wrong_all() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_5522_test_loaded:-}" ]] && return 0
+    _5522_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/5530_nfs_mount_nconnect.bashunit.sh
+++ b/scripts/tests/check/5530_nfs_mount_nconnect.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_5530_nfs_mount_nconnect_test_loaded:-}" ]] && return 0
-_5530_nfs_mount_nconnect_test_loaded=true
-
 #mock PREREQUISITE functions
 LIB_FUNC_STRINGCONTAIN() { [[ -z "${1##*"$2"*}" ]] && [[ -z "$2" || -n "$1" ]]; }
 
@@ -141,7 +137,8 @@ function test_nfs_nconnect_not_supported() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_5530_test_loaded:-}" ]] && return 0
+    _5530_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/5540_fs_hana_mount.bashunit.sh
+++ b/scripts/tests/check/5540_fs_hana_mount.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_5540_fs_hana_mount_test_loaded:-}" ]] && return 0
-_5540_fs_hana_mount_test_loaded=true
-
 # mock PREREQUISITE functions
 LIB_FUNC_STRINGCONTAIN() { [[ -z "${1##*"$2"*}" ]] && [[ -z "$2" || -n "$1" ]]; }
 
@@ -121,7 +117,8 @@ function test_unsupported_fs() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_5540_test_loaded:-}" ]] && return 0
+    _5540_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/7010_corosync_version.bashunit.sh
+++ b/scripts/tests/check/7010_corosync_version.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_7010_corosync_version_test_loaded:-}" ]] && return 0
-_7010_corosync_version_test_loaded=true
-
 #mock PREREQUISITE functions
 LIB_FUNC_IS_SLES() { return 0 ; }
 LIB_FUNC_NORMALIZE_RPM() { : ; }
@@ -148,7 +144,8 @@ function test_rpm_old_and_used() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_7010_test_loaded:-}" ]] && return 0
+    _7010_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/7015_pacemaker_version.bashunit.sh
+++ b/scripts/tests/check/7015_pacemaker_version.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_7015_pacemaker_version_test_loaded:-}" ]] && return 0
-_7015_pacemaker_version_test_loaded=true
-
 #mock PREREQUISITE functions
 LIB_FUNC_IS_SLES() { return 0 ; }
 LIB_FUNC_IS_RHEL() { return 1 ; }
@@ -242,7 +238,8 @@ function test_sles15_5_version_old_both_enabled_and_active() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_7015_test_loaded:-}" ]] && return 0
+    _7015_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/7018_pacemaker_attributes.bashunit.sh
+++ b/scripts/tests/check/7018_pacemaker_attributes.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_7018_pacemaker_attributes_test_loaded:-}" ]] && return 0
-_7018_pacemaker_attributes_test_loaded=true
-
 #mock PREREQUISITE functions
 LIB_FUNC_IS_SLES() { return 0 ; }
 LIB_FUNC_IS_RHEL() { return 1 ; }
@@ -37,7 +33,8 @@ declare cibadmin_output=''
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_7018_test_loaded:-}" ]] && return 0
+    _7018_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/7020_ha_resource_agent_scaleup_sles.bashunit.sh
+++ b/scripts/tests/check/7020_ha_resource_agent_scaleup_sles.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_7020_ha_resource_agent_sles_test_loaded:-}" ]] && return 0
-_7020_ha_resource_agent_sles_test_loaded=true
-
 #mock PREREQUISITE functions
 LIB_FUNC_IS_SLES() { return 0 ; }
 LIB_FUNC_NORMALIZE_RPMn() { : ; }
@@ -77,7 +73,8 @@ function test_rpm_old() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_7020_test_loaded:-}" ]] && return 0
+    _7020_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/7021_ha_resource_agent_angi_sles.bashunit.sh
+++ b/scripts/tests/check/7021_ha_resource_agent_angi_sles.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_7021_ha_resource_agent_angi_sles_test_loaded:-}" ]] && return 0
-_7021_ha_resource_agent_angi_sles_test_loaded=true
-
 #mock PREREQUISITE functions
 LIB_FUNC_IS_SLES() { return 0 ; }
 LIB_FUNC_NORMALIZE_RPMn() { : ; }
@@ -77,7 +73,8 @@ function test_rpm_old() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_7021_test_loaded:-}" ]] && return 0
+    _7021_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"

--- a/scripts/tests/check/8050_hana_revision_infra_issues.bashunit.sh
+++ b/scripts/tests/check/8050_hana_revision_infra_issues.bashunit.sh
@@ -10,10 +10,6 @@ if [[ -z "${PROGRAM_DIR:-}" ]]; then
     [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
 fi
 
-# Guard to avoid reloading
-[[ -n "${_8050_hana_revision_test_loaded:-}" ]] && return 0
-_8050_hana_revision_test_loaded=true
-
 #mock PREREQUISITE functions
 LIB_FUNC_IS_INTEL() { return 0 ; }
 
@@ -191,7 +187,8 @@ function test_hana_releases_affected3() {
 function set_up_before_script() {
     set +eE
 
-    [[ -n "${HANA_HELPER_PROGVERSION:-}" ]] && return 0
+    [[ -n "${_8050_test_loaded:-}" ]] && return 0
+    _8050_test_loaded=true
 
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"


### PR DESCRIPTION
…_NNNN_test_loaded

HANA_HELPER_PROGVERSION is the real guard variable used by saphana-helper-funcs. Using it in test files could collide if the helper library were ever sourced in the same bashunit session.

Replace with isolated _NNNN_test_loaded variables inside set_up_before_script() and remove redundant top-level guards (bashunit sources each file exactly once).

Affected: 5010, 5100, 5200, 5210, 5521, 5522, 5530, 5540, 7010, 7015, 7018, 7020, 7021, 8050