### PR TITLE
Simplify 1400/1410 CPU idle checks and add unit coverage

### DIFF
--- a/scripts/lib/check/1400_cpu_idle_driver_intel.check
+++ b/scripts/lib/check/1400_cpu_idle_driver_intel.check
@@ -7,20 +7,15 @@ function check_1400_cpu_idle_driver_intel {
     local -i _retval=99
 
     # MODIFICATION SECTION>>
-    local -r sapnote_sles12='#2205917'  # SAP HANA DB: Recommended OS settings for SLES 12
-    local -r sapnote_sles15='#2684254'  # SAP HANA DB: Recommended OS settings for SLES 15
-    local -r sapnote_sles16='#3577842'  # SAP HANA DB: Recommended OS settings for SLES 16
-    local -r sapnote_rhel7='#2292690'   # SAP HANA DB: Recommended OS settings for RHEL 7
-    local -r sapnote_rhel8='#2777782'   # SAP HANA DB: Recommended OS Settings for RHEL 8
-    local -r sapnote_rhel9='#3108302'   # SAP HANA DB: Recommended OS Settings for RHEL 9
-    local -r sapnote_rhel10='#3562919'  # SAP HANA DB: Recommended OS Settings for RHEL 10
+
+    local sapnote='#3710700'             # Requirements on Intel CPU-idle time management for SAP HANA
+    local expected_driver='intel_idle'
+
     local -r sapnote_kvm_sles='#3430656' # SAP HANA on SUSE KVM Virtualization
     local -r sapnote_kvm_rhel='#2599726' # SAP HANA on Red Hat Virtualization
     local -r sapnote_vmware='#2161991'   # VMware vSphere configuration guidelines
     # MODIFICATION SECTION<<
 
-    local sapnote
-    local expected_driver='intel_idle'
 
     # PRECONDITIONS
     if ! LIB_FUNC_IS_INTEL; then
@@ -28,34 +23,8 @@ function check_1400_cpu_idle_driver_intel {
         logCheckSkipped 'Not running on Intel CPU. Skipping' "<${FUNCNAME[0]}>"
         _retval=3
 
-    elif LIB_FUNC_IS_SLES; then
-        case "${OS_VERSION}" in
+    else
 
-            12.*) : "${sapnote_sles12}" ;;
-            15.*) : "${sapnote_sles15}" ;;
-            16.*) : "${sapnote_sles16}" ;;
-
-            *)  logCheckWarning 'CHECK does NOT support SLES release' "(is: ${OS_VERSION}) - <${FUNCNAME[0]}>"
-                _retval=1 ;;
-        esac
-        sapnote="$_"
-
-    elif LIB_FUNC_IS_RHEL; then
-        case "${OS_VERSION}" in
-
-            7.*) : "${sapnote_rhel7}" ;;
-            8.*) : "${sapnote_rhel8}" ;;
-            9.*) : "${sapnote_rhel9}" ;;
-            10.*) : "${sapnote_rhel10}" ;;
-
-            *)  logCheckWarning 'CHECK does NOT support RHEL release' "(is: ${OS_VERSION}) - <${FUNCNAME[0]}>"
-                _retval=1 ;;
-        esac
-        sapnote="$_"
-
-    fi
-
-    if [[ ${_retval} -eq 99 ]]; then
         #KVM - but not Hyperscaler
         if LIB_FUNC_IS_VIRT_KVM; then
 
