### PR TITLE
lib_platf_power - fix issue "warning: command substitution: ignored n…

### DIFF
--- a/scripts/bin/lib_platf_power
+++ b/scripts/bin/lib_platf_power
@@ -157,7 +157,7 @@ function __lib_func_get_hypervisor_details {
     elif [[ -r '/proc/device-tree/compatible' ]]; then
 
         local pdt_compatible
-        pdt_compatible=$(</proc/device-tree/compatible)
+        IFS= read -r -d '' pdt_compatible </proc/device-tree/compatible
         readonly pdt_compatible
 
         case "${pdt_compatible}" in


### PR DESCRIPTION
…ull byte in input"

The /proc/device-tree/compatible file contains null-byte-terminated strings, which causes bash to warn when using command substitution to read it.