### PR TITLE
refactor(check/0500_selinux_rhel): Simplify logic and add SLES 16 sup…

### DIFF
--- a/scripts/lib/check/0500_selinux.check
+++ b/scripts/lib/check/0500_selinux.check
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-function check_0500_selinux_rhel {
+function check_0500_selinux {
 
     logTrace "<${BASH_SOURCE[0]}:${FUNCNAME[*]}>"
 

--- a/scripts/lib/check/0500_selinux_rhel.check
+++ b/scripts/lib/check/0500_selinux_rhel.check
@@ -11,41 +11,76 @@ function check_0500_selinux_rhel {
     local -r sapnote_rhel8='#2777782'   # 2777782 - SAP HANA DB: Recommended OS Settings for RHEL 8
     local -r sapnote_rhel9='#3108302'   # 3108302 - SAP HANA DB: Recommended OS Settings for RHEL 9
     local -r sapnote_rhel10='#3562919'  # 3562919 - SAP HANA DB: Recommended OS Settings for RHEL 10
+    local -r sapnote_sles16='#3577842'  # 3577842 - SAP HANA DB: Recommended OS settings for SLES 16
+
+    local allowed_modes='Disabled'
+    local allowed_modes_kernel612='Disabled or Permissive'
     # MODIFICATION SECTION<<
 
     # PRECONDITIONS
-    if ! LIB_FUNC_IS_RHEL ; then
+    if ! LIB_FUNC_IS_RHEL && ! LIB_FUNC_IS_SLES ; then
 
-        logCheckSkipped 'Linux distribution is not RHEL. Skipping' "<${FUNCNAME[0]}>"
+        logCheckSkipped 'Linux distribution is not RHEL or SLES. Skipping' "<${FUNCNAME[0]}>"
         _retval=3
 
     else
         local sapnote
 
-        case "${OS_VERSION}" in
+        if LIB_FUNC_IS_RHEL; then
 
-            7.*)    sapnote="${sapnote_rhel7}" ;;
-            8.*)    sapnote="${sapnote_rhel8}" ;;
-            9.*)    sapnote="${sapnote_rhel9}" ;;
-            10.*)   sapnote="${sapnote_rhel10}" ;;
+            case "${OS_VERSION}" in
 
-            *)
-                    logCheckWarning 'CHECK does not support RHEL release.' "(is: ${OS_VERSION}) - <${FUNCNAME[0]}>"
-                    _retval=1 ;;
+                7.*)    sapnote="${sapnote_rhel7}" ;;
+                8.*)    sapnote="${sapnote_rhel8}" ;;
+                9.*)    sapnote="${sapnote_rhel9}" ;;
+                10.*)   sapnote="${sapnote_rhel10}" ; allowed_modes="${allowed_modes_kernel612}" ;;
 
-        esac
+                *)
+                        logCheckWarning 'CHECK does not support RHEL release.' "(is: ${OS_VERSION}) - <${FUNCNAME[0]}>"
+                        _retval=1 ;;
+
+            esac
+
+        elif LIB_FUNC_IS_SLES; then
+
+            case "${OS_VERSION}" in
+
+                12.*)   allowed_modes='Skip' ;;
+                15.*)   allowed_modes='Skip' ;;
+                16.*)   sapnote="${sapnote_sles16}" ; allowed_modes="${allowed_modes_kernel612}" ;;
+
+                *)
+                        logCheckWarning 'CHECK does not support SLES release.' "(is: ${OS_VERSION}) - <${FUNCNAME[0]}>"
+                        _retval=1 ;;
+
+            esac
+
+        fi
+
+        if [[ "${allowed_modes}" == 'Skip' ]]; then
+
+            logCheckSkipped 'Not running on SELinux technology aware system. Skipping' "<${FUNCNAME[0]}>"
+            _retval=3
+
+        fi
 
     fi
 
     # CHECK
     if [[ ${_retval} -eq 99 ]]; then
 
-        if ! /usr/sbin/getenforce | grep -q 'Disabled' ; then
-            logCheckError "SELinux is not disabled (SAP Note ${sapnote:-})"
-            _retval=2
-        else
-            logCheckOk "SELinux is disabled (SAP Note ${sapnote:-})"
+        local selinux_mode="${TEST_SELINUX_MODE:-$(/usr/sbin/getenforce)}"
+
+        if LIB_FUNC_STRINGCONTAIN "${allowed_modes}" "${selinux_mode}"; then
+
+            logCheckOk "SELinux mode is ${selinux_mode}. Allowed: ${allowed_modes} (SAP Note ${sapnote:-})"
             _retval=0
+
+        else
+
+            logCheckError "SELinux mode is ${selinux_mode}. Allowed: ${allowed_modes} (SAP Note ${sapnote:-})"
+            _retval=2
+
         fi
 
     fi

--- a/scripts/lib/checkset/RHELonPoweronly.checkset
+++ b/scripts/lib/checkset/RHELonPoweronly.checkset
@@ -13,7 +13,7 @@
 0350_timesync
 0410_glibc_ibmpower
 0450_tunedprofiles-saphana_rhel
-0500_selinux_rhel
+0500_selinux
 0600_systemd_version
 0700_sysstat
 0800_sap_host_agent

--- a/scripts/lib/checkset/RHELonX64only.checkset
+++ b/scripts/lib/checkset/RHELonX64only.checkset
@@ -15,7 +15,7 @@
 0350_timesync
 0400_glibc_x64
 0450_tunedprofiles-saphana_rhel
-0500_selinux_rhel
+0500_selinux
 0600_systemd_version
 0700_sysstat
 0800_sap_host_agent

--- a/scripts/lib/checkset/SLESonPoweronly.checkset
+++ b/scripts/lib/checkset/SLESonPoweronly.checkset
@@ -15,6 +15,7 @@
 0410_glibc_ibmpower
 0440_sapconf_sles
 0441_saptune_sles
+0500_selinux
 0600_systemd_version
 0620_systemd_pam_config_sles
 0700_sysstat

--- a/scripts/lib/checkset/SLESonX64only.checkset
+++ b/scripts/lib/checkset/SLESonX64only.checkset
@@ -18,6 +18,7 @@
 0400_glibc_x64
 0440_sapconf_sles
 0441_saptune_sles
+0500_selinux
 0600_systemd_version
 0620_systemd_pam_config_sles
 0700_sysstat

--- a/scripts/tests/check/0500_selinux.bashunit.sh
+++ b/scripts/tests/check/0500_selinux.bashunit.sh
@@ -39,7 +39,7 @@ function test_non_rhel_non_sles_skipped() {
     LIB_FUNC_IS_SLES() { return 1 ; }
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -58,7 +58,7 @@ function test_rhel9_requires_disabled() {
     TEST_SELINUX_MODE='Disabled'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -78,7 +78,7 @@ function test_rhel7_requires_disabled() {
     TEST_SELINUX_MODE='Disabled'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -98,7 +98,7 @@ function test_rhel8_requires_disabled() {
     TEST_SELINUX_MODE='Disabled'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -118,7 +118,7 @@ function test_rhel9_permissive_is_error() {
     TEST_SELINUX_MODE='Permissive'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -138,7 +138,7 @@ function test_rhel10_permissive_is_ok() {
     TEST_SELINUX_MODE='Permissive'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -158,7 +158,7 @@ function test_rhel10_disabled_is_ok() {
     TEST_SELINUX_MODE='Disabled'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -178,7 +178,7 @@ function test_rhel10_enforcing_is_error() {
     TEST_SELINUX_MODE='Enforcing'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -198,7 +198,7 @@ function test_rhel9_enforcing_is_error() {
     TEST_SELINUX_MODE='Enforcing'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -218,7 +218,7 @@ function test_sles12_skipped() {
     TEST_SELINUX_MODE='Disabled'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -237,7 +237,7 @@ function test_sles15_skipped() {
     TEST_SELINUX_MODE='Permissive'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -256,7 +256,7 @@ function test_sles16_permissive_is_ok() {
     TEST_SELINUX_MODE='Permissive'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -276,7 +276,7 @@ function test_sles16_disabled_is_ok() {
     TEST_SELINUX_MODE='Disabled'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -296,7 +296,7 @@ function test_sles16_enforcing_is_error() {
     TEST_SELINUX_MODE='Enforcing'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -316,7 +316,7 @@ function test_unsupported_sles_release_warns() {
     TEST_SELINUX_MODE='Disabled'
 
     #act
-    check_0500_selinux_rhel
+    check_0500_selinux
     local rc=$?
 
     #assert
@@ -338,8 +338,8 @@ function set_up_before_script() {
     #shellcheck source=../saphana-logger-stubs
     source "${PROGRAM_DIR}/../saphana-logger-stubs"
 
-    #shellcheck source=../../lib/check/0500_selinux_rhel.check
-    source "${PROGRAM_DIR}/../../lib/check/0500_selinux_rhel.check"
+    #shellcheck source=../../lib/check/0500_selinux.check
+    source "${PROGRAM_DIR}/../../lib/check/0500_selinux.check"
 
 }
 

--- a/scripts/tests/check/0500_selinux_rhel.bashunit.sh
+++ b/scripts/tests/check/0500_selinux_rhel.bashunit.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+#------------------------------------------------------------------
+# bashunit migration notes:
+# 1. PROGRAM_DIR not readonly - bashunit runs all tests in same session
+# 2. Guard check skips if already loaded to avoid readonly variable conflicts
+#------------------------------------------------------------------
+set -u  # treat unset variables as an error
+
+if [[ -z "${PROGRAM_DIR:-}" ]]; then
+    PROGRAM_DIR="${BASH_SOURCE[0]%/*}"
+    [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
+fi
+
+# Mock variables
+OS_VERSION='9.4'
+TEST_SELINUX_MODE='Disabled'
+
+# Mock functions
+LIB_FUNC_IS_RHEL() { return 0 ; }
+LIB_FUNC_IS_SLES() { return 1 ; }
+
+# Mock LIB_FUNC_STRINGCONTAIN - checks if first arg contains second arg
+LIB_FUNC_STRINGCONTAIN() {
+    [[ "$1" == *"$2"* ]]
+}
+
+assert_check_processed() {
+    local rc=$1
+    local context="${2:-}"
+    if [[ ${rc} -eq 99 ]]; then
+        bashunit::fail "RC=99 (unprocessed) - check logic did not reach a conclusion${context:+ in }${context}"
+    fi
+}
+
+function test_non_rhel_non_sles_skipped() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 1 ; }
+    LIB_FUNC_IS_SLES() { return 1 ; }
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 3 ]]; then
+        bashunit::fail "Expected RC=3 (skipped) for non-RHEL/non-SLES"
+    fi
+    assert_true true
+}
+
+function test_rhel9_requires_disabled() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 0 ; }
+    LIB_FUNC_IS_SLES() { return 1 ; }
+    OS_VERSION='9.4'
+    TEST_SELINUX_MODE='Disabled'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} 'RHEL9 disabled'
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for RHEL9 with SELinux Disabled"
+    fi
+    assert_true true
+}
+
+function test_rhel7_requires_disabled() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 0 ; }
+    LIB_FUNC_IS_SLES() { return 1 ; }
+    OS_VERSION='7.9'
+    TEST_SELINUX_MODE='Disabled'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} 'RHEL7 disabled'
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for RHEL7 with SELinux Disabled"
+    fi
+    assert_true true
+}
+
+function test_rhel8_requires_disabled() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 0 ; }
+    LIB_FUNC_IS_SLES() { return 1 ; }
+    OS_VERSION='8.8'
+    TEST_SELINUX_MODE='Disabled'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} 'RHEL8 disabled'
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for RHEL8 with SELinux Disabled"
+    fi
+    assert_true true
+}
+
+function test_rhel9_permissive_is_error() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 0 ; }
+    LIB_FUNC_IS_SLES() { return 1 ; }
+    OS_VERSION='9.4'
+    TEST_SELINUX_MODE='Permissive'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} 'RHEL9 permissive'
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) for RHEL9 with SELinux Permissive"
+    fi
+    assert_true true
+}
+
+function test_rhel10_permissive_is_ok() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 0 ; }
+    LIB_FUNC_IS_SLES() { return 1 ; }
+    OS_VERSION='10.0'
+    TEST_SELINUX_MODE='Permissive'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} 'RHEL10 permissive'
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for RHEL10 with SELinux Permissive"
+    fi
+    assert_true true
+}
+
+function test_rhel10_disabled_is_ok() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 0 ; }
+    LIB_FUNC_IS_SLES() { return 1 ; }
+    OS_VERSION='10.0'
+    TEST_SELINUX_MODE='Disabled'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} 'RHEL10 disabled'
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for RHEL10 with SELinux Disabled"
+    fi
+    assert_true true
+}
+
+function test_rhel10_enforcing_is_error() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 0 ; }
+    LIB_FUNC_IS_SLES() { return 1 ; }
+    OS_VERSION='10.0'
+    TEST_SELINUX_MODE='Enforcing'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} 'RHEL10 enforcing'
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) for RHEL10 with SELinux Enforcing"
+    fi
+    assert_true true
+}
+
+function test_rhel9_enforcing_is_error() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 0 ; }
+    LIB_FUNC_IS_SLES() { return 1 ; }
+    OS_VERSION='9.4'
+    TEST_SELINUX_MODE='Enforcing'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} 'RHEL9 enforcing'
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) for RHEL9 with SELinux Enforcing"
+    fi
+    assert_true true
+}
+
+function test_sles12_skipped() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 1 ; }
+    LIB_FUNC_IS_SLES() { return 0 ; }
+    OS_VERSION='12.5'
+    TEST_SELINUX_MODE='Disabled'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 3 ]]; then
+        bashunit::fail "Expected RC=3 (skipped) for SLES12"
+    fi
+    assert_true true
+}
+
+function test_sles15_skipped() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 1 ; }
+    LIB_FUNC_IS_SLES() { return 0 ; }
+    OS_VERSION='15.6'
+    TEST_SELINUX_MODE='Permissive'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 3 ]]; then
+        bashunit::fail "Expected RC=3 (skipped) for SLES15"
+    fi
+    assert_true true
+}
+
+function test_sles16_permissive_is_ok() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 1 ; }
+    LIB_FUNC_IS_SLES() { return 0 ; }
+    OS_VERSION='16.0'
+    TEST_SELINUX_MODE='Permissive'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} 'SLES16 permissive'
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for SLES16 with SELinux Permissive"
+    fi
+    assert_true true
+}
+
+function test_sles16_disabled_is_ok() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 1 ; }
+    LIB_FUNC_IS_SLES() { return 0 ; }
+    OS_VERSION='16.0'
+    TEST_SELINUX_MODE='Disabled'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} 'SLES16 disabled'
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for SLES16 with SELinux Disabled"
+    fi
+    assert_true true
+}
+
+function test_sles16_enforcing_is_error() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 1 ; }
+    LIB_FUNC_IS_SLES() { return 0 ; }
+    OS_VERSION='16.0'
+    TEST_SELINUX_MODE='Enforcing'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} 'SLES16 enforcing'
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) for SLES16 with SELinux Enforcing"
+    fi
+    assert_true true
+}
+
+function test_unsupported_sles_release_warns() {
+
+    #arrange
+    LIB_FUNC_IS_RHEL() { return 1 ; }
+    LIB_FUNC_IS_SLES() { return 0 ; }
+    OS_VERSION='11.4'
+    TEST_SELINUX_MODE='Disabled'
+
+    #act
+    check_0500_selinux_rhel
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for unsupported SLES release"
+    fi
+    assert_true true
+}
+
+function set_up_before_script() {
+
+    # Disable errexit - bashunit enables it but sourced files may return non-zero
+    set +eE
+
+    # Skip if already loaded (bashunit runs all tests in same session)
+    [[ -n "${_0500_test_loaded:-}" ]] && return 0
+    _0500_test_loaded=true
+
+    #shellcheck source=../saphana-logger-stubs
+    source "${PROGRAM_DIR}/../saphana-logger-stubs"
+
+    #shellcheck source=../../lib/check/0500_selinux_rhel.check
+    source "${PROGRAM_DIR}/../../lib/check/0500_selinux_rhel.check"
+
+}
+
+function set_up() {
+
+    # Reset mock variables
+    OS_VERSION='9.4'
+    TEST_SELINUX_MODE='Disabled'
+
+    # Reset mock functions to default (RHEL)
+    LIB_FUNC_IS_RHEL() { return 0 ; }
+    LIB_FUNC_IS_SLES() { return 1 ; }
+
+}


### PR DESCRIPTION
…port

- Refactor variable initialization to use parameter expansion with command substitution: `${TEST_SELINUX_MODE:-$(/usr/sbin/getenforce)} `This replaces the 5-line if/else block with a single, cleaner line.

- Simplify SELinux mode validation by using LIB_FUNC_STRINGCONTAIN instead of multiple if/elif/else conditions. The allowed_modes variable now supports substring matching for flexibility (e.g., "Disabled or Permissive" contains both valid modes).

- Add support for SLES 16 with SELinux validation:
  - SLES 16 follows the same pattern as RHEL 10 with kernel 6.12+
  - Allows both Disabled and Permissive SELinux modes
  - Skips SLES 12 and 15 as SELinux is not applicable on these versions

- Add comprehensive unit test coverage:
  - RHEL 7, 8, 9: Require Disabled mode only
  - RHEL 10: Allow Disabled or Permissive (kernel 6.12+)
  - SLES 12, 15: Skipped (RC=3) - SELinux not applicable
  - SLES 16: New - Allows Disabled or Permissive modes
  - Test invalid modes (Enforcing) for strict version requirements
  - Add mock for LIB_FUNC_STRINGCONTAIN in test suite

- Tests: 15 passed (all scenarios including new SLES 16 support)