@@ -78,8 +47,7 @@ function check_1400_cpu_idle_driver_intel {
     #CHECK
     if [[ ${_retval} -eq 99 ]]; then
 
-        local _current_driver
-        _current_driver="$(</sys/devices/system/cpu/cpuidle/current_driver)"
+        local _current_driver="${TEST_current_driver:-$(</sys/devices/system/cpu/cpuidle/current_driver)}"
 
         case ${_current_driver} in
 
@@ -125,7 +93,11 @@ function check_1400_cpu_idle_driver_intel {
         'none')
 
             local _mwait_exposed=false
-            grep -e '^flags' -m1 /proc/cpuinfo | grep -qs -e 'monitor' && _mwait_exposed=true
+            if [[ -z ${TEST_mwait_exposed:-} ]]; then
+                grep -e '^flags' -m1 /proc/cpuinfo | grep -qs -e 'monitor' && _mwait_exposed=true
+            elif [[ ${TEST_mwait_exposed} == true ]]; then
+                _mwait_exposed=true
+            fi
 
             if LIB_FUNC_IS_BARE_METAL; then
 

--- a/scripts/lib/check/1410_cpu_idle_intel_cstates_intel.check
+++ b/scripts/lib/check/1410_cpu_idle_intel_cstates_intel.check
@@ -15,13 +15,7 @@ function check_1410_cpu_idle_intel_cstates_intel {
     #tuned profile parameter force_latency finally sets /dev/cpu_dma_latency (root required)
 
     # MODIFICATION SECTION>>
-    local -r sapnote_sles12='#2205917' # SAP HANA DB: Recommended OS settings for SLES 12
-    local -r sapnote_sles15='#2684254' # SAP HANA DB: Recommended OS settings for SLES 15
-    local -r sapnote_sles16='#3577842' # SAP HANA DB: Recommended OS settings for SLES 16
-    local -r sapnote_rhel7='#2292690'  # SAP HANA DB: Recommended OS settings for RHEL 7
-    local -r sapnote_rhel8='#2777782'  # SAP HANA DB: Recommended OS Settings for RHEL 8
-    local -r sapnote_rhel9='#3108302'  # SAP HANA DB: Recommended OS Settings for RHEL 9
-    local -r sapnote_rhel10='#3562919' # SAP HANA DB: Recommended OS Settings for RHEL 10
+    local -r sapnote='3710700'  # Requirements on Intel CPU-idle time management for SAP HANA
 
     # there is no C3 since years - recommend latency <=(C1E)
     local -ir _reco_latency=10
@@ -64,39 +58,6 @@ function check_1410_cpu_idle_intel_cstates_intel {
 
     fi
 
-    if [[ ${_retval} -ne 99 ]]; then
-        : #due to UNIT TESTING
-
-    elif LIB_FUNC_IS_SLES; then
-        case "${OS_VERSION}" in
-
-            12.*) : "${sapnote_sles12}" ;;
-            15.*) : "${sapnote_sles15}" ;;
-            16.*) : "${sapnote_sles16}" ;;
-
-            *)  logCheckWarning 'CHECK does NOT support SLES release' "(is: ${OS_VERSION}) - <${FUNCNAME[0]}>"
-                _retval=1 ;;
-        esac
-        sapnote="$_"
-
-    elif LIB_FUNC_IS_RHEL; then
-        case "${OS_VERSION}" in
-
-            7.*) : "${sapnote_rhel7}" ;;
-            8.*) : "${sapnote_rhel8}" ;;
-            9.*) : "${sapnote_rhel9}" ;;
-            10.*) : "${sapnote_rhel10}" ;;
-
-            *)  logCheckWarning 'CHECK does NOT support RHEL release' "(is: ${OS_VERSION}) - <${FUNCNAME[0]}>"
-                _retval=1 ;;
-        esac
-        sapnote="$_"
-
-    else
-        logCheckError 'Linux distribution NOT supported (SAP Note #2235581)' "(is: ${OS_NAME} ${OS_VERSION}) - <${FUNCNAME[0]}>"
-        _retval=2
-    fi
-
     #CHECK
     if [[ ${_retval} -eq 99 ]]; then
 
@@ -106,13 +67,8 @@ function check_1410_cpu_idle_intel_cstates_intel {
         logCheckInfo ' c) PM QoS framework (cpu_dma_latency/tuned:force_latency)'
 
         # a) fixed driver max_cstate (not preferred)
-        local -i _driverMaxCstate
         #TEST_VARIABLES only required for UNIT TESTING
-        if [[ -z ${TEST_driverMaxCstate:-} ]]; then
-            _driverMaxCstate=$(</sys/module/intel_idle/parameters/max_cstate)
-        else
-            _driverMaxCstate="${TEST_driverMaxCstate:-}"
-        fi
+        local -i _driverMaxCstate="${TEST_driverMaxCstate:-$(</sys/module/intel_idle/parameters/max_cstate)}"
 
         # b) individual cstates for CPU0
         local _maxCstateName

--- a/scripts/tests/check/1400_cpu_idle_driver_intel.bashunit.sh
+++ b/scripts/tests/check/1400_cpu_idle_driver_intel.bashunit.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2329
+set -u
+
+if [[ -z "${PROGRAM_DIR:-}" ]]; then
+    PROGRAM_DIR="${BASH_SOURCE[0]%/*}"
+    [[ "$PROGRAM_DIR" == "${BASH_SOURCE[0]}" ]] && PROGRAM_DIR="."
+fi
+
+# Mock variables
+TEST_current_driver=''
+TEST_mwait_exposed=''
+
+# Mock functions
+LIB_FUNC_IS_INTEL() { return 0 ; }
+LIB_FUNC_IS_VIRT_KVM() { return 1 ; }
+LIB_FUNC_IS_VIRT_VMWARE() { return 1 ; }
+LIB_FUNC_IS_CLOUD_AMAZON() { return 1 ; }
+LIB_FUNC_IS_CLOUD_GOOGLE() { return 1 ; }
+LIB_FUNC_IS_SLES() { return 0 ; }
+LIB_FUNC_IS_RHEL() { return 1 ; }
+LIB_FUNC_IS_BARE_METAL() { return 0 ; }
+
+assert_check_processed() {
+    local rc=$1
+    local context="${2:-}"
+    if [[ ${rc} -eq 99 ]]; then
+        bashunit::fail "RC=99 (unprocessed) - check logic did not reach a conclusion${context:+ in }${context}"
+    fi
+}
+
+function test_non_intel_skipped() {
+
+    #arrange
+    LIB_FUNC_IS_INTEL() { return 1 ; }
+
+    #act
+    check_1400_cpu_idle_driver_intel
+    local rc=$?
+
+    #assert
+    if [[ ${rc} -ne 3 ]]; then
+        bashunit::fail "Expected RC=3 (skipped) on non-Intel systems"
+    fi
+    assert_true true
+}
+
+function test_intel_idle_default_ok() {
+
+    #arrange
+    TEST_current_driver='intel_idle'
+
+    #act
+    check_1400_cpu_idle_driver_intel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "default intel_idle"
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for intel_idle on default platforms"
+    fi
+    assert_true true
+}
+
+function test_acpi_idle_warning() {
+
+    #arrange
+    TEST_current_driver='acpi_idle'
+
+    #act
+    check_1400_cpu_idle_driver_intel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "acpi_idle"
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for acpi_idle"
+    fi
+    assert_true true
+}
+
+function test_kvm_non_cloud_haltpoll_expected_intel_idle_warns() {
+
+    #arrange
+    LIB_FUNC_IS_VIRT_KVM() { return 0 ; }
+    TEST_current_driver='intel_idle'
+
+    #act
+    check_1400_cpu_idle_driver_intel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "kvm non-cloud intel_idle"
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) when haltpoll is expected on KVM"
+    fi
+    assert_true true
+}
+
+function test_kvm_non_cloud_haltpoll_ok() {
+
+    #arrange
+    LIB_FUNC_IS_VIRT_KVM() { return 0 ; }
+    TEST_current_driver='haltpoll'
+
+    #act
+    check_1400_cpu_idle_driver_intel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "kvm non-cloud haltpoll"
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) when haltpoll is active on KVM"
+    fi
+    assert_true true
+}
+
+function test_kvm_amazon_keeps_intel_idle_ok() {
+
+    #arrange
+    LIB_FUNC_IS_VIRT_KVM() { return 0 ; }
+    LIB_FUNC_IS_CLOUD_AMAZON() { return 0 ; }
+    TEST_current_driver='intel_idle'
+
+    #act
+    check_1400_cpu_idle_driver_intel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "kvm amazon intel_idle"
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for amazon KVM with intel_idle"
+    fi
+    assert_true true
+}
+
+function test_vmware_none_with_mwait_hidden_ok() {
+
+    #arrange
+    LIB_FUNC_IS_VIRT_VMWARE() { return 0 ; }
+    LIB_FUNC_IS_BARE_METAL() { return 1 ; }
+    TEST_current_driver='none'
+    TEST_mwait_exposed='false'
+
+    #act
+    check_1400_cpu_idle_driver_intel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "vmware none mwait hidden"
+    if [[ ${rc} -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for VMware with none driver and hidden MWAIT"
+    fi
+    assert_true true
+}
+
+function test_vmware_none_with_mwait_exposed_warns() {
+
+    #arrange
+    LIB_FUNC_IS_VIRT_VMWARE() { return 0 ; }
+    LIB_FUNC_IS_BARE_METAL() { return 1 ; }
+    TEST_current_driver='none'
+    TEST_mwait_exposed='true'
+
+    #act
+    check_1400_cpu_idle_driver_intel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "vmware none mwait exposed"
+    if [[ ${rc} -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for VMware with none driver and exposed MWAIT"
+    fi
+    assert_true true
+}
+
+function test_unknown_driver_errors() {
+
+    #arrange
+    TEST_current_driver='mystery_idle'
+
+    #act
+    check_1400_cpu_idle_driver_intel
+    local rc=$?
+
+    #assert
+    assert_check_processed ${rc} "unknown driver"
+    if [[ ${rc} -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) for unknown CPUidle driver"
+    fi
+    assert_true true
+}
+
+function set_up_before_script() {
+
+    set +eE
+
+    [[ -n "${_1400_test_loaded:-}" ]] && return 0
+    _1400_test_loaded=true
+
+    #shellcheck source=../saphana-logger-stubs
+    source "${PROGRAM_DIR}/../saphana-logger-stubs"
+
+    #shellcheck source=../../lib/check/1400_cpu_idle_driver_intel.check
+    source "${PROGRAM_DIR}/../../lib/check/1400_cpu_idle_driver_intel.check"
+
+}
+
+function set_up() {
+
+    TEST_current_driver=''
+    TEST_mwait_exposed=''
+
+    LIB_FUNC_IS_INTEL() { return 0 ; }
+    LIB_FUNC_IS_VIRT_KVM() { return 1 ; }
+    LIB_FUNC_IS_VIRT_VMWARE() { return 1 ; }
+    LIB_FUNC_IS_CLOUD_AMAZON() { return 1 ; }
+    LIB_FUNC_IS_CLOUD_GOOGLE() { return 1 ; }
+    LIB_FUNC_IS_SLES() { return 0 ; }
+    LIB_FUNC_IS_RHEL() { return 1 ; }
+    LIB_FUNC_IS_BARE_METAL() { return 0 ; }
+
+}

--- a/scripts/tests/check/1410_cpu_idle_intel_cstates_intel.bashunit.sh
+++ b/scripts/tests/check/1410_cpu_idle_intel_cstates_intel.bashunit.sh
@@ -176,28 +176,12 @@ function test_sles15_supported() {
     assert_true true
 }
 
-function test_sles_unsupported_version() {
-
-    #arrange
-    OS_VERSION='11.4'  # Unsupported SLES version
-    TEST_driverMaxCstate=6
-    TEST_maxCstateLatency=5
-    TEST_maxForceLatency=2000000000
-
-    #act
-    check_1410_cpu_idle_intel_cstates_intel
-
-    #assert
-    if [[ $? -ne 1 ]]; then
-        bashunit::fail "Expected RC=1 (warning) for unsupported SLES version"
-    fi
-    assert_true true
-}
 
 # ROOT PERMISSION TESTS
 function test_non_root_warning() {
 
     #arrange
+    # shellcheck disable=SC2329
     LIB_FUNC_IS_ROOT() { return 1 ; }  # Mock non-root
     OS_VERSION='12.5'
     TEST_driverMaxCstate=6
@@ -209,6 +193,7 @@ function test_non_root_warning() {
     local rc=$?
 
     # Restore mock
+    # shellcheck disable=SC2329
     LIB_FUNC_IS_ROOT() { return 0 ; }
 
     #assert


### PR DESCRIPTION
Align checks 1400 and 1410 with the simplified CPU idle logic. Use SAP Note 3710700 as the primary reference and remove obsolete OS-release branching in this area.

Refactor test-value fallbacks to one-line parameter expansion for cleaner, consistent style.

Add test hooks for 1400 runtime reads to support deterministic unit testing. Introduce a new bashunit test suite for check 1400 covering skip/ok/warn/error paths and virtualization scenarios.

Update 1410 bashunit expectations to match the simplified behavior.