### PR TITLE
Refine IBM Power power-mode handling for check 1310

### DIFF
--- a/scripts/bin/lib_platf_power
+++ b/scripts/bin/lib_platf_power
@@ -24,20 +24,29 @@ function LIB_FUNC_TRANSFORM_POWER_POWERMODE {
 
     logTrace "<${BASH_SOURCE[0]}:${FUNCNAME[*]}>"
 
-    # P9,P10,?P11
+    # P10,?P11
     # 0x0001: "Maximum Performance"
-    # 0x0002: "None"
-    # 0x0003: "Static"
-    # 0x0004: "Dynamic Performance"
+    # 0x0002: "None" ?
+    # 0x0003: "Power Saving"
     # default: "Unknown"
 
-    if [[ "${LIB_PLATF_POWER_PLATFORM_BASE:-}" =~ POWER(11|10|9) ]]; then
+    if [[ "${LIB_PLATF_POWER_PLATFORM_BASE:-}" =~ POWER(11|10) ]]; then
 
         case "${powermode}" in
             '0001')  : 'Maximum Performance' ;;
+            '0002')  : 'Static' ;;
+            '0003')  : 'Power Saving' ;;
+            *)       : 'Unknown';;
+        esac
+        powermode="$_"
+
+    elif [[ "${LIB_PLATF_POWER_PLATFORM_BASE:-}" == 'POWER9' ]]; then
+
+        # 0x0001: "Maximum Performance" or "Dynamic, Favor Performance" (ambiguous)
+        case "${powermode}" in
+            '0001')  : 'Dynamic, Favor Performance' ;;
             '0002')  : 'None' ;;
             '0003')  : 'Static' ;;
-            '0004')  : 'Dynamic Performance' ;;
             *)       : 'Unknown';;
         esac
         powermode="$_"

--- a/scripts/lib/check/1310_cpu_powersavings_ibmpower.check
+++ b/scripts/lib/check/1310_cpu_powersavings_ibmpower.check
@@ -8,6 +8,8 @@ function check_1310_cpu_powersavings_ibmpower {
 
     # MODIFICATION SECTION>>
     local -r sapnote='#3684765'
+    local path_to_value_desc="${path_to_value_desc:-/sys/firmware/papr/energy_scale_info/1/value_desc}"
+    local -r expected_value_desc='Maximum Performance'
     # MODIFICATION SECTION<<
 
     #3684765 - IBM Power Systems: Recommended IBM EnergyScale settings
@@ -18,15 +20,42 @@ function check_1310_cpu_powersavings_ibmpower {
         logCheckSkipped 'Not running on IBM Power. Skipping' "<${FUNCNAME[0]}>"
         _retval=3
 
-    elif [[ -z ${LIB_PLATF_POWER_POWERMODE:-} ]]; then
+    fi
 
-        logCheckError "Power Savings Mode NOT known (SAP Note ${sapnote:-}) (is: Unknown, should be: Maximum Performance)"
+    #CHECK - preferred interface: /sys/firmware/papr/energy_scale_info/1/value_desc
+    if [[ ${_retval} -eq 99 ]] && [[ -r "${path_to_value_desc}" ]]; then
+
+        local value_desc=''
+        value_desc=$(< "${path_to_value_desc}")
+        value_desc="$(LIB_FUNC_TRIM "${value_desc}")"
+
+        logDebug "<${BASH_SOURCE[0]}:${FUNCNAME[0]}> # value_desc file: ${path_to_value_desc}; content: '${value_desc:-}'"
+
+        if [[ "${value_desc}" == "${expected_value_desc}" ]]; then
+
+            logCheckOk "Power Savings Mode set as recommended (SAP Note ${sapnote:-}) (is: ${value_desc})"
+            _retval=0
+
+        else
+
+            logCheckError "Power Savings Mode NOT set as recommended (SAP Note ${sapnote:-}) (is: ${value_desc:-Unknown}, should be: ${expected_value_desc})"
+            _retval=2
+
+        fi
+
+    fi
+
+    #CHECK - fallback: lparcfg-derived LIB_PLATF_POWER_POWERMODE
+    if [[ ${_retval} -eq 99 ]] && [[ -z ${LIB_PLATF_POWER_POWERMODE:-} ]]; then
+
+        logCheckError "Power Savings Mode NOT known (SAP Note ${sapnote:-}) (is: Unknown, should be: ${expected_value_desc})"
         _retval=2
 
     fi
 
-    #CHECK
     if [[ ${_retval} -eq 99 ]]; then
+
+        logCheckWarning 'Legacy check: Power Savings Mode value derived from lparcfg file (power_mode_data)'
 
         # The power mode result is defined as
         # XXXX XXXX XXXX XXXX
@@ -37,11 +66,9 @@ function check_1310_cpu_powersavings_ibmpower {
         #e.g. 0002000000020002
         local pwr_system_mode
         pwr_system_mode="${LIB_PLATF_POWER_POWERMODE:0:4}"
-        local pwr_partition_mode
-        pwr_partition_mode="${LIB_PLATF_POWER_POWERMODE: -4}"
 
-        # P9,P10,P11
-        # 0x0001: "Maximum Performance"
+        # P9
+        # 0x0001: "Maximum Performance" or "Dynamic, Favor Performance" (ambiguous)
 
         local pwr_system_txt
         LIB_FUNC_TRANSFORM_POWER_POWERMODE "${pwr_system_mode}"
@@ -49,21 +76,12 @@ function check_1310_cpu_powersavings_ibmpower {
 
         logDebug "<${BASH_SOURCE[0]}:${FUNCNAME[0]}> # PowerSystemMode : ${pwr_system_mode:-}; PowerSystemText : ${pwr_system_txt:-}; PowerPartMode : ${pwr_partition_mode:-}}"
 
-
-        if [[ "${pwr_system_mode}" != "${pwr_partition_mode}" ]]; then
-
-            local pwr_partition_txt
-            LIB_FUNC_TRANSFORM_POWER_POWERMODE "${pwr_partition_mode}"
-            pwr_partition_txt="${RETURN_POWER_POWERMODE}"
-
-            logCheckInfo "Power Savings Mode different for System and Partition. (System: ${pwr_system_txt:-}, Partition: ${pwr_partition_txt:-})"
-
-        fi
-
         if [[ "${pwr_system_mode}" == '0001' ]];then
 
-            logCheckOk "Power Savings Mode set as recommended (SAP Note ${sapnote:-}) (is: ${pwr_system_txt})"
-            _retval=0
+            logCheckWarning 'Power Savings Mode value 0001 is ambiguous and can map to "Maximum Performance" or "Dynamic, Favor Performance".'
+            logCheckWarning 'Verify the exact mode manually - either ppc64_cpu or CPU frequency specs can be used to determine the actual mode.'
+            logCheckWarning "Power Savings Mode value requires manual verification (SAP Note ${sapnote:-}) (is: ${pwr_system_txt})"
+            _retval=1
 
         else
 

--- a/scripts/tests/check/1310_cpu_powersavings_ibmpower.bashunit.sh
+++ b/scripts/tests/check/1310_cpu_powersavings_ibmpower.bashunit.sh
@@ -17,8 +17,21 @@ LIB_PLATF_POWER_PLATFORM_BASE=''
 RETURN_POWER_POWERMODE=''
 _is_ibmpower=0
 
+# Override path used by check to a non-existing file by default so the
+# fallback (lparcfg-derived LIB_PLATF_POWER_POWERMODE) logic is exercised.
+path_to_value_desc='/nonexistent/saphana-check/value_desc'
+
 # Mock functions
 LIB_FUNC_IS_IBMPOWER() { return "${_is_ibmpower}" ; }
+
+# Trim helper used by the check (mock to avoid sourcing helper-funcs)
+LIB_FUNC_TRIM() {
+    local s="$1"
+    # strip leading and trailing whitespace
+    s="${s#"${s%%[![:space:]]*}"}"
+    s="${s%"${s##*[![:space:]]}"}"
+    printf '%s' "${s}"
+}
 
 # Mock the transform function
 LIB_FUNC_TRANSFORM_POWER_POWERMODE() {
@@ -91,8 +104,8 @@ function test_power11_maximum_performance_ok() {
     check_1310_cpu_powersavings_ibmpower
 
     #assert
-    if [[ $? -ne 0 ]]; then
-        bashunit::fail "Expected RC=0 (ok) for POWER11 maximum performance"
+    if [[ $? -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for POWER11 ambiguous mode 0001"
     fi
     assert_true true
 }
@@ -107,8 +120,8 @@ function test_power11_maximum_performance_system_diff_partition_ok() {
     check_1310_cpu_powersavings_ibmpower
 
     #assert
-    if [[ $? -ne 0 ]]; then
-        bashunit::fail "Expected RC=0 (ok) for POWER11 system diff partition"
+    if [[ $? -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for POWER11 ambiguous system mode 0001 with different partition mode"
     fi
     assert_true true
 }
@@ -191,8 +204,8 @@ function test_power10_maximum_performance_ok() {
     check_1310_cpu_powersavings_ibmpower
 
     #assert
-    if [[ $? -ne 0 ]]; then
-        bashunit::fail "Expected RC=0 (ok) for POWER10 maximum performance"
+    if [[ $? -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for POWER10 ambiguous mode 0001"
     fi
     assert_true true
 }
@@ -271,8 +284,8 @@ function test_power10_system_partition_mode_diff_ok() {
     check_1310_cpu_powersavings_ibmpower
 
     #assert
-    if [[ $? -ne 0 ]]; then
-        bashunit::fail "Expected RC=0 (ok) for POWER10 system/partition diff"
+    if [[ $? -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for POWER10 ambiguous system mode 0001 with different partition mode"
     fi
     assert_true true
 }
@@ -291,8 +304,8 @@ function test_power9_maximum_performance_ok() {
     check_1310_cpu_powersavings_ibmpower
 
     #assert
-    if [[ $? -ne 0 ]]; then
-        bashunit::fail "Expected RC=0 (ok) for POWER9 maximum performance"
+    if [[ $? -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for POWER9 ambiguous mode 0001"
     fi
     assert_true true
 }
@@ -371,8 +384,8 @@ function test_power9_system_partition_mode_diff_ok() {
     check_1310_cpu_powersavings_ibmpower
 
     #assert
-    if [[ $? -ne 0 ]]; then
-        bashunit::fail "Expected RC=0 (ok) for POWER9 system/partition diff"
+    if [[ $? -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for POWER9 ambiguous system mode 0001 with different partition mode"
     fi
     assert_true true
 }
@@ -439,8 +452,147 @@ function test_system_mode_valid_partition_invalid_power11() {
     check_1310_cpu_powersavings_ibmpower
 
     #assert
-    if [[ $? -ne 0 ]]; then
-        bashunit::fail "Expected RC=0 (ok) for POWER11 valid system mode"
+    if [[ $? -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for POWER11 ambiguous system mode 0001"
+    fi
+    assert_true true
+}
+
+
+# ========================================
+# value_desc INTERFACE TESTS (preferred)
+# /sys/firmware/papr/energy_scale_info/1/value_desc
+# ========================================
+
+function test_value_desc_maximum_performance_ok() {
+
+    #arrange
+    local tmpfile
+    tmpfile="$(mktemp)"
+    printf 'Maximum Performance' > "${tmpfile}"
+    path_to_value_desc="${tmpfile}"
+    # No POWERMODE / PLATFORM_BASE needed - preferred interface wins
+    LIB_PLATF_POWER_POWERMODE=
+    LIB_PLATF_POWER_PLATFORM_BASE=
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+    local rc=$?
+
+    #cleanup
+    rm -f "${tmpfile}"
+
+    #assert
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for value_desc='Maximum Performance' (got RC=${rc})"
+    fi
+    assert_true true
+}
+
+function test_value_desc_maximum_performance_with_whitespace_ok() {
+
+    #arrange
+    local tmpfile
+    tmpfile="$(mktemp)"
+    # value_desc files typically have a trailing newline; also test surrounding whitespace
+    printf '  Maximum Performance  \n' > "${tmpfile}"
+    path_to_value_desc="${tmpfile}"
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+    local rc=$?
+
+    #cleanup
+    rm -f "${tmpfile}"
+
+    #assert
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for value_desc with trailing newline/whitespace (got RC=${rc})"
+    fi
+    assert_true true
+}
+
+function test_value_desc_dynamic_performance_error() {
+
+    #arrange
+    local tmpfile
+    tmpfile="$(mktemp)"
+    printf 'Dynamic Performance\n' > "${tmpfile}"
+    path_to_value_desc="${tmpfile}"
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+    local rc=$?
+
+    #cleanup
+    rm -f "${tmpfile}"
+
+    #assert
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) for value_desc='Dynamic Performance' (got RC=${rc})"
+    fi
+    assert_true true
+}
+
+function test_value_desc_empty_error() {
+
+    #arrange
+    local tmpfile
+    tmpfile="$(mktemp)"
+    : > "${tmpfile}"
+    path_to_value_desc="${tmpfile}"
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+    local rc=$?
+
+    #cleanup
+    rm -f "${tmpfile}"
+
+    #assert
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) for empty value_desc file (got RC=${rc})"
+    fi
+    assert_true true
+}
+
+function test_value_desc_takes_precedence_over_lparcfg() {
+
+    #arrange - lparcfg says Maximum Performance, but value_desc says otherwise
+    local tmpfile
+    tmpfile="$(mktemp)"
+    printf 'Static\n' > "${tmpfile}"
+    path_to_value_desc="${tmpfile}"
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER11'
+    LIB_PLATF_POWER_POWERMODE='0001000100010001'   # would be OK via fallback
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+    local rc=$?
+
+    #cleanup
+    rm -f "${tmpfile}"
+
+    #assert - value_desc must win, so RC=2
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 - value_desc must take precedence over lparcfg fallback (got RC=${rc})"
+    fi
+    assert_true true
+}
+
+function test_value_desc_missing_uses_lparcfg_fallback_ok() {
+
+    #arrange - non-existing value_desc path; lparcfg says Maximum Performance
+    path_to_value_desc='/nonexistent/saphana-check/value_desc'
+    LIB_PLATF_POWER_PLATFORM_BASE='POWER10'
+    LIB_PLATF_POWER_POWERMODE='0001000100010001'
+
+    #act
+    check_1310_cpu_powersavings_ibmpower
+
+    #assert
+    if [[ $? -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) - fallback 0001 is ambiguous when value_desc file is missing"
     fi
     assert_true true
 }
@@ -470,5 +622,7 @@ function set_up() {
     LIB_PLATF_POWER_PLATFORM_BASE=
     RETURN_POWER_POWERMODE=
     _is_ibmpower=0
+    # Default to a non-existing path so fallback logic is exercised
+    path_to_value_desc='/nonexistent/saphana-check/value_desc'
 
 }


### PR DESCRIPTION
Use the preferred value_desc interface for check 1310 and trim whitespace before comparison. Treat fallback mode 0001 from lparcfg as ambiguous and return warning with manual verification guidance instead of OK. Update power mode mapping logic for POWER9 vs POWER10/11 in lib_platf_power to reflect the ambiguity. Extend and align 1310 bashunit tests, including value_desc precedence and fallback behavior, with the new warning semantics.