### PR TITLE
refactored check 3105_ip_port_range_width.check

### DIFF
--- a/scripts/lib/check/3105_ip_port_range_width.check
+++ b/scripts/lib/check/3105_ip_port_range_width.check
@@ -8,59 +8,43 @@ function check_3105_ip_port_range_width {
 
     # MODIFICATION SECTION>>
     local -r sapnote='#2382421,#401162'
-    local -ri pr_lower_expected=9000
-    local -ri pr_upper_expected=65499
+    local -ri pr_range_width_expected=40000
     # MODIFICATION SECTION<<
 
     # 2382421 - Optimizing the Network Configuration on HANA- and OS-Level
     # 401162  - Linux: Avoiding TCP/IP port conflicts and start problems
-    #'net.ipv4.ip_local_port_range' "9000 65499"
+    # Range width (upper - lower) must be >= 40000
 
     # PRECONDITIONS
 
     # CHECK
     if [[ ${_retval} -eq 99 ]]; then
 
+        local path_to_ip_local_port_range="${path_to_ip_local_port_range:-/proc/sys/net/ipv4/ip_local_port_range}"
+
         local port_range
-        port_range=$(</proc/sys/net/ipv4/ip_local_port_range)    # 40000 64999
+        port_range=$(<"${path_to_ip_local_port_range}")    # e.g. 40000 64999
         readonly port_range
 
         local -ri port_range_lower="${port_range%%[[:space:]]*}"    # BLANKS and TABS --> 40000
         local -ri port_range_upper="${port_range##*[[:space:]]}"    # BLANKS and TABS --> 64999
 
-        if [[ ${port_range_lower} -le ${pr_lower_expected} ]]; then
+        local -ri port_range_width=$(( port_range_upper - port_range_lower ))
 
-            logCheckOk "sysctl parameter net.ipv4.ip_local_port_range's lower value set as recommended (is: ${port_range_lower})"
+        if [[ ${port_range_width} -ge ${pr_range_width_expected} ]]; then
+
+            logCheckOk "sysctl parameter net.ipv4.ip_local_port_range (lower: ${port_range_lower}, upper: ${port_range_upper}, width: ${port_range_width})"
+            logCheckOk "sysctl parameter net.ipv4.ip_local_port_range width set as recommended (SAP Note ${sapnote:-}) (is: ${port_range_width})"
+            _retval=0
 
         else
 
-            logCheckWarning "sysctl parameter net.ipv4.ip_local_port_range's lower value NOT set as recommended (is: ${port_range_lower}, should be: <= ${pr_lower_expected})"
+            logCheckWarning "sysctl parameter net.ipv4.ip_local_port_range (lower: ${port_range_lower}, upper: ${port_range_upper}, width: ${port_range_width})"
+            logCheckWarning "sysctl parameter net.ipv4.ip_local_port_range width NOT set as recommended (SAP Note ${sapnote:-}) (is: ${port_range_width}, should be: >= ${pr_range_width_expected})"
             _retval=1
 
         fi
 
-        if [[ ${port_range_upper} -ge ${pr_upper_expected} ]]; then
-
-            logCheckOk "sysctl parameter net.ipv4.ip_local_port_range's upper value set as recommended (is: ${port_range_upper})"
-
-        else
-
-            logCheckWarning "sysctl parameter net.ipv4.ip_local_port_range's upper value NOT set as recommended (is: ${port_range_upper}, should be: >= ${pr_upper_expected})"
-            _retval=1
-
-        fi
-
-    fi
-
-    if [[ ${_retval} -eq 99 ]]; then
-
-        logCheckOk "sysctl parameter net.ipv4.ip_local_port_range width set as recommended (SAP Note ${sapnote:-})"
-        _retval=0
-
-    else
-
-        logCheckWarning "sysctl parameter net.ipv4.ip_local_port_range width NOT set as recommended (SAP Note ${sapnote:-})"
-        _retval=1
     fi
 
     logDebug "<${BASH_SOURCE[0]}:${FUNCNAME[0]}> # RC=${_retval}"

--- a/scripts/tests/check/3105_ip_port_range_width.bashunit.sh
+++ b/scripts/tests/check/3105_ip_port_range_width.bashunit.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#------------------------------------------------------------------
+# bashunit tests for check_3105_ip_port_range_width
+#
+# Check logic: net.ipv4.ip_local_port_range width (upper - lower)
+# must be >= 40000 to pass.
+#------------------------------------------------------------------
+set -u
+
+if [[ -z "${PROGRAM_DIR:-}" ]]; then
+    PROGRAM_DIR="${BASH_SOURCE[0]%/*}"
+    [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
+fi
+
+# Mock variables
+mock_port_range='40000 64999'
+
+# Helper: write mock file and export path
+setup_test() {
+    mkdir -p "${PROGRAM_DIR}/mock_proc/sys/net/ipv4"
+    echo "${mock_port_range}" > "${PROGRAM_DIR}/mock_proc/sys/net/ipv4/ip_local_port_range"
+    export path_to_ip_local_port_range="${PROGRAM_DIR}/mock_proc/sys/net/ipv4/ip_local_port_range"
+}
+
+assert_check_processed() {
+    local rc=$1
+    local context="${2:-}"
+    if [[ ${rc} -eq 99 ]]; then
+        bashunit::fail "RC=99 (unprocessed) - check logic did not reach a conclusion${context:+ in }${context}"
+    fi
+}
+
+function test_range_width_exactly_40000_passes() {
+    #arrange  lower=10000 upper=50000  width=40000
+    mock_port_range='10000 50000'
+    setup_test
+
+    #act
+    check_3105_ip_port_range_width
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "width exactly 40000"
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for width=40000, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_range_width_above_40000_passes() {
+    #arrange  lower=32768 upper=60999  width=28231 -- wait, 60999-32768=28231 < 40000
+    # Use lower=20000 upper=65000 width=45000
+    mock_port_range='20000 65000'
+    setup_test
+
+    #act
+    check_3105_ip_port_range_width
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "width 45000 > 40000"
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for width=45000, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_typical_sap_range_9000_65499_passes() {
+    #arrange  lower=9000 upper=65499  width=56499 >= 40000
+    mock_port_range='9000 65499'
+    setup_test
+
+    #act
+    check_3105_ip_port_range_width
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "SAP recommended range 9000-65499"
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for SAP recommended range 9000-65499 (width=56499), got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_range_width_below_40000_warns() {
+    #arrange  lower=32768 upper=60999  width=28231 < 40000
+    mock_port_range='32768 60999'
+    setup_test
+
+    #act
+    check_3105_ip_port_range_width
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "width 28231 < 40000"
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for width=28231, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_range_width_just_under_40000_warns() {
+    #arrange  lower=0 upper=39999  width=39999 < 40000
+    mock_port_range='0 39999'
+    setup_test
+
+    #act
+    check_3105_ip_port_range_width
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "width 39999 just under 40000"
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for width=39999, got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function test_default_linux_range_32768_60999_warns() {
+    #arrange  Linux default: lower=32768 upper=60999  width=28231 < 40000
+    mock_port_range='32768	60999'
+    setup_test
+
+    #act
+    check_3105_ip_port_range_width
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "Linux default range 32768-60999"
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for Linux default range 32768-60999 (width=28231), got RC=${rc}"
+    fi
+    assert_true true
+}
+
+function set_up_before_script() {
+    set +eE
+
+    [[ -n "${_3105_test_loaded:-}" ]] && return 0
+    _3105_test_loaded=true
+
+    #shellcheck source=../saphana-logger-stubs
+    source "${PROGRAM_DIR}/../saphana-logger-stubs"
+
+    #shellcheck source=../../lib/check/3105_ip_port_range_width.check
+    source "${PROGRAM_DIR}/../../lib/check/3105_ip_port_range_width.check"
+}
+
+function set_up() {
+    mock_port_range='40000 64999'
+    unset path_to_ip_local_port_range
+}
+
+function tear_down_after_script() {
+    rm -f "${PROGRAM_DIR}/mock_proc/sys/net/ipv4/ip_local_port_range"
+}


### PR DESCRIPTION
-removed the separate lower/upper bound checks (<= 9000 and >= 65499) 
-now computes width = upper - lower and checks width >= 40000 
-added path_to_ip_local_port_range variable with /proc/sys/net/ipv4/ip_local_port_range as default, enabling test mocking 
-single pass/fail decision with clear log message including width and range

- added Unit tests (3105_ip_port_range_width.bashunit.sh):