### PR TITLE
fix(0300,0301): update clocksource checks for Hyper-V/Azure and fix p…

### DIFF
--- a/scripts/lib/check/0300_timer_and_clocksource_intel.check
+++ b/scripts/lib/check/0300_timer_and_clocksource_intel.check
@@ -44,16 +44,8 @@ function check_0300_timer_and_clocksource_intel {
         local available_clocksource
 
         #TEST_VARIABLES only required for UNIT TESTING
-        if [[ -z ${TEST_CURRENT_CLOCKSOURCE:-} ]]; then
-            current_clocksource=$(</sys/devices/system/clocksource/clocksource0/current_clocksource)
-        else
-            current_clocksource="${TEST_CURRENT_CLOCKSOURCE:-}"
-        fi
-        if [[ -z ${TEST_AVAILABLE_CLOCKSOURCE:-} ]]; then
-            available_clocksource=$(</sys/devices/system/clocksource/clocksource0/available_clocksource)
-        else
-            available_clocksource="${TEST_AVAILABLE_CLOCKSOURCE:-}"
-        fi
+        current_clocksource="${TEST_CURRENT_CLOCKSOURCE:-$(</sys/devices/system/clocksource/clocksource0/current_clocksource)}"
+        available_clocksource="${TEST_AVAILABLE_CLOCKSOURCE:-$(</sys/devices/system/clocksource/clocksource0/available_clocksource)}"
 
         if [[ "${current_clocksource}" == 'tsc' ]]; then
 
@@ -123,7 +115,7 @@ function check_0300_timer_and_clocksource_intel {
     #SYSTEM/FALLBACK
     if [[ ${_retval} -eq 99 ]]; then
 
-        if [[ "${reco_clocksource}" != *"${current_clocksource}"* ]] ; then
+        if [[ "|${reco_clocksource}|" != *"|${current_clocksource}|"* ]] ; then
 
             logCheckError "OS clocksource is NOT set as recommended (SAP Note ${sapnote:-}) (is: ${current_clocksource}, should be: ${reco_clocksource})"
             _retval=2

--- a/scripts/lib/check/0301_timer_and_clocksource_hyperv.check
+++ b/scripts/lib/check/0301_timer_and_clocksource_hyperv.check
@@ -7,15 +7,15 @@ function check_0301_timer_and_clocksource_hyperv {
     local -i _retval=99
 
     # MODIFICATION SECTION>>
-    local -r sapnote='#2753418'
-
-    local -r recommended_clocksource='hyperv_clocksource_tsc_page'
+    local -r sapnote='#2791572'
+    local -r preferred_clocksource='tsc'
+    local -r older_clocksource='hyperv_clocksource_tsc_page'
 
     # MODIFICATION SECTION<<
 
-    #2753418 - Performance Degradation Due to Timer Fallback
-
-    local current_clocksource
+    #2791572 - Performance Degradation Because of Missing VDSO Support in Microsoft Azure VM
+    # https://docs.kernel.org/virt/hyperv/clocks.html
+    # https://learn.microsoft.com/en-us/azure/sap/workloads/hana-vm-operations#clock-source-options-in-azure-vms
 
     # PRECONDITIONS
     if ! LIB_FUNC_IS_VIRT_MICROSOFT; then
@@ -28,26 +28,30 @@ function check_0301_timer_and_clocksource_hyperv {
     # CHECK
     if [[ ${_retval} -eq 99 ]]; then
 
+        #kernel clocksource
+        local current_clocksource
+
         #TEST_VARIABLE only required for UNIT TESTING
-        if [[ -z ${TEST_CURRENT_CLOCKSOURCE:-} ]]; then
-            current_clocksource=$(</sys/devices/system/clocksource/clocksource0/current_clocksource)
-        else
-            current_clocksource="${TEST_CURRENT_CLOCKSOURCE:-}"
-        fi
+        current_clocksource="${TEST_CURRENT_CLOCKSOURCE:-$(</sys/devices/system/clocksource/clocksource0/current_clocksource)}"
 
-        logCheckInfo 'HANA does NOT use internal timer and falls back to OS clocksource'
-        logCheckInfo 'Check indexserver trace files for <Fallback to system call for HR timer> messages'
-        logCheckInfo 'The trace message can be suppressed by setting variable <HDB_TIMER=system>'
+        if [[ "${current_clocksource}" == "${preferred_clocksource}" ]]; then
 
-        if [[ "${current_clocksource}" != "${recommended_clocksource}" ]]; then
-
-            logCheckError "Fallback OS clocksource is NOT set as recommended (SAP Note ${sapnote:-}) (is: ${current_clocksource}, should be: ${recommended_clocksource})"
-            _retval=2
-
-        else
-
-            logCheckOk "Fallback OS clocksource is set as recommended (SAP Note ${sapnote:-}) (is: ${current_clocksource})"
+            logCheckOk "OS clocksource is set as recommended (SAP Note ${sapnote:-}) (is: ${current_clocksource})"
             _retval=0
+
+        elif [[ "${current_clocksource}" == "${older_clocksource}" ]]; then
+
+            logCheckWarning 'Modern Azure generations expose a highly optimized virtual TSC which is preferred over the older hyperv_clocksource_tsc_page'
+            logCheckWarning 'https://learn.microsoft.com/en-us/azure/sap/workloads/hana-vm-operations#clock-source-options-in-azure-vms'
+            logCheckWarning 'https://docs.kernel.org/virt/hyperv/clocks.html'
+
+            logCheckWarning "OS clocksource is supported but NOT preferred (SAP Note ${sapnote:-}) (is: ${current_clocksource}, preferred: ${preferred_clocksource})"
+            _retval=1
+
+        else
+
+            logCheckError "OS clocksource is NOT set as recommended (SAP Note ${sapnote:-}) (is: ${current_clocksource}, should be: ${preferred_clocksource})"
+            _retval=2
 
         fi
 

--- a/scripts/tests/check/0300_timer_and_clocksource_intel.bashunit.sh
+++ b/scripts/tests/check/0300_timer_and_clocksource_intel.bashunit.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2329
+
 #------------------------------------------------------------------
 # bashunit migration notes:
 # 1. PROGRAM_DIR not readonly - bashunit runs all tests in same session
@@ -179,11 +181,182 @@ function set_up_before_script() {
 
 }
 
+function test_not_intel_skipped() {
+
+    #arrange
+    LIB_FUNC_IS_INTEL() { return 1 ; }
+    TEST_CURRENT_CLOCKSOURCE='tsc'
+    TEST_AVAILABLE_CLOCKSOURCE='tsc'
+
+    #act
+    check_0300_timer_and_clocksource_intel
+
+    #assert
+    if [[ $? -ne 3 ]]; then
+        bashunit::fail "Expected RC=3 (skipped) for non-Intel"
+    fi
+    assert_true true
+}
+
+function test_hyperv_skipped() {
+
+    #arrange
+    LIB_FUNC_IS_VIRT_MICROSOFT() { return 0 ; }
+    TEST_CURRENT_CLOCKSOURCE='tsc'
+    TEST_AVAILABLE_CLOCKSOURCE='tsc'
+
+    #act
+    check_0300_timer_and_clocksource_intel
+
+    #assert
+    if [[ $? -ne 3 ]]; then
+        bashunit::fail "Expected RC=3 (skipped) for Hyper-V"
+    fi
+    assert_true true
+}
+
+function test_gcp_kvm_kvm_clock_ok() {
+
+    #arrange
+    LIB_FUNC_IS_CLOUD_GOOGLE() { return 0 ; }
+    LIB_FUNC_IS_VIRT_KVM() { return 0 ; }
+    TEST_CURRENT_CLOCKSOURCE='kvm-clock'
+    TEST_AVAILABLE_CLOCKSOURCE='kvm-clock tsc'
+
+    #act
+    check_0300_timer_and_clocksource_intel
+
+    #assert
+    # reco='tsc|kvm-clock' - kvm-clock is accepted on GCP KVM
+    if [[ $? -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for GCP KVM with kvm-clock"
+    fi
+    assert_true true
+}
+
+function test_gcp_kvm_tsc_ok() {
+
+    #arrange
+    LIB_FUNC_IS_CLOUD_GOOGLE() { return 0 ; }
+    LIB_FUNC_IS_VIRT_KVM() { return 0 ; }
+    cpu_flags=('constant_tsc' 'nonstop_tsc' 'rdtscp')
+    TEST_CURRENT_CLOCKSOURCE='tsc'
+    TEST_AVAILABLE_CLOCKSOURCE='kvm-clock tsc'
+
+    #act
+    check_0300_timer_and_clocksource_intel
+
+    #assert
+    # reco='tsc|kvm-clock' - tsc is also accepted on GCP KVM
+    if [[ $? -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for GCP KVM with tsc (also accepted)"
+    fi
+    assert_true true
+}
+
+function test_gcp_kvm_wrong_clocksource() {
+
+    #arrange
+    LIB_FUNC_IS_CLOUD_GOOGLE() { return 0 ; }
+    LIB_FUNC_IS_VIRT_KVM() { return 0 ; }
+    TEST_CURRENT_CLOCKSOURCE='acpi_pm'
+    TEST_AVAILABLE_CLOCKSOURCE='kvm-clock tsc acpi_pm'
+
+    #act
+    check_0300_timer_and_clocksource_intel
+
+    #assert
+    if [[ $? -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) for GCP KVM with wrong clocksource"
+    fi
+    assert_true true
+}
+
+function test_kvm_nongcp_kvm_clock_ok() {
+
+    #arrange
+    LIB_FUNC_IS_VIRT_KVM() { return 0 ; }
+    TEST_CURRENT_CLOCKSOURCE='kvm-clock'
+    TEST_AVAILABLE_CLOCKSOURCE='kvm-clock tsc'
+
+    #act
+    check_0300_timer_and_clocksource_intel
+
+    #assert
+    if [[ $? -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for non-GCP KVM with kvm-clock"
+    fi
+    assert_true true
+}
+
+function test_kvm_nongcp_tsc_error() {
+
+    #arrange
+    LIB_FUNC_IS_VIRT_KVM() { return 0 ; }
+    cpu_flags=('constant_tsc' 'nonstop_tsc' 'rdtscp')
+    TEST_CURRENT_CLOCKSOURCE='tsc'
+    TEST_AVAILABLE_CLOCKSOURCE='kvm-clock tsc'
+
+    #act
+    check_0300_timer_and_clocksource_intel
+
+    #assert
+    # reco='kvm-clock' - tsc is NOT accepted on non-GCP KVM
+    if [[ $? -ne 2 ]]; then
+        bashunit::fail "Expected RC=2 (error) for non-GCP KVM with tsc (should be kvm-clock)"
+    fi
+    assert_true true
+}
+
+function test_amazon_tsc_ok() {
+
+    #arrange
+    LIB_FUNC_IS_CLOUD_AMAZON() { return 0 ; }
+    cpu_flags=('constant_tsc' 'nonstop_tsc' 'rdtscp')
+    TEST_CURRENT_CLOCKSOURCE='tsc'
+    TEST_AVAILABLE_CLOCKSOURCE='tsc'
+
+    #act
+    check_0300_timer_and_clocksource_intel
+
+    #assert
+    if [[ $? -ne 0 ]]; then
+        bashunit::fail "Expected RC=0 (ok) for Amazon with tsc"
+    fi
+    assert_true true
+}
+
+function test_all_flags_ok_but_tsc_not_in_available() {
+
+    #arrange
+    cpu_flags=('constant_tsc' 'nonstop_tsc' 'rdtscp')
+    TEST_CURRENT_CLOCKSOURCE='tsc'
+    TEST_AVAILABLE_CLOCKSOURCE='acpi_pm hpet'
+
+    #act
+    check_0300_timer_and_clocksource_intel
+
+    #assert
+    # tsc active but not listed as available - unintended fallback risk
+    if [[ $? -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for tsc not in available_clocksource"
+    fi
+    assert_true true
+}
+
+
 function set_up() {
 
     # Reset mock variables
     cpu_flags=()
     TEST_CURRENT_CLOCKSOURCE=''
     TEST_AVAILABLE_CLOCKSOURCE=''
+
+    # Reset mock functions to defaults
+    LIB_FUNC_IS_INTEL() { return 0 ; }
+    LIB_FUNC_IS_VIRT_MICROSOFT() { return 1 ; }
+    LIB_FUNC_IS_CLOUD_GOOGLE() { return 1 ; }
+    LIB_FUNC_IS_CLOUD_AMAZON() { return 1 ; }
+    LIB_FUNC_IS_VIRT_KVM() { return 1 ; }
 
 }

--- a/scripts/tests/check/0301_timer_and_clocksource_hyperv.bashunit.sh
+++ b/scripts/tests/check/0301_timer_and_clocksource_hyperv.bashunit.sh
@@ -18,7 +18,7 @@ TEST_CURRENT_CLOCKSOURCE=''
 LIB_FUNC_IS_VIRT_MICROSOFT() { return 0 ; }
 
 
-function test_reco_clock() {
+function test_hyperv_clocksource_warning() {
 
     #arrange
     TEST_CURRENT_CLOCKSOURCE='hyperv_clocksource_tsc_page'
@@ -27,8 +27,39 @@ function test_reco_clock() {
     check_0301_timer_and_clocksource_hyperv
 
     #assert
+    if [[ $? -ne 1 ]]; then
+        bashunit::fail "Expected RC=1 (warning) for supported but non-preferred Hyper-V clocksource"
+    fi
+    assert_true true
+}
+
+function test_tsc_clocksource_ok() {
+
+    #arrange
+    TEST_CURRENT_CLOCKSOURCE='tsc'
+
+    #act
+    check_0301_timer_and_clocksource_hyperv
+
+    #assert
     if [[ $? -ne 0 ]]; then
-        bashunit::fail "Expected RC=0 (ok) for recommended clocksource"
+        bashunit::fail "Expected RC=0 (ok) for tsc clocksource"
+    fi
+    assert_true true
+}
+
+function test_not_hyperv_skipped() {
+
+    #arrange
+    LIB_FUNC_IS_VIRT_MICROSOFT() { return 1 ; }
+    TEST_CURRENT_CLOCKSOURCE='acpi_pm'
+
+    #act
+    check_0301_timer_and_clocksource_hyperv
+
+    #assert
+    if [[ $? -ne 3 ]]; then
+        bashunit::fail "Expected RC=3 (skipped) for non-Hyper-V"
     fi
     assert_true true
 }
@@ -70,5 +101,8 @@ function set_up() {
 
     # Reset mock variables
     TEST_CURRENT_CLOCKSOURCE=''
+
+    # Reset mock functions to defaults
+    LIB_FUNC_IS_VIRT_MICROSOFT() { return 0 ; }
 
 }


### PR DESCRIPTION
…artial-match bug

## 0301 - Hyper-V/Azure clocksource (SAP Note update)

Replace deprecated SAP Note #2753418 with #2791572 ("Performance Degradation Because of Missing VDSO Support in Microsoft Azure VM").

Modern Azure VM generations expose a highly optimised virtual TSC that has full VDSO support. The check logic is updated accordingly:

  tsc                        → OK  (preferred, RC=0)
  hyperv_clocksource_tsc_page → WARNING – supported but not preferred (RC=1)
  anything else               → ERROR (RC=2)

References added:
  https://docs.kernel.org/virt/hyperv/clocks.html
  https://learn.microsoft.com/en-us/azure/sap/workloads/hana-vm-operations

Remove the stale HANA-internal-timer info messages (HDB_TIMER=system hint, indexserver trace advice) which belonged to the old note context.

## 0300 - Intel clocksource partial-match bug fix

The fallback/system path compared reco_clocksource against current_clocksource with a plain substring test:

    [[ "${reco_clocksource}" != *"${current_clocksource}"* ]]

This caused a false-positive OK when current was e.g. "tsc" and reco contained "hyperv_clocksource_tsc_page" (because "tsc" is a substring). Fix by using pipe-delimited tokens:

    [[ "|${reco_clocksource}|" != *"|${current_clocksource}|"* ]]

## Both checks – simplified TEST_VARIABLE pattern

Replace the if/else test-variable guards with the idiomatic default- substitution form, reducing boilerplate by ~6 lines per variable:

    var="${TEST_VAR:-$(</sys/path/to/file)}"

## Test coverage (0300 bashunit)

Add 9 new test cases to cover previously untested branches:
  - non-Intel → skipped (RC=3)
  - Hyper-V host → skipped by 0300 (RC=3)
  - GCP/KVM: kvm-clock OK, tsc OK, wrong clocksource ERROR
  - non-GCP KVM: kvm-clock OK, tsc ERROR (should be kvm-clock)
  - Amazon: tsc OK
  - tsc active but absent from available_clocksource → WARNING (RC=1)

Fix set_up() to reset all mock functions between tests so each test starts from a clean, known state.

## Test coverage (0301 bashunit)

Rename test_reco_clock → test_hyperv_clocksource_warning and update expected RC from 0 to 1 (hyperv_clocksource_tsc_page is now a warning). Add test_tsc_clocksource_ok (RC=0) and test_not_hyperv_skipped (RC=3). Fix set_up() to reset LIB_FUNC_IS_VIRT_MICROSOFT between tests.