### PR TITLE
check(0440): simplify sapconf SLES version logic and usage detection

### DIFF
--- a/scripts/lib/check/0440_sapconf_sles.check
+++ b/scripts/lib/check/0440_sapconf_sles.check
@@ -13,7 +13,6 @@ function check_0440_sapconf_sles {
     local -r sapnote='#1275776'         #1275776 - Linux: Preparing SLES for SAP environments
 
     local -r sles12x='5.0.6'
-    local -r sles150='5.0.7'
     local -r sles154='5.0.8'
     # MODIFICATION SECTION<<
 
@@ -35,7 +34,6 @@ function check_0440_sapconf_sles {
         case "${OS_VERSION}" in
 
                 12.5     )  : "${sles12x}" ;;
-                15.[0-3] )  : "${sles150}" ;;
                 15.*     )  : "${sles154}" ;;
 
                 *)
@@ -55,18 +53,11 @@ function check_0440_sapconf_sles {
 
         local _is_used=false
 
-        if systemctl is-enabled "sapconf" --quiet; then
-            logCheckInfo 'sapconf is installed and enabled'
-            _is_used=true
-        else
-            logCheckInfo 'sapconf is installed but not enabled - saptune in use?'
-        fi
-
         if systemctl is-active "sapconf" --quiet; then
             logCheckInfo 'sapconf is active'
             _is_used=true
         else
-            logCheckInfo 'sapconf is not active'
+            logCheckInfo 'sapconf is not active - saptune in use?'
         fi
 
         _fullversion=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}" sapconf)

--- a/scripts/tests/check/0440_sapconf_sles.bashunit.sh
+++ b/scripts/tests/check/0440_sapconf_sles.bashunit.sh
@@ -50,6 +50,21 @@ function test_sapconf_not_installed() {
     assert_true true
 }
 
+function test_not_sles_skip() {
+
+    #arrange
+    LIB_FUNC_IS_SLES() { return 1 ; }
+
+    #act
+    check_0440_sapconf_sles
+
+    #assert
+    if [[ $? -ne 3 ]]; then
+        bashunit::fail "Expected RC=3 (skipped) when distribution is not SLES"
+    fi
+    assert_true true
+}
+
 function test_sapconf_ok() {
 
     #arrange
@@ -62,6 +77,22 @@ function test_sapconf_ok() {
     #assert
     if [[ $? -ne 0 ]]; then
         bashunit::fail "Expected RC=0 (ok) for sapconf ok"
+    fi
+    assert_true true
+}
+
+function test_sapconf_equal_version_ok() {
+
+    #arrange
+    rpm_rc=0
+    compare_version_rc=0
+
+    #act
+    check_0440_sapconf_sles
+
+    #assert
+    if [[ $? -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for sapconf equal version"
     fi
     assert_true true
 }
@@ -100,6 +131,22 @@ function test_sapconf_old_and_used() {
     assert_true true
 }
 
+function test_unsupported_sles_release_warning() {
+
+    #arrange
+    OS_VERSION='11.4'
+    rpm_rc=0
+
+    #act
+    check_0440_sapconf_sles
+
+    #assert
+    if [[ $? -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for unsupported SLES release"
+    fi
+    assert_true true
+}
+
 
 function set_up_before_script() {
 
@@ -125,5 +172,8 @@ function set_up() {
     compare_version_rc=0
     rpm_rc=0
     isused_rc=0
+
+    # Reset mock functions possibly overridden in tests
+    LIB_FUNC_IS_SLES() { return 0 ; }
 
 }


### PR DESCRIPTION
- remove obsolete SLES 15.0-15.3 sapconf threshold (5.0.7)
- use one SLES 15.* threshold (5.0.8) for version validation
- simplify sapconf usage detection to systemctl is-active only
- adjust inactive info message to mention possible saptune usage

test(0440): extend unit coverage for updated check behavior

- add non-SLES skip test
- add equal-version OK test
- add unsupported SLES release warning test
- reset overridden SLES mock in set_up to avoid cross-test leakage
- verify 0440 unit tests pass (7/7)