### PR TITLE
test: upgrade bashunit and refresh test conventions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,8 +58,8 @@ jobs:
       # Run bashunit tests
       - name: Run unit tests (bashunit)
         run: |
-          bash ./bashunit --log-junit test-results-global.xml ./*.bashunit.sh
-          bash ./bashunit --log-junit test-results-checks.xml ./check/*.bashunit.sh
+          bash ./bashunit test --fail-on-risky --log-junit test-results-global.xml ./*.bashunit.sh
+          bash ./bashunit test --fail-on-risky --log-junit test-results-checks.xml ./check/*.bashunit.sh
         working-directory: ./scripts/tests
 
       - name: Upload JUnit XML results

--- a/scripts/tests/bashunit
+++ b/scripts/tests/bashunit
@@ -7998,7 +7998,7 @@ function bashunit::helper::_annotations_is_count() {
   return 0
 }
 
-function bashunit::helper::annotations_validate_or_exit() {
+function bashunit::helper::annotations_validate() {
   local script=$1
   local i=0
   local total=${#_BASHUNIT_ANNOT_MAP_FNS[@]}
@@ -8010,21 +8010,28 @@ function bashunit::helper::annotations_validate_or_exit() {
     value="${_BASHUNIT_ANNOT_MAP_TIMEOUTS[i]}"
     if [ -n "$value" ] && ! bashunit::helper::_annotations_is_count "$value"; then
       bashunit::helper::_annotations_reject "$script" "$fn" "timeout" "$value"
+      return 1
     fi
 
     value="${_BASHUNIT_ANNOT_MAP_RETRIES[i]}"
     if [ -n "$value" ] && ! bashunit::helper::_annotations_is_count "$value"; then
       bashunit::helper::_annotations_reject "$script" "$fn" "retry" "$value"
+      return 1
     fi
 
     i=$((i + 1))
   done
 }
 
+_BASHUNIT_ANNOT_REJECT_FN_OUT=""
+_BASHUNIT_ANNOT_REJECT_MSG_OUT=""
+
 function bashunit::helper::_annotations_reject() {
-  printf "%sError: @%s '%s' above %s in %s is not a non-negative integer.%s\n" \
-    "${_BASHUNIT_COLOR_FAILED}" "$3" "$4" "$2" "$1" "${_BASHUNIT_COLOR_DEFAULT}" >&2
-  exit 1
+  _BASHUNIT_ANNOT_REJECT_FN_OUT=$2
+  _BASHUNIT_ANNOT_REJECT_MSG_OUT="@$3 '$4' above $2 in $1 is not a non-negative integer."
+  printf "%sError: %s%s\n" \
+    "${_BASHUNIT_COLOR_FAILED}" "$_BASHUNIT_ANNOT_REJECT_MSG_OUT" \
+    "${_BASHUNIT_COLOR_DEFAULT}" >&2
 }
 
 # src/helper/provider.sh
@@ -16942,6 +16949,37 @@ function bashunit::runner::clear_mocks() {
   done
 }
 
+_BASHUNIT_FILE_TEARDOWN_PENDING=""
+
+function bashunit::runner::mark_file_teardown_pending() {
+  if declare -F tear_down_after_script >/dev/null 2>&1; then
+    _BASHUNIT_FILE_TEARDOWN_PENDING="$1"
+  fi
+}
+
+function bashunit::runner::run_pending_file_teardown() {
+  local test_file="$_BASHUNIT_FILE_TEARDOWN_PENDING"
+  [ -n "$test_file" ] || return 0
+
+  _BASHUNIT_FILE_TEARDOWN_PENDING=""
+  bashunit::runner::run_tear_down_after_script "$test_file"
+}
+
+_BASHUNIT_WORKER_TEST_PIDS=""
+
+function bashunit::runner::cleanup_worker_on_signal() {
+
+  trap - TERM
+
+  local test_pid
+  for test_pid in $_BASHUNIT_WORKER_TEST_PIDS; do
+    kill -TERM -"$test_pid" 2>/dev/null
+  done
+
+  bashunit::runner::run_pending_file_teardown || true
+  exit 143
+}
+
 function bashunit::runner::run_tear_down_after_script() {
   local test_file="$1"
   bashunit::internal_log "run_tear_down_after_script"
@@ -17053,6 +17091,40 @@ function bashunit::runner::parse_result_parallel() {
   bashunit::runner::parse_result_sync "$fn_name" "$execution_result"
 
   echo "$execution_result" >"$unique_test_result_file"
+}
+
+function bashunit::runner::publish_file_hook_failure() {
+  local status=$1
+  local test_file=$2
+
+  local slot=${3:-tear_down_after_script}
+
+  [ "$status" -ne 0 ] || return 0
+  bashunit::parallel::is_enabled || return 0
+
+  bashunit::runner::parallel_suite_dir_to_slot "$test_file"
+  local test_suite_dir=$_BASHUNIT_RUNNER_SUITE_DIR_OUT
+  [ -d "$test_suite_dir" ] || mkdir -p "$test_suite_dir"
+
+  local payload="\
+##ASSERTIONS_FAILED=0\
+##ASSERTIONS_PASSED=0\
+##ASSERTIONS_SKIPPED=0\
+##ASSERTIONS_INCOMPLETE=0\
+##ASSERTIONS_SNAPSHOT=0\
+##TEST_EXIT_CODE=$status##"
+  printf '%s\n' "$payload" >"$test_suite_dir/$slot.result"
+}
+
+function bashunit::runner::report_annotation_abort() {
+  local test_file=$1
+
+  local normalized_fn
+  normalized_fn="$(bashunit::helper::normalize_test_function_name \
+    "$_BASHUNIT_ANNOT_REJECT_FN_OUT")"
+  bashunit::reports::add_test_failed \
+    "$test_file" "$normalized_fn" 0 0 "$_BASHUNIT_ANNOT_REJECT_MSG_OUT"
+  bashunit::runner::publish_file_hook_failure 1 "$test_file" "annotation_abort"
 }
 
 function bashunit::runner::parse_result_sync() {
@@ -17402,12 +17474,18 @@ function bashunit::runner::call_test_functions() {
 
   bashunit::helper::build_provider_map "$script"
 
-  bashunit::helper::annotations_validate_or_exit "$script"
+  if ! bashunit::helper::annotations_validate "$script"; then
+
+    bashunit::runner::report_annotation_abort "$script"
+    return 1
+  fi
 
   local allow_test_parallel=true
   if [ "$_BASHUNIT_PROVIDER_MAP_NO_PARALLEL" = true ]; then
     allow_test_parallel=false
   fi
+
+  _BASHUNIT_WORKER_TEST_PIDS=""
 
   if bashunit::parallel::is_enabled && [ "$allow_test_parallel" = true ]; then
     bashunit::runner::parallel_suite_dir_to_slot "$script"
@@ -17426,6 +17504,7 @@ function bashunit::runner::call_test_functions() {
         _test_ordinal=$((_test_ordinal + 1))
         _BASHUNIT_RUNNER_RESULT_ORDINAL=$_test_ordinal
         bashunit::runner::run_test "$script" "$fn_name" &
+        _BASHUNIT_WORKER_TEST_PIDS="$_BASHUNIT_WORKER_TEST_PIDS $!"
       else
         bashunit::runner::run_test "$script" "$fn_name"
       fi
@@ -17467,6 +17546,7 @@ function bashunit::runner::call_test_functions() {
         _test_ordinal=$((_test_ordinal + 1))
         _BASHUNIT_RUNNER_RESULT_ORDINAL=$_test_ordinal
         bashunit::runner::run_test "$script" "$fn_name" ${parsed_data+"${parsed_data[@]}"} &
+        _BASHUNIT_WORKER_TEST_PIDS="$_BASHUNIT_WORKER_TEST_PIDS $!"
       else
         bashunit::runner::run_test "$script" "$fn_name" ${parsed_data+"${parsed_data[@]}"}
       fi
@@ -17495,6 +17575,8 @@ function bashunit::runner::execute_test_body() {
   _BASHUNIT_RUNNER_EXIT_FILE=$test_file
 
   trap 'exit_code=$?; bashunit::runner::cleanup_on_exit "$_BASHUNIT_RUNNER_EXIT_FILE" "$exit_code"' EXIT
+
+  trap 'exit 143' TERM
   bashunit::state::initialize_assertions_count
 
   if bashunit::env::is_login_shell_enabled; then
@@ -18127,6 +18209,8 @@ function bashunit::runner::load_test_files() {
       bashunit::runner::record_file_hook_failure \
         "source" "$test_file" "$message" 1 true
       bashunit::runner::clean_set_up_and_tear_down_after_script
+
+      bashunit::cleanup_script_temp_files
       bashunit::runner::restore_workdir
       continue
     fi
@@ -18189,6 +18273,8 @@ function bashunit::runner::load_test_files() {
         done
       fi
 
+      bashunit::runner::run_tear_down_after_script "$test_file"
+
       bashunit::runner::clean_script_test_functions "$_script_fns_to_clean"
       bashunit::runner::clean_set_up_and_tear_down_after_script
       if ! bashunit::parallel::is_enabled; then
@@ -18197,9 +18283,13 @@ function bashunit::runner::load_test_files() {
       bashunit::runner::restore_workdir
       continue
     fi
+
+    bashunit::runner::mark_file_teardown_pending "$test_file"
     local _cached_fns="$functions_for_script"
 
     bashunit::helper::check_duplicate_functions "$test_file" || true
+
+    local file_status=0
     if bashunit::parallel::is_enabled; then
       bashunit::runner::wait_for_job_slot
 
@@ -18207,11 +18297,28 @@ function bashunit::runner::load_test_files() {
       worker_stderr_paths[worker_stderr_count]="$_worker_stderr"
       worker_stderr_owners[worker_stderr_count]="$test_file"
       worker_stderr_count=$((worker_stderr_count + 1))
-      bashunit::runner::call_test_functions "$test_file" "$_cached_fns" 2>"$_worker_stderr" &
+
+      {
+
+        trap 'bashunit::runner::cleanup_worker_on_signal' TERM
+
+        set -m
+
+        bashunit::runner::call_test_functions "$test_file" "$_cached_fns"
+
+        _BASHUNIT_FILE_TEARDOWN_PENDING=""
+        bashunit::runner::run_tear_down_after_script "$test_file"
+
+        bashunit::runner::publish_file_hook_failure "$?" "$test_file"
+      } 2>"$_worker_stderr" &
     else
+
       bashunit::runner::call_test_functions "$test_file" "$_cached_fns"
+      file_status=$?
+      bashunit::runner::run_tear_down_after_script "$test_file"
     fi
-    bashunit::runner::run_tear_down_after_script "$test_file"
+
+    _BASHUNIT_FILE_TEARDOWN_PENDING=""
     bashunit::runner::clean_script_test_functions "$_script_fns_to_clean"
     bashunit::runner::clean_set_up_and_tear_down_after_script
     if ! bashunit::parallel::is_enabled; then
@@ -18219,6 +18326,10 @@ function bashunit::runner::load_test_files() {
     fi
     bashunit::internal_log "Finished file" "$test_file"
     bashunit::runner::restore_workdir
+
+    if [ "$file_status" -ne 0 ]; then
+      exit "$file_status"
+    fi
   done
 
   if bashunit::parallel::is_enabled && ! bashunit::env::is_list_enabled; then
@@ -18359,16 +18470,23 @@ function bashunit::runner::load_bench_files() {
           bashunit::state::add_tests_failed
         done
       fi
+
+      bashunit::runner::run_tear_down_after_script "$bench_file"
       bashunit::runner::clean_set_up_and_tear_down_after_script
       bashunit::cleanup_script_temp_files
       bashunit::runner::restore_workdir
       continue
     fi
     bashunit::runner::call_bench_functions "$bench_file" "$filter"
+    local bench_status=$?
     bashunit::runner::run_tear_down_after_script "$bench_file"
     bashunit::runner::clean_set_up_and_tear_down_after_script
     bashunit::cleanup_script_temp_files
     bashunit::runner::restore_workdir
+
+    if [ "$bench_status" -ne 0 ]; then
+      exit "$bench_status"
+    fi
   done
 }
 
@@ -18402,7 +18520,7 @@ function bashunit::runner::call_bench_functions() {
   for fn_name in "${functions_to_run[@]+"${functions_to_run[@]}"}"; do
 
     local parsed_annotations
-    parsed_annotations=$(bashunit::benchmark::parse_annotations "$fn_name" "$script") || exit 1
+    parsed_annotations=$(bashunit::benchmark::parse_annotations "$fn_name" "$script") || return 1
     read -r revs its max_ms <<<"$parsed_annotations"
     bashunit::benchmark::run_function "$fn_name" "$revs" "$its" "$max_ms" "$script"
     unset -v fn_name
@@ -19603,10 +19721,14 @@ function bashunit::main::exec_benchmarks() {
 }
 
 function bashunit::main::cleanup() {
+
+  trap - INT
   printf "%sCaught Ctrl-C, killing all child processes...%s\n" \
     "${_BASHUNIT_COLOR_SKIPPED}" "${_BASHUNIT_COLOR_DEFAULT}"
 
   pkill -P $$
+
+  bashunit::runner::run_pending_file_teardown || true
   bashunit::cleanup_script_temp_files
   if bashunit::parallel::is_enabled; then
     bashunit::parallel::cleanup
@@ -19616,6 +19738,8 @@ function bashunit::main::cleanup() {
 }
 
 function bashunit::main::handle_stop_on_failure_sync() {
+
+  bashunit::runner::run_pending_file_teardown || true
   printf "\n%sStop on failure enabled...%s\n" "${_BASHUNIT_COLOR_SKIPPED}" "${_BASHUNIT_COLOR_DEFAULT}"
   bashunit::console_results::print_failing_tests_and_reset
   bashunit::console_results::print_risky_tests_and_reset
@@ -20868,7 +20992,7 @@ function _check_bash_version() {
 
 _check_bash_version
 
-declare -r BASHUNIT_VERSION="0.50.0"
+declare -r BASHUNIT_VERSION="0.50.1"
 
 _bashunit_root="${BASH_SOURCE[0]%/*}"
 

--- a/scripts/tests/bashunit
+++ b/scripts/tests/bashunit
@@ -146,6 +146,15 @@ function bashunit::dependencies::has_tput() {
 
 # src/system/io.sh
 
+function bashunit::io::file_size() {
+  local bytes
+  bytes=$(wc -c <"$1" 2>/dev/null | tr -d ' ') || bytes=""
+  if [ -z "$bytes" ]; then
+    bytes="unknown"
+  fi
+  printf '%s' "$bytes"
+}
+
 function bashunit::io::clear_screen() {
   if bashunit::dependencies::has_tput; then
     local out
@@ -236,7 +245,8 @@ function bashunit::str::strip_ansi_to_slot() {
     fi
     ;;
   esac
-  _BASHUNIT_STR_STRIPPED_OUT=$(echo -e "$input" | sed -E 's/\x1B\[[0-9;]*[mK]//g; s/[[:cntrl:]]//g')
+
+  _BASHUNIT_STR_STRIPPED_OUT=$(printf '%s' "$input" | sed -E 's/\x1B\[[0-9;]*[mK]//g; s/[[:cntrl:]]//g')
 }
 
 function bashunit::str::strip_ansi() {
@@ -306,6 +316,16 @@ function bashunit::str::rpad() {
   fi
 
   printf "%s%${remaining_space}s %s\n" "$result_left_text" "" "$right_word"
+}
+
+function bashunit::str::html_escape() {
+  printf '%s' "$1" | awk '{
+    gsub(/&/, "\\&amp;")
+    gsub(/</, "\\&lt;")
+    gsub(/>/, "\\&gt;")
+    gsub(/"/, "\\&quot;")
+    print
+  }'
 }
 
 # src/util/math.sh
@@ -668,13 +688,32 @@ function bashunit::clock::shell_time() {
 }
 
 function bashunit::clock::total_runtime_in_milliseconds() {
-  local end_time
-  end_time=$(bashunit::clock::now)
-  if [ -n "$end_time" ]; then
-    bashunit::math::calculate "($end_time - $_BASHUNIT_START_TIME) / 1000000"
-  else
+
+  bashunit::clock::now_to_slot || {
     echo ""
+    return
+  }
+  local end_time=$_BASHUNIT_CLOCK_NOW_OUT
+  local start_time=${_BASHUNIT_START_TIME:-}
+  case "$end_time" in
+  '' | *[!0-9]*)
+    echo ""
+    return
+    ;;
+  esac
+  case "$start_time" in
+  '' | *[!0-9]*)
+    echo ""
+    return
+    ;;
+  esac
+  local elapsed=$(((end_time - start_time) / 1000000))
+
+  if [ "$elapsed" -lt 0 ]; then
+    echo ""
+    return
   fi
+  echo "$elapsed"
 }
 
 function bashunit::clock::init() {
@@ -706,6 +745,13 @@ function bashunit::is_command_available() {
   command -v "$1" >/dev/null 2>&1
 }
 
+function bashunit::_mark_temp_owner() {
+  local test_prefix=$1
+  if [ -n "$test_prefix" ]; then
+    : >"$BASHUNIT_TEMP_DIR/${test_prefix}.mark" 2>/dev/null || true
+  fi
+}
+
 function bashunit::temp_file() {
   local prefix=${1:-bashunit}
   local test_prefix=""
@@ -716,6 +762,7 @@ function bashunit::temp_file() {
 
     test_prefix="${BASHUNIT_CURRENT_SCRIPT_ID}_"
   fi
+  bashunit::_mark_temp_owner "$test_prefix"
   "$MKTEMP" "$BASHUNIT_TEMP_DIR/${test_prefix}${prefix}.XXXXXXX"
 }
 
@@ -729,12 +776,17 @@ function bashunit::temp_dir() {
 
     test_prefix="${BASHUNIT_CURRENT_SCRIPT_ID}_"
   fi
+  bashunit::_mark_temp_owner "$test_prefix"
   "$MKTEMP" -d "$BASHUNIT_TEMP_DIR/${test_prefix}${prefix}.XXXXXXX"
 }
 
 function bashunit::cleanup_testcase_temp_files() {
   bashunit::internal_log "cleanup_testcase_temp_files"
   if [ -n "${BASHUNIT_CURRENT_TEST_ID:-}" ]; then
+
+    if [ ! -e "$BASHUNIT_TEMP_DIR/${BASHUNIT_CURRENT_TEST_ID}_.mark" ]; then
+      return 0
+    fi
 
     local matches
     matches=("$BASHUNIT_TEMP_DIR/${BASHUNIT_CURRENT_TEST_ID}"_*)
@@ -748,6 +800,10 @@ function bashunit::cleanup_testcase_temp_files() {
 function bashunit::cleanup_script_temp_files() {
   bashunit::internal_log "cleanup_script_temp_files"
   if [ -n "${BASHUNIT_CURRENT_SCRIPT_ID:-}" ]; then
+
+    if [ ! -e "$BASHUNIT_TEMP_DIR/${BASHUNIT_CURRENT_SCRIPT_ID}_.mark" ]; then
+      return 0
+    fi
     rm -rf "$BASHUNIT_TEMP_DIR/${BASHUNIT_CURRENT_SCRIPT_ID}"_*
   fi
 }
@@ -785,14 +841,92 @@ function bashunit::data_set() {
 
 # src/api/skip_todo.sh
 
-function bashunit::skip() {
+function bashunit::skip::__mark() {
   local reason=${1-}
+  local depth=${2:-2}
   local label
-  label="$(bashunit::helper::normalize_test_function_name "${FUNCNAME[1]}")"
 
-  bashunit::console_results::print_skipped_test "${label}" "${reason}"
+  label="$(bashunit::helper::normalize_test_function_name "${FUNCNAME[$depth]:-}")"
+
+  bashunit::skip::__mark_with_label "$label" "$reason"
+}
+
+function bashunit::skip::__mark_with_label() {
+  bashunit::console_results::print_skipped_test "${1}" "${2-}"
 
   bashunit::state::add_assertions_skipped
+}
+
+function bashunit::skip::__mark_and_stop() {
+  bashunit::skip::__mark "${1-}" 3
+  exit 0
+}
+
+function bashunit::skip() {
+  bashunit::skip::__mark "${1-}" 2
+}
+
+function bashunit::skip_if() {
+  local condition=${1-}
+  local reason=${2-}
+
+  if eval "$condition"; then
+    bashunit::skip::__mark_and_stop "$reason"
+  fi
+}
+
+function bashunit::skip_unless() {
+  local condition=${1-}
+  local reason=${2-}
+
+  if eval "$condition"; then
+    return 0
+  fi
+
+  bashunit::skip::__mark_and_stop "$reason"
+}
+
+function bashunit::skip_unless_command() {
+  local cmd
+  for cmd in "$@"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      bashunit::skip::__mark_and_stop "requires $cmd"
+    fi
+  done
+}
+
+function bashunit::skip_on() {
+  local os=${1-}
+  local reason=${2-}
+  local matches=false
+
+  case "$os" in
+  windows)
+    if bashunit::check_os::is_windows; then
+      matches=true
+    fi
+    ;;
+  macos)
+    if bashunit::check_os::is_macos; then
+      matches=true
+    fi
+    ;;
+  linux)
+    if bashunit::check_os::is_linux; then
+      matches=true
+    fi
+    ;;
+  *)
+
+    bashunit::assert::usage_error_detail "bashunit::skip_on" \
+      "accepts windows, macos or linux, got '$os'"
+    return 1
+    ;;
+  esac
+
+  if [ "$matches" = true ]; then
+    bashunit::skip::__mark_and_stop "$reason"
+  fi
 }
 
 function bashunit::todo() {
@@ -861,9 +995,12 @@ function bashunit::parallel::must_stop_on_failure() {
 
 function bashunit::parallel::cleanup() {
   local target="$TEMP_DIR_PARALLEL_TEST_SUITE"
+
+  target="${target%/}"
   case "$target" in
-  */bashunit/parallel/*)
+  */bashunit/parallel/*/?*)
     rm -rf "$target"
+    return 0
     ;;
   *)
     bashunit::internal_log "parallel::cleanup" "refused unsafe path:$target"
@@ -991,7 +1128,7 @@ _BASHUNIT_DEPRECATED_ALIASES="DEFAULT_PATH DEV_LOG BOOTSTRAP BOOTSTRAP_ARGS
 LOG_JUNIT LOG_GHA REPORT_HTML REPORT_TAP REPORT_JSON WATCH_INTERVAL COVERAGE
 COVERAGE_PATHS COVERAGE_EXCLUDE COVERAGE_REPORT COVERAGE_REPORT_HTML
 COVERAGE_MIN COVERAGE_THRESHOLD_LOW COVERAGE_THRESHOLD_HIGH PARALLEL_RUN
-SHOW_HEADER HEADER_ASCII_ART SIMPLE_OUTPUT STOP_ON_FAILURE SHOW_EXECUTION_TIME
+SHOW_HEADER HEADER_ASCII_ART SIMPLE_OUTPUT STOP_ON_FAILURE PASS_WITH_NO_TESTS SHOW_EXECUTION_TIME
 VERBOSE BENCH_MODE NO_OUTPUT INTERNAL_LOG SHOW_SKIPPED SHOW_INCOMPLETE
 STRICT_MODE STOP_ON_ASSERTION_FAILURE SKIP_ENV_FILE LOGIN_SHELL FAILURES_ONLY
 SHOW_OUTPUT_ON_FAILURE NO_DIFF NO_PROGRESS OUTPUT_FORMAT FAIL_ON_RISKY PROFILE
@@ -1086,6 +1223,7 @@ _BASHUNIT_DEFAULT_SHOW_HEADER="true"
 _BASHUNIT_DEFAULT_HEADER_ASCII_ART="false"
 _BASHUNIT_DEFAULT_SIMPLE_OUTPUT="false"
 _BASHUNIT_DEFAULT_STOP_ON_FAILURE="false"
+_BASHUNIT_DEFAULT_PASS_WITH_NO_TESTS="false"
 
 _BASHUNIT_DEFAULT_SHOW_EXECUTION_TIME="auto"
 _BASHUNIT_DEFAULT_VERBOSE="false"
@@ -1105,6 +1243,14 @@ _BASHUNIT_DEFAULT_SHOW_OUTPUT_ON_FAILURE="true"
 _BASHUNIT_DEFAULT_NO_PROGRESS="false"
 _BASHUNIT_DEFAULT_OUTPUT_FORMAT=""
 _BASHUNIT_DEFAULT_FAIL_ON_RISKY="false"
+_BASHUNIT_DEFAULT_SNAPSHOT_PRUNE="false"
+_BASHUNIT_DEFAULT_BENCH_BASELINE=""
+_BASHUNIT_DEFAULT_BENCH_BASELINE_TOLERANCE="10"
+_BASHUNIT_DEFAULT_BENCH_BASELINE_UPDATE=""
+_BASHUNIT_DEFAULT_BENCH_REPORT_JSON=""
+_BASHUNIT_DEFAULT_BENCH_REPORT_JUNIT=""
+_BASHUNIT_DEFAULT_SANDBOX="false"
+_BASHUNIT_DEFAULT_SANDBOX_ALLOW=""
 _BASHUNIT_DEFAULT_PROFILE="false"
 _BASHUNIT_DEFAULT_PROFILE_COUNT="10"
 
@@ -1139,6 +1285,8 @@ _BASHUNIT_DEFAULT_LIST_TESTS="false"
 
 _BASHUNIT_DEFAULT_LIST_FORMAT="text"
 
+_BASHUNIT_DEFAULT_LIST_TAGS="false"
+
 _BASHUNIT_DEFAULT_SNAPSHOT_UPDATE="false"
 
 _BASHUNIT_DEFAULT_SNAPSHOT_CREATE="true"
@@ -1151,6 +1299,7 @@ _BASHUNIT_DEFAULT_SNAPSHOT_REPORT_UNUSED="false"
 : "${BASHUNIT_HEADER_ASCII_ART:=${HEADER_ASCII_ART:=$_BASHUNIT_DEFAULT_HEADER_ASCII_ART}}"
 : "${BASHUNIT_SIMPLE_OUTPUT:=${SIMPLE_OUTPUT:=$_BASHUNIT_DEFAULT_SIMPLE_OUTPUT}}"
 : "${BASHUNIT_STOP_ON_FAILURE:=${STOP_ON_FAILURE:=$_BASHUNIT_DEFAULT_STOP_ON_FAILURE}}"
+: "${BASHUNIT_PASS_WITH_NO_TESTS:=${PASS_WITH_NO_TESTS:=$_BASHUNIT_DEFAULT_PASS_WITH_NO_TESTS}}"
 : "${BASHUNIT_SHOW_EXECUTION_TIME:=${SHOW_EXECUTION_TIME:=$_BASHUNIT_DEFAULT_SHOW_EXECUTION_TIME}}"
 : "${BASHUNIT_VERBOSE:=${VERBOSE:=$_BASHUNIT_DEFAULT_VERBOSE}}"
 : "${BASHUNIT_BENCH_MODE:=${BENCH_MODE:=$_BASHUNIT_DEFAULT_BENCH_MODE}}"
@@ -1168,6 +1317,15 @@ _BASHUNIT_DEFAULT_SNAPSHOT_REPORT_UNUSED="false"
 : "${BASHUNIT_NO_PROGRESS:=${NO_PROGRESS:=$_BASHUNIT_DEFAULT_NO_PROGRESS}}"
 : "${BASHUNIT_OUTPUT_FORMAT:=${OUTPUT_FORMAT:=$_BASHUNIT_DEFAULT_OUTPUT_FORMAT}}"
 : "${BASHUNIT_FAIL_ON_RISKY:=${FAIL_ON_RISKY:=$_BASHUNIT_DEFAULT_FAIL_ON_RISKY}}"
+
+: "${BASHUNIT_SNAPSHOT_PRUNE:=$_BASHUNIT_DEFAULT_SNAPSHOT_PRUNE}"
+: "${BASHUNIT_BENCH_BASELINE:=$_BASHUNIT_DEFAULT_BENCH_BASELINE}"
+: "${BASHUNIT_BENCH_BASELINE_TOLERANCE:=$_BASHUNIT_DEFAULT_BENCH_BASELINE_TOLERANCE}"
+: "${BASHUNIT_BENCH_BASELINE_UPDATE:=$_BASHUNIT_DEFAULT_BENCH_BASELINE_UPDATE}"
+: "${BASHUNIT_BENCH_REPORT_JSON:=$_BASHUNIT_DEFAULT_BENCH_REPORT_JSON}"
+: "${BASHUNIT_BENCH_REPORT_JUNIT:=$_BASHUNIT_DEFAULT_BENCH_REPORT_JUNIT}"
+: "${BASHUNIT_SANDBOX:=$_BASHUNIT_DEFAULT_SANDBOX}"
+: "${BASHUNIT_SANDBOX_ALLOW:=$_BASHUNIT_DEFAULT_SANDBOX_ALLOW}"
 : "${BASHUNIT_PROFILE:=${PROFILE:=$_BASHUNIT_DEFAULT_PROFILE}}"
 : "${BASHUNIT_PROFILE_COUNT:=${PROFILE_COUNT:=$_BASHUNIT_DEFAULT_PROFILE_COUNT}}"
 : "${BASHUNIT_TEST_TIMEOUT:=${TEST_TIMEOUT:=$_BASHUNIT_DEFAULT_TEST_TIMEOUT}}"
@@ -1201,6 +1359,7 @@ export _BASHUNIT_GHA_ANNOTATIONS_CLAIMED=1
 : "${BASHUNIT_EXCLUDE_FILTER:=$_BASHUNIT_DEFAULT_EXCLUDE_FILTER}"
 : "${BASHUNIT_LIST_TESTS:=$_BASHUNIT_DEFAULT_LIST_TESTS}"
 : "${BASHUNIT_LIST_FORMAT:=$_BASHUNIT_DEFAULT_LIST_FORMAT}"
+: "${BASHUNIT_LIST_TAGS:=$_BASHUNIT_DEFAULT_LIST_TAGS}"
 
 : "${BASHUNIT_SNAPSHOT_UPDATE:=$_BASHUNIT_DEFAULT_SNAPSHOT_UPDATE}"
 : "${BASHUNIT_SNAPSHOT_CREATE:=$_BASHUNIT_DEFAULT_SNAPSHOT_CREATE}"
@@ -1291,6 +1450,10 @@ function bashunit::env::is_simple_output_enabled() {
 
 function bashunit::env::is_stop_on_failure_enabled() {
   [ "$BASHUNIT_STOP_ON_FAILURE" = "true" ]
+}
+
+function bashunit::env::is_pass_with_no_tests_enabled() {
+  [ "$BASHUNIT_PASS_WITH_NO_TESTS" = "true" ]
 }
 
 function bashunit::env::is_show_execution_time_enabled() {
@@ -1434,6 +1597,25 @@ function bashunit::env::is_tap_output_enabled() {
   [ "$BASHUNIT_OUTPUT_FORMAT" = "tap" ]
 }
 
+function bashunit::env::is_json_output_enabled() {
+  [ "$BASHUNIT_OUTPUT_FORMAT" = "json" ]
+}
+
+function bashunit::env::is_junit_output_enabled() {
+  [ "$BASHUNIT_OUTPUT_FORMAT" = "junit" ]
+}
+
+function bashunit::env::is_machine_output_enabled() {
+  case "$BASHUNIT_OUTPUT_FORMAT" in
+  tap | json | junit) return 0 ;;
+  esac
+  return 1
+}
+
+function bashunit::env::is_snapshot_prune_enabled() {
+  [ "${BASHUNIT_SNAPSHOT_PRUNE:-false}" = "true" ]
+}
+
 function bashunit::env::is_snapshot_report_unused_enabled() {
   [ "$BASHUNIT_SNAPSHOT_REPORT_UNUSED" = "true" ]
 }
@@ -1450,8 +1632,16 @@ function bashunit::env::is_list_enabled() {
   [ "$BASHUNIT_LIST_TESTS" = "true" ]
 }
 
+function bashunit::env::is_list_tags_enabled() {
+  [ "$BASHUNIT_LIST_TAGS" = "true" ]
+}
+
 function bashunit::env::is_fail_on_risky_enabled() {
   [ "$BASHUNIT_FAIL_ON_RISKY" = "true" ]
+}
+
+function bashunit::env::is_sandbox_enabled() {
+  [ "${BASHUNIT_SANDBOX:-false}" = "true" ]
 }
 
 function bashunit::env::should_print_gha_annotations() {
@@ -1462,7 +1652,7 @@ function bashunit::env::should_print_gha_annotations() {
 
   [ "${_BASHUNIT_IS_OUTERMOST_RUN:-true}" = true ] &&
     [ "${GITHUB_ACTIONS:-}" = "true" ] &&
-    ! bashunit::env::is_tap_output_enabled
+    ! bashunit::env::is_machine_output_enabled
 }
 
 function bashunit::env::should_append_step_summary() {
@@ -1530,6 +1720,7 @@ function bashunit::env::print_verbose() {
     "BASHUNIT_HEADER_ASCII_ART"
     "BASHUNIT_SIMPLE_OUTPUT"
     "BASHUNIT_STOP_ON_FAILURE"
+    "BASHUNIT_PASS_WITH_NO_TESTS"
     "BASHUNIT_SHOW_EXECUTION_TIME"
     "BASHUNIT_VERBOSE"
     "BASHUNIT_STRICT_MODE"
@@ -1571,6 +1762,8 @@ MKTEMP="$(command -v mktemp)"
 AWK="$(command -v awk)"
 
 _BASHUNIT_RUN_OUTPUT_DIR="${TMPDIR:-/tmp}/bashunit/run/${_BASHUNIT_OS:-Unknown}/$(bashunit::random_str 8)"
+
+_BASHUNIT_RUN_DIR_VANISHED=false
 FAILURES_OUTPUT_PATH="$_BASHUNIT_RUN_OUTPUT_DIR/failures"
 SKIPPED_OUTPUT_PATH="$_BASHUNIT_RUN_OUTPUT_DIR/skipped"
 INCOMPLETE_OUTPUT_PATH="$_BASHUNIT_RUN_OUTPUT_DIR/incomplete"
@@ -1606,9 +1799,12 @@ bashunit::env::create_scratch_dirs "$_BASHUNIT_RUN_OUTPUT_DIR" "$BASHUNIT_TEMP_D
 
 function bashunit::env::cleanup_run_output_dir() {
   local target="$_BASHUNIT_RUN_OUTPUT_DIR"
+
+  target="${target%/}"
   case "$target" in
-  */bashunit/run/*)
+  */bashunit/run/*/?*)
     rm -rf "$target"
+    return 0
     ;;
   *)
     bashunit::internal_log "env::cleanup_run_output_dir" "refused unsafe path:$target"
@@ -1617,7 +1813,20 @@ function bashunit::env::cleanup_run_output_dir() {
   esac
 }
 
-trap 'bashunit::env::cleanup_run_output_dir' EXIT
+_BASHUNIT_LOADING_BOOTSTRAP=""
+
+function bashunit::env::report_unfinished_bootstrap() {
+  if [ -n "${_BASHUNIT_LOADING_BOOTSTRAP:-}" ]; then
+    printf "%sError: the bootstrap file did not load: '%s'.%s\n" \
+      "${_BASHUNIT_COLOR_FAILED}" "$_BASHUNIT_LOADING_BOOTSTRAP" \
+      "${_BASHUNIT_COLOR_DEFAULT}" >&2
+    printf "%s\n" "It ended the shell before any test ran (a syntax error, or an 'exit')." >&2
+    _BASHUNIT_LOADING_BOOTSTRAP=""
+    exit 1
+  fi
+}
+
+trap 'bashunit::env::report_unfinished_bootstrap; bashunit::env::cleanup_run_output_dir' EXIT
 
 if bashunit::env::is_dev_mode_enabled; then
   bashunit::internal_log "info" "Dev log enabled" "file:$BASHUNIT_DEV_LOG"
@@ -1770,6 +1979,167 @@ function bashunit::rerun::filter_functions() {
   echo "${kept# }"
 }
 
+# src/config/suites.sh
+
+_BASHUNIT_SUITE_NAMES=()
+_BASHUNIT_SUITE_PATHS=()
+_BASHUNIT_SUITE_ARGS=()
+_BASHUNIT_SUITES_LOADED_FILE=""
+
+_BASHUNIT_SUITE_PATHS_OUT=""
+_BASHUNIT_SUITE_ARGS_OUT=""
+
+function bashunit::suites::_abort() {
+  printf "%sError: %s in %s: '%s'.%s\n" \
+    "${_BASHUNIT_COLOR_FAILED:-}" "$2" "$1" "$3" "${_BASHUNIT_COLOR_DEFAULT:-}" >&2
+  exit 1
+}
+
+function bashunit::suites::load() {
+  local file=${1:-.bashunitrc}
+
+  if [ "$file" = "$_BASHUNIT_SUITES_LOADED_FILE" ]; then
+    return 0
+  fi
+  _BASHUNIT_SUITES_LOADED_FILE="$file"
+  _BASHUNIT_SUITE_NAMES=()
+  _BASHUNIT_SUITE_PATHS=()
+  _BASHUNIT_SUITE_ARGS=()
+
+  [ -f "$file" ] || return 0
+
+  local line raw key val index=-1
+
+  while IFS= read -r line || [ -n "$line" ]; do
+    raw=$line
+    line=${line#"${line%%[![:space:]]*}"}
+    line=${line%"${line##*[![:space:]]}"}
+
+    case "$line" in
+    '' | '#'* | ';'*) continue ;;
+    esac
+
+    case "$line" in
+    '['*']')
+      case "$line" in
+      '[suite:'*']')
+        local name=${line#\[suite:}
+        name=${name%\]}
+        name=${name#"${name%%[![:space:]]*}"}
+        name=${name%"${name##*[![:space:]]}"}
+        if [ -z "$name" ]; then
+          bashunit::suites::_abort "$file" "a suite section needs a name" "$raw"
+        fi
+        index=$((${#_BASHUNIT_SUITE_NAMES[@]}))
+        _BASHUNIT_SUITE_NAMES[index]="$name"
+        _BASHUNIT_SUITE_PATHS[index]=""
+        _BASHUNIT_SUITE_ARGS[index]=""
+        ;;
+      *) index=-1 ;;
+      esac
+      continue
+      ;;
+    esac
+
+    if [ "$index" -lt 0 ]; then
+      continue
+    fi
+
+    case "$line" in
+    *=*) ;;
+    *) bashunit::suites::_abort "$file" "a suite entry must be 'key = value'" "$raw" ;;
+    esac
+
+    key=${line%%=*}
+    val=${line#*=}
+    key=${key%"${key##*[![:space:]]}"}
+    val=${val#"${val%%[![:space:]]*}"}
+    val=${val%"${val##*[![:space:]]}"}
+    case "$val" in
+    \"*\") val=${val#\"} val=${val%\"} ;;
+    \'*\') val=${val#\'} val=${val%\'} ;;
+    esac
+
+    if [ "$key" = "paths" ] || [ "$key" = "path" ]; then
+      _BASHUNIT_SUITE_PATHS[index]="$val"
+      continue
+    fi
+
+    key=$(printf '%s' "$key" | tr '_' '-')
+    case "$key" in
+    '' | *[!a-z0-9-]*)
+      bashunit::suites::_abort "$file" "a suite option must be a long flag name" "$raw"
+      ;;
+    esac
+
+    case "$val" in
+    false) continue ;;
+    true) bashunit::suites::_append "$index" "--$key" ;;
+    *) bashunit::suites::_append "$index" "--$key" "$val" ;;
+    esac
+  done <"$file"
+}
+
+function bashunit::suites::_append() {
+  local index=$1
+  shift
+  local current=${_BASHUNIT_SUITE_ARGS[index]}
+  local entry
+  for entry in "$@"; do
+    if [ -z "$current" ]; then
+      current="$entry"
+    else
+      current="$current
+$entry"
+    fi
+  done
+  _BASHUNIT_SUITE_ARGS[index]="$current"
+}
+
+function bashunit::suites::names() {
+  local i=0
+  local total=${#_BASHUNIT_SUITE_NAMES[@]}
+
+  local seen=""
+  local name
+  while [ "$i" -lt "$total" ]; do
+    name="${_BASHUNIT_SUITE_NAMES[i]}"
+    case "$seen" in
+    *"|$name|"*) ;;
+    *)
+      seen="$seen|$name|"
+      printf '%s\n' "$name"
+      ;;
+    esac
+    i=$((i + 1))
+  done
+}
+
+function bashunit::suites::resolve() {
+  local wanted=$1
+  local i=0
+  local total=${#_BASHUNIT_SUITE_NAMES[@]}
+
+  while [ "$i" -lt "$total" ]; do
+    if [ "${_BASHUNIT_SUITE_NAMES[i]}" = "$wanted" ]; then
+      _BASHUNIT_SUITE_PATHS_OUT="${_BASHUNIT_SUITE_PATHS[i]}"
+      _BASHUNIT_SUITE_ARGS_OUT="${_BASHUNIT_SUITE_ARGS[i]}"
+      return 0
+    fi
+    i=$((i + 1))
+  done
+
+  local defined
+  defined=$(bashunit::suites::names | tr '\n' ' ')
+  defined=${defined%" "}
+  if [ -z "$defined" ]; then
+    defined="none defined in .bashunitrc"
+  fi
+  printf "%sError: unknown suite '%s'. Defined: %s.%s\n" \
+    "${_BASHUNIT_COLOR_FAILED:-}" "$wanted" "$defined" "${_BASHUNIT_COLOR_DEFAULT:-}" >&2
+  exit 1
+}
+
 # src/coverage/index.sh
 
 # src/coverage/config.sh
@@ -1837,14 +2207,19 @@ function bashunit::coverage::init() {
 
   : >"$_BASHUNIT_COVERAGE_DATA_FILE"
   : >"$_BASHUNIT_COVERAGE_TRACKED_FILES"
+  _BASHUNIT_COVERAGE_SEEDED=false
   : >"$_BASHUNIT_COVERAGE_TRACKED_CACHE_FILE"
   : >"$_BASHUNIT_COVERAGE_TEST_HITS_FILE"
 
-  _BASHUNIT_COVERAGE_BUFFER=""
-  _BASHUNIT_COVERAGE_BUFFER_COUNT=0
-  _BASHUNIT_COVERAGE_HITS_BUFFER=""
-  _BASHUNIT_COVERAGE_TRACK_CACHE=""
-  _BASHUNIT_COVERAGE_PATH_CACHE=""
+  _BASHUNIT_COVERAGE_DISKCACHE_FILE=""
+  _BASHUNIT_COVERAGE_DISKCACHE_KEYS=()
+  _BASHUNIT_COVERAGE_DISKCACHE_VALUES=()
+  _BASHUNIT_COVERAGE_DISKCACHE_COUNT=0
+
+  bashunit::coverage::build_trap_glob
+  export _BASHUNIT_COVERAGE_TRAP_GLOB
+  bashunit::coverage::invalidate_hits_aggregation
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_FILE_"
   _BASHUNIT_COVERAGE_IS_PARALLEL=""
   _BASHUNIT_COVERAGE_STATS_FILES=()
   _BASHUNIT_COVERAGE_STATS_EXEC=()
@@ -1852,7 +2227,7 @@ function bashunit::coverage::init() {
   _BASHUNIT_COVERAGE_STATS_PCT=()
   _BASHUNIT_COVERAGE_STATS_CLASS=()
   _BASHUNIT_COVERAGE_STATS_COUNT=0
-  _BASHUNIT_COVERAGE_STATS_LOOKUP=""
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_STATS_"
 
   _BASHUNIT_COVERAGE_ENGINE_RESOLVED=$(bashunit::coverage::resolve_engine)
 
@@ -1903,17 +2278,58 @@ function bashunit::coverage::engine_was_downgraded() {
 
 # src/coverage/paths.sh
 
-_BASHUNIT_COVERAGE_TRACK_CACHE=""
-_BASHUNIT_COVERAGE_PATH_CACHE=""
+_BASHUNIT_COVERAGE_LOOKUP_OUT=""
+
+_BASHUNIT_COVERAGE_LOOKUP_KEY_OUT=""
+
+function bashunit::coverage::lookup_key_to_slot() {
+  _BASHUNIT_COVERAGE_LOOKUP_KEY_OUT="$1${2//[^a-zA-Z0-9]/_}"
+}
+
+function bashunit::coverage::lookup_put() {
+  bashunit::coverage::lookup_key_to_slot "$1" "$2"
+  local key=$_BASHUNIT_COVERAGE_LOOKUP_KEY_OUT
+  eval "${key}_PATH=\$2"
+  eval "${key}_VALUE=\$3"
+}
+
+function bashunit::coverage::lookup_get() {
+  bashunit::coverage::lookup_key_to_slot "$1" "$2"
+  local path_var="${_BASHUNIT_COVERAGE_LOOKUP_KEY_OUT}_PATH"
+  local value_var="${_BASHUNIT_COVERAGE_LOOKUP_KEY_OUT}_VALUE"
+
+  _BASHUNIT_COVERAGE_LOOKUP_OUT=""
+  if [ "${!path_var:-}" != "$2" ]; then
+    return 1
+  fi
+  _BASHUNIT_COVERAGE_LOOKUP_OUT="${!value_var:-}"
+  return 0
+}
+
+function bashunit::coverage::reset_lookup_namespace() {
+  local name
+  for name in $(compgen -v "$1" 2>/dev/null || true); do
+    unset "$name"
+  done
+}
 
 function bashunit::coverage::normalize_path() {
   local file="$1"
 
-  if [ -f "$file" ]; then
-    echo "$(cd "$(dirname "$file")" && pwd)/$(basename "$file")"
-  else
-    echo "$file"
+  [ -f "$file" ] || {
+
+    builtin printf '%s' "$file"
+    return 0
+  }
+
+  local dir="${file%/*}" base="${file##*/}"
+  if [ "$dir" = "$file" ]; then
+    dir="."
+  elif [ -z "$dir" ]; then
+    dir="/"
   fi
+
+  builtin printf '%s/%s' "$(cd "$dir" 2>/dev/null && pwd)" "$base"
 }
 
 function bashunit::coverage::get_tracked_files() {
@@ -1921,6 +2337,169 @@ function bashunit::coverage::get_tracked_files() {
     return
   fi
   sort -u "$_BASHUNIT_COVERAGE_TRACKED_FILES"
+}
+
+_BASHUNIT_COVERAGE_TRAP_GLOB=""
+
+function bashunit::coverage::_single_quote() {
+  local value=$1
+
+  local q="'"
+  local esc="$q\\$q$q"
+  printf "%s%s%s" "$q" "${value//$q/$esc}" "$q"
+}
+
+function bashunit::coverage::build_trap_glob() {
+  _BASHUNIT_COVERAGE_TRAP_GLOB=""
+
+  [ -n "${BASHUNIT_COVERAGE_PATHS:-}" ] || return 0
+
+  local glob=""
+  local cwd
+  cwd=$(pwd)
+  local old_ifs="$IFS"
+  IFS=','
+  local path resolved relative
+  for path in $BASHUNIT_COVERAGE_PATHS; do
+    [ -n "$path" ] || continue
+    case "$path" in
+    /*) resolved="$path" ;;
+    *) resolved="$cwd/$path" ;;
+    esac
+
+    relative="$path"
+    case "$relative" in
+    "$cwd"/*) relative="${relative#"$cwd"/}" ;;
+    esac
+
+    local q_resolved q_relative
+    q_resolved=$(bashunit::coverage::_single_quote "$resolved")
+    q_relative=$(bashunit::coverage::_single_quote "$relative")
+
+    if [ -n "$glob" ]; then
+      glob="$glob|"
+    fi
+    glob="$glob${q_resolved}*|${q_relative}*|./${q_relative}*|*/${q_relative}/*|*/${q_relative}"
+  done
+  IFS="$old_ifs"
+
+  _BASHUNIT_COVERAGE_TRAP_GLOB="$glob"
+}
+
+_BASHUNIT_COVERAGE_SEEDED=false
+
+function bashunit::coverage::seed_tracked_files() {
+
+  if [ "$_BASHUNIT_COVERAGE_SEEDED" = true ]; then
+    return 0
+  fi
+  _BASHUNIT_COVERAGE_SEEDED=true
+
+  [ -n "${BASHUNIT_COVERAGE_PATHS:-}" ] || return 0
+  [ -n "${_BASHUNIT_COVERAGE_TRACKED_FILES:-}" ] || return 0
+
+  local old_ifs="$IFS"
+  IFS=','
+  local path
+  for path in $BASHUNIT_COVERAGE_PATHS; do
+    [ -n "$path" ] || continue
+    IFS="$old_ifs"
+    bashunit::coverage::_seed_one_path "$path"
+    IFS=','
+  done
+  IFS="$old_ifs"
+}
+
+function bashunit::coverage::_seed_one_path() {
+  local path="$1"
+  local root
+
+  case "$path" in
+  /*) root="$path" ;;
+  *) root="$(pwd)/$path" ;;
+  esac
+
+  if [ -f "$root" ]; then
+    root="$(bashunit::coverage::normalize_path "$root")"
+    bashunit::coverage::_seed_emit "$root"
+    return 0
+  fi
+  [ -d "$root" ] || return 0
+  root="$(cd "$root" && pwd)"
+
+  local file
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    bashunit::coverage::_seed_emit "$file"
+  done < <(find "$root" -type f -name '*.sh' 2>/dev/null)
+}
+
+function bashunit::coverage::_seed_emit() {
+  local file="$1"
+  local old_ifs="$IFS"
+  IFS=','
+  local pattern
+  for pattern in ${BASHUNIT_COVERAGE_EXCLUDE:-}; do
+    case "$file" in
+    *$pattern*)
+      IFS="$old_ifs"
+      return 0
+      ;;
+    esac
+  done
+  IFS="$old_ifs"
+
+  printf '%s\n' "$file" >>"$_BASHUNIT_COVERAGE_TRACKED_FILES"
+}
+
+_BASHUNIT_COVERAGE_DISKCACHE_FILE=""
+_BASHUNIT_COVERAGE_DISKCACHE_KEYS=()
+_BASHUNIT_COVERAGE_DISKCACHE_VALUES=()
+_BASHUNIT_COVERAGE_DISKCACHE_COUNT=0
+
+function bashunit::coverage::_diskcache_load() {
+  local cache_file="$1"
+  [ "$_BASHUNIT_COVERAGE_DISKCACHE_FILE" = "$cache_file" ] && return 0
+
+  _BASHUNIT_COVERAGE_DISKCACHE_FILE="$cache_file"
+  _BASHUNIT_COVERAGE_DISKCACHE_KEYS=()
+  _BASHUNIT_COVERAGE_DISKCACHE_VALUES=()
+  _BASHUNIT_COVERAGE_DISKCACHE_COUNT=0
+  [ -f "$cache_file" ] || return 0
+
+  local line idx=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -n "$line" ] || continue
+    _BASHUNIT_COVERAGE_DISKCACHE_KEYS[idx]="${line%:*}"
+    _BASHUNIT_COVERAGE_DISKCACHE_VALUES[idx]="${line##*:}"
+    idx=$((idx + 1))
+  done <"$cache_file"
+  _BASHUNIT_COVERAGE_DISKCACHE_COUNT=$idx
+}
+
+_BASHUNIT_COVERAGE_DISKCACHE_OUT=""
+
+function bashunit::coverage::_diskcache_get() {
+  local file="$1" idx=0
+  while [ "$idx" -lt "$_BASHUNIT_COVERAGE_DISKCACHE_COUNT" ]; do
+    if [ "${_BASHUNIT_COVERAGE_DISKCACHE_KEYS[idx]}" = "$file" ]; then
+      _BASHUNIT_COVERAGE_DISKCACHE_OUT="${_BASHUNIT_COVERAGE_DISKCACHE_VALUES[idx]}"
+      return 0
+    fi
+    idx=$((idx + 1))
+  done
+  return 1
+}
+
+function bashunit::coverage::_diskcache_put() {
+  local cache_file="$1" file="$2" decision="$3"
+  { [ -n "$cache_file" ] && [ -f "$cache_file" ]; } || return 0
+
+  echo "${file}:${decision}" >>"$cache_file"
+  local idx="$_BASHUNIT_COVERAGE_DISKCACHE_COUNT"
+  _BASHUNIT_COVERAGE_DISKCACHE_KEYS[idx]="$file"
+  _BASHUNIT_COVERAGE_DISKCACHE_VALUES[idx]="$decision"
+  _BASHUNIT_COVERAGE_DISKCACHE_COUNT=$((idx + 1))
 }
 
 function bashunit::coverage::should_track() {
@@ -1934,14 +2513,14 @@ function bashunit::coverage::should_track() {
   if bashunit::parallel::is_enabled && [ -n "$cache_file" ]; then
     cache_file="${cache_file}.$$"
 
-    [ ! -f "$cache_file" ] && [ -d "$(dirname "$cache_file")" ] && : >"$cache_file"
+    if [ ! -f "$cache_file" ] && [ -d "${cache_file%/*}" ]; then
+      : >"$cache_file"
+    fi
   fi
-  if [ -n "$cache_file" ] && [ -f "$cache_file" ]; then
-    local cached_decision
-
-    cached_decision=$(grep "^${file}:" "$cache_file" 2>/dev/null | head -1) || true
-    if [ -n "$cached_decision" ]; then
-      [ "${cached_decision##*:}" = "1" ] && return 0 || return 1
+  if [ -n "$cache_file" ]; then
+    bashunit::coverage::_diskcache_load "$cache_file"
+    if bashunit::coverage::_diskcache_get "$file"; then
+      [ "$_BASHUNIT_COVERAGE_DISKCACHE_OUT" = "1" ] && return 0 || return 1
     fi
   fi
 
@@ -1956,7 +2535,7 @@ function bashunit::coverage::should_track() {
     *$pattern*)
       IFS="$old_ifs"
 
-      { [ -n "$cache_file" ] && [ -f "$cache_file" ]; } && echo "${file}:0" >>"$cache_file"
+      bashunit::coverage::_diskcache_put "$cache_file" "$file" "0"
       return 1
       ;;
     esac
@@ -1976,6 +2555,10 @@ function bashunit::coverage::should_track() {
       ;;
     esac
 
+    while [ "$resolved_path" != "${resolved_path//\/\//\/}" ]; do
+      resolved_path="${resolved_path//\/\//\/}"
+    done
+
     case "$normalized_file" in
     "$resolved_path"*)
       matched=true
@@ -1987,11 +2570,11 @@ function bashunit::coverage::should_track() {
 
   if [ "$matched" = "false" ]; then
 
-    { [ -n "$cache_file" ] && [ -f "$cache_file" ]; } && echo "${file}:0" >>"$cache_file"
+    bashunit::coverage::_diskcache_put "$cache_file" "$file" "0"
     return 1
   fi
 
-  { [ -n "$cache_file" ] && [ -f "$cache_file" ]; } && echo "${file}:1" >>"$cache_file"
+  bashunit::coverage::_diskcache_put "$cache_file" "$file" "1"
 
   local tracked_file="$_BASHUNIT_COVERAGE_TRACKED_FILES"
   if bashunit::parallel::is_enabled; then
@@ -2008,12 +2591,330 @@ function bashunit::coverage::should_track() {
   return 0
 }
 
-function bashunit::coverage::path_to_filename() {
+_BASHUNIT_COVERAGE_SAFE_NAME_OUT=""
+
+function bashunit::coverage::path_to_filename_to_slot() {
   local file="$1"
-  local display_file="${file#"$(pwd)"/}"
+  local display_file="${file#"$PWD"/}"
 
   local safe_name="${display_file//\//_}"
-  echo "${safe_name//./_}"
+  _BASHUNIT_COVERAGE_SAFE_NAME_OUT="${safe_name//./_}"
+}
+
+function bashunit::coverage::path_to_filename() {
+  bashunit::coverage::path_to_filename_to_slot "$1"
+  echo "$_BASHUNIT_COVERAGE_SAFE_NAME_OUT"
+}
+
+# src/coverage/rules_awk.sh
+
+_BASHUNIT_COVERAGE_AWK_RULES='
+# Whether a source line counts as executable. Mirrors
+# bashunit::coverage::is_executable_line, quirk for quirk.
+function bu_is_executable(line,   tmp, stripped, trimmed, first, rest, fn_rest, fn_name, cp_before, cp_after, i, c) {
+  # Empty means "nothing but SPACES": the reference strips spaces only, so a
+  # line of tabs is not empty and goes on to the rules below.
+  tmp = line
+  gsub(/ /, "", tmp)
+  if (tmp == "") { return 0 }
+
+  stripped = line
+  sub(/^[ \t]+/, "", stripped)
+  trimmed = stripped
+  sub(/[ \t]+$/, "", trimmed)
+
+  if (substr(trimmed, 1, 1) == "#") { return 0 }
+  if (trimmed == "{" || trimmed == "}" || trimmed == "\\") { return 0 }
+
+  # The first token ends at whitespace or at a `#`, so `done#note` still reads
+  # as the keyword `done`.
+  first = trimmed
+  sub(/[ \t].*$/, "", first)
+  sub(/#.*$/, "", first)
+
+  if (first == "then" || first == "else" || first == "fi" || first == "do" ||
+      first == "done" || first == "esac" || first == "in" || first == ";;" ||
+      first == ";;&" || first == ";&" || first == ")") {
+    rest = substr(trimmed, length(first) + 1)
+    sub(/^[ \t]+/, "", rest)
+    if (rest == "" || substr(rest, 1, 1) == "#") { return 0 }
+    # A loop terminator still terminates the loop when a redirection or a pipe
+    # follows: `done < file`, `done | sort`.
+    if (first == "done") { return 0 }
+  }
+
+  # Function declarations: `[function ]name()` with an optional trailing `{`,
+  # and no trailing comment.
+  if (index(trimmed, "()") > 0) {
+    fn_rest = trimmed
+    if (fn_rest ~ /^function[ \t]/) {
+      sub(/^function/, "", fn_rest)
+      sub(/^[ \t]+/, "", fn_rest)
+    }
+    if (substr(fn_rest, length(fn_rest), 1) == "{") {
+      fn_rest = substr(fn_rest, 1, length(fn_rest) - 1)
+      sub(/[ \t]+$/, "", fn_rest)
+    }
+    if (length(fn_rest) >= 2 && substr(fn_rest, length(fn_rest) - 1) == "()") {
+      fn_name = substr(fn_rest, 1, length(fn_rest) - 2)
+      sub(/[ \t]+$/, "", fn_name)
+      if (fn_name ~ /^[a-zA-Z_]/) {
+        # Every character after the first must be a name character; the
+        # reference accepts `:` so bashunit::fn() reads as a declaration.
+        for (i = 2; i <= length(fn_name); i++) {
+          c = substr(fn_name, i, 1)
+          if (c !~ /[a-zA-Z0-9_:]/) { return 1 }
+        }
+        return 0
+      }
+    }
+  }
+
+  # Case arms: something, then `)`, then end of line or a comment. The `)` only
+  # closes an arm when no `(` opened earlier on the line, so `x=$(foo)`,
+  # `((i++))` and `cmd <(sub)` stay statements (#1055).
+  if (index(trimmed, ")") > 0) {
+    cp_before = trimmed
+    sub(/\).*$/, "", cp_before)
+    if (cp_before != "" && index(cp_before, "(") == 0) {
+      cp_after = substr(trimmed, length(cp_before) + 2)
+      sub(/^[ \t]+/, "", cp_after)
+      if (cp_after == "" || substr(cp_after, 1, 1) == "#") { return 0 }
+    }
+  }
+
+  return 1
+}
+
+# Whether a source line ends with a line continuation: an odd number of
+# trailing backslashes, and not a comment. Lives here because both the LCOV
+# emitter and the stats pass propagate hits along a continuation chain (#722).
+function bu_ends_with_continuation(line,   lead, i, n) {
+  lead = line
+  sub(/^[ \t]+/, "", lead)
+  if (substr(lead, 1, 1) == "#") { return 0 }
+  n = 0
+  for (i = length(line); i >= 1; i--) {
+    if (substr(line, i, 1) == "\\") { n++ } else { break }
+  }
+  return (n % 2) == 1
+}
+'
+
+_BASHUNIT_COVERAGE_AWK_LCOV='
+# The guard is FILENAME, not the usual `FNR == NR`: a run with no recorded hits
+# passes an EMPTY first file, and `FNR == NR` is then true for the first record
+# of the SECOND file, which would swallow the source line 1.
+FILENAME == hitsfile {
+  # The hits block: "<lineno> <count>".
+  hits[$1] = $2
+  next
+}
+
+{
+  total++
+  src[total] = $0
+}
+
+END {
+  carry = 0
+  for (ln = 1; ln <= total; ln++) {
+    h = (ln in hits) ? hits[ln] + 0 : 0
+    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
+    if (h > 0 && bu_ends_with_continuation(src[ln])) { carry = h } else { carry = 0 }
+  }
+
+  executable = 0
+  hit = 0
+  for (ln = 1; ln <= total; ln++) {
+    if (!bu_is_executable(src[ln])) { continue }
+    executable++
+    h = (ln in hits) ? hits[ln] + 0 : 0
+    if (h > 0) { hit++ }
+    printf "DA:%s,%s\n", ln, h
+  }
+  printf "LF:%s\n", executable
+  printf "LH:%s\n", hit
+}
+'
+
+_BASHUNIT_COVERAGE_AWK_STATS='
+{
+  hitsfile = $0
+  sub(/\t.*$/, "", hitsfile)
+  src = $0
+  sub(/^[^\t]*\t/, "", src)
+
+  split("", hits)
+  if (hitsfile != "") {
+    while ((getline hline < hitsfile) > 0) {
+      split(hline, hp, " ")
+      hits[hp[1] + 0] = hp[2] + 0
+    }
+    close(hitsfile)
+  }
+
+  total = 0
+  split("", sl)
+  while ((getline sline < src) > 0) {
+    total++
+    sl[total] = sline
+  }
+  close(src)
+
+  # The DEBUG trap attributes a multi-line statement to its starting line, so
+  # the count carries forward across the backslash chain (#722).
+  carry = 0
+  for (ln = 1; ln <= total; ln++) {
+    h = (ln in hits) ? hits[ln] : 0
+    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
+    if (h > 0 && bu_ends_with_continuation(sl[ln])) { carry = h } else { carry = 0 }
+  }
+
+  executable = 0
+  hit = 0
+  for (ln = 1; ln <= total; ln++) {
+    if (!bu_is_executable(sl[ln])) { continue }
+    executable++
+    if ((ln in hits) && hits[ln] > 0) { hit++ }
+  }
+
+  print executable "\t" hit "\t" src
+}
+'
+
+_BASHUNIT_COVERAGE_AWK_LCOV_ALL='
+# An arm ran as often as its FIRST executable line did (#1061).
+function bu_arm_taken(s, e,   ln) {
+  for (ln = s; ln <= e; ln++) {
+    if (!bu_is_executable(sl[ln])) { continue }
+    return (ln in hits) ? hits[ln] : 0
+  }
+  return 0
+}
+
+BEGIN { print "TN:" }
+
+{
+  hitsfile = $0
+  sub(/\t.*$/, "", hitsfile)
+  src = $0
+  sub(/^[^\t]*\t/, "", src)
+
+  split("", hits)
+  if (hitsfile != "") {
+    while ((getline hline < hitsfile) > 0) {
+      split(hline, hp, " ")
+      hits[hp[1] + 0] = hp[2] + 0
+    }
+    close(hitsfile)
+  }
+
+  total = 0
+  split("", sl)
+  while ((getline sline < src) > 0) {
+    total++
+    sl[total] = sline
+  }
+  close(src)
+
+  # The DEBUG trap attributes a multi-line statement to its starting line, so
+  # the count carries forward across the backslash chain (#722).
+  carry = 0
+  for (ln = 1; ln <= total; ln++) {
+    h = (ln in hits) ? hits[ln] : 0
+    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
+    if (h > 0 && bu_ends_with_continuation(sl[ln])) { carry = h } else { carry = 0 }
+  }
+
+  bu_fn_reset()
+  bu_br_reset()
+  for (ln = 1; ln <= total; ln++) {
+    bu_fn_line(sl[ln], ln)
+    bu_br_line(sl[ln], ln)
+  }
+  bu_fn_finish(total)
+
+  print "SF:" src
+
+  # FN lines as we walk, the matching FNDA lines after them, per LCOV
+  # convention.
+  fn_hit = 0
+  fnda = ""
+  for (i = 1; i <= fn_count; i++) {
+    print "FN:" fns[i] "," fnn[i]
+    any = 0
+    for (ln = fns[i]; ln <= fne[i]; ln++) {
+      if ((ln in hits) && hits[ln] > 0) { any = 1; break }
+    }
+    fnda = fnda "FNDA:" any "," fnn[i] "\n"
+    if (any == 1) { fn_hit++ }
+  }
+  printf "%s", fnda
+  print "FNF:" fn_count
+  print "FNH:" fn_hit
+
+  br_total = 0
+  br_hit = 0
+  for (i = 1; i <= br_count; i++) {
+    n = split(br_arms[i], arms, ",")
+    for (a = 1; a <= n; a++) {
+      split(arms[a], se, ":")
+      taken = bu_arm_taken(se[1] + 0, se[2] + 0)
+      print "BRDA:" br_dec[i] "," (i - 1) "," (a - 1) "," taken
+      br_total++
+      if (taken > 0) { br_hit++ }
+    }
+  }
+  print "BRF:" br_total
+  print "BRH:" br_hit
+
+  executable = 0
+  hit = 0
+  for (ln = 1; ln <= total; ln++) {
+    if (!bu_is_executable(sl[ln])) { continue }
+    executable++
+    h = (ln in hits) ? hits[ln] : 0
+    if (h > 0) { hit++ }
+    print "DA:" ln "," h
+  }
+  print "LF:" executable
+  print "LH:" hit
+  print "end_of_record"
+}
+'
+
+function bashunit::coverage::awk_rules() {
+  printf '%s' "$_BASHUNIT_COVERAGE_AWK_RULES"
+}
+
+function bashunit::coverage::awk_lcov_lines() {
+  local file="$1"
+
+  bashunit::coverage::ensure_hits_aggregated
+  bashunit::coverage::hits_file_for "$file"
+  local hits_file="$_BASHUNIT_COVERAGE_HITS_FILE_OUT"
+  if [ -z "$hits_file" ] || [ ! -f "$hits_file" ]; then
+
+    hits_file="/dev/null"
+  fi
+
+  env LC_ALL=C "$AWK" -v hitsfile="$hits_file" \
+    "${_BASHUNIT_COVERAGE_AWK_RULES}${_BASHUNIT_COVERAGE_AWK_LCOV}" \
+    "$hits_file" "$file"
+}
+
+function bashunit::coverage::awk_file_stats() {
+  env LC_ALL=C "$AWK" \
+    "${_BASHUNIT_COVERAGE_AWK_RULES}${_BASHUNIT_COVERAGE_AWK_STATS}" \
+    "$1"
+}
+
+function bashunit::coverage::awk_lcov_report() {
+  env LC_ALL=C "$AWK" \
+    "${_BASHUNIT_COVERAGE_AWK_RULES}${_BASHUNIT_COVERAGE_AWK_FUNCTIONS}\
+${_BASHUNIT_COVERAGE_AWK_BRANCHES}${_BASHUNIT_COVERAGE_AWK_LCOV_ALL}" \
+    "$1"
 }
 
 # src/coverage/lines.sh
@@ -2086,7 +2987,7 @@ function bashunit::coverage::is_executable_line() {
   *')'*)
     local cp_before="${line%%')'*}"
     case "$cp_before" in
-    '' | *[\\]*) : ;;
+    '' | *'('*) : ;;
     *)
       local cp_after="${line#*')'}"
       cp_after="${cp_after#"${cp_after%%[![:space:]]*}"}"
@@ -2183,6 +3084,93 @@ function bashunit::coverage::_ends_with_continuation() {
   [ $((${#trailing} % 2)) -eq 1 ]
 }
 
+_BASHUNIT_COVERAGE_HITS_AGGREGATED=false
+_BASHUNIT_COVERAGE_HITS_FILE_OUT=""
+
+function bashunit::coverage::hits_file_for() {
+  _BASHUNIT_COVERAGE_HITS_FILE_OUT=""
+  [ -n "${_BASHUNIT_COVERAGE_DATA_FILE:-}" ] || return 0
+
+  local dir="${_BASHUNIT_COVERAGE_DATA_FILE%/*}/hits"
+  local name="${1//[^a-zA-Z0-9]/_}"
+  _BASHUNIT_COVERAGE_HITS_FILE_OUT="$dir/$name"
+}
+
+_BASHUNIT_COVERAGE_MANIFEST_OUT=""
+
+function bashunit::coverage::write_batch_manifest() {
+  _BASHUNIT_COVERAGE_MANIFEST_OUT=""
+
+  local data_dir="${_BASHUNIT_COVERAGE_DATA_FILE%/*}"
+  { [ -n "${_BASHUNIT_COVERAGE_DATA_FILE:-}" ] && [ -d "$data_dir" ]; } || return 1
+
+  bashunit::coverage::ensure_hits_aggregated
+
+  local manifest="$data_dir/$1"
+  local tracked=0 file
+  {
+    while IFS= read -r file; do
+      { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
+      tracked=$((tracked + 1))
+      bashunit::coverage::hits_file_for "$file"
+      printf '%s\t%s\n' "$_BASHUNIT_COVERAGE_HITS_FILE_OUT" "$file"
+    done < <(bashunit::coverage::get_tracked_files)
+  } >"$manifest" 2>/dev/null || return 1
+
+  if [ "$tracked" -gt 0 ]; then
+    _BASHUNIT_COVERAGE_MANIFEST_OUT="$manifest"
+  fi
+  return 0
+}
+
+function bashunit::coverage::invalidate_hits_aggregation() {
+  _BASHUNIT_COVERAGE_HITS_AGGREGATED=false
+
+  _BASHUNIT_COVERAGE_HITS_BY_LINE_FILE=""
+}
+
+function bashunit::coverage::ensure_hits_aggregated() {
+  if [ "$_BASHUNIT_COVERAGE_HITS_AGGREGATED" = true ]; then
+    return 0
+  fi
+  _BASHUNIT_COVERAGE_HITS_AGGREGATED=true
+
+  [ -n "${_BASHUNIT_COVERAGE_DATA_FILE:-}" ] || return 0
+  [ -f "$_BASHUNIT_COVERAGE_DATA_FILE" ] || return 0
+
+  local dir="${_BASHUNIT_COVERAGE_DATA_FILE%/*}/hits"
+  rm -rf "$dir" 2>/dev/null || true
+  mkdir -p "$dir" 2>/dev/null || return 0
+
+  env LC_ALL=C awk -v dir="$dir" '
+    {
+      i = length($0)
+      while (i > 0 && substr($0, i, 1) != ":") { i-- }
+      if (i == 0) { next }
+      path = substr($0, 1, i - 1)
+      line = substr($0, i + 1)
+      if (line !~ /^[0-9]+$/) { next }
+      key = path SUBSEP line
+      if (!(key in counts)) { order[++n] = key }
+      counts[key]++
+    }
+    END {
+      for (j = 1; j <= n; j++) {
+        split(order[j], parts, SUBSEP)
+        name = parts[1]
+        gsub(/[^a-zA-Z0-9]/, "_", name)
+        print parts[2], counts[order[j]] > (dir "/" name)
+      }
+      for (j = 1; j <= n; j++) {
+        split(order[j], parts, SUBSEP)
+        name = parts[1]
+        gsub(/[^a-zA-Z0-9]/, "_", name)
+        close(dir "/" name)
+      }
+    }
+  ' "$_BASHUNIT_COVERAGE_DATA_FILE" 2>/dev/null || true
+}
+
 function bashunit::coverage::get_all_line_hits() {
   local file="$1"
 
@@ -2190,15 +3178,22 @@ function bashunit::coverage::get_all_line_hits() {
     return
   fi
 
+  bashunit::coverage::ensure_hits_aggregated
+
   local -a counts=()
   local count lineno maxln=0
-  while read -r count lineno; do
-    if [ -n "$lineno" ]; then
-      counts[lineno]=$count
-      [ "$lineno" -gt "$maxln" ] && maxln=$lineno
-    fi
-  done < <(grep "^${file}:" "$_BASHUNIT_COVERAGE_DATA_FILE" 2>/dev/null |
-    cut -d: -f2 | sort | uniq -c)
+  local hits_file
+  bashunit::coverage::hits_file_for "$file"
+  hits_file=$_BASHUNIT_COVERAGE_HITS_FILE_OUT
+
+  if [ -n "$hits_file" ] && [ -f "$hits_file" ]; then
+    while read -r lineno count; do
+      if [ -n "$count" ]; then
+        counts[lineno]=$count
+        [ "$lineno" -gt "$maxln" ] && maxln=$lineno
+      fi
+    done <"$hits_file"
+  fi
 
   if [ "$maxln" -eq 0 ]; then
     return
@@ -2238,9 +3233,19 @@ function bashunit::coverage::get_all_line_hits() {
 
 declare -a _BASHUNIT_COVERAGE_HITS_BY_LINE
 
+_BASHUNIT_COVERAGE_HITS_BY_LINE_FILE=""
+
 function bashunit::coverage::load_hits_by_line() {
   local file="$1"
+
+  if [ -n "$file" ] && [ "$file" = "$_BASHUNIT_COVERAGE_HITS_BY_LINE_FILE" ]; then
+    return 0
+  fi
+
+  bashunit::coverage::ensure_hits_aggregated
+
   _BASHUNIT_COVERAGE_HITS_BY_LINE=()
+  _BASHUNIT_COVERAGE_HITS_BY_LINE_FILE="$file"
   local hl_lineno hl_count
   while IFS=: read -r hl_lineno hl_count; do
     [ -n "$hl_lineno" ] && _BASHUNIT_COVERAGE_HITS_BY_LINE[hl_lineno]=$hl_count
@@ -2260,95 +3265,184 @@ function bashunit::coverage::get_all_line_tests() {
 
 # src/coverage/functions.sh
 
+_BASHUNIT_COVERAGE_AWK_FUNCTIONS='
+BEGIN { SQ = sprintf("%c", 39) }
+
+# Scans one line under the quote and heredoc state carried over from the lines
+# before it -- a string or a heredoc body can span lines, so per-line state is
+# not enough. Sets nopen/nclose to the braces that are code, and code_start to
+# 1 when the line begins outside any string or heredoc, which is the only place
+# a declaration can start.
+function bu_scan(line,   i, n, c, rest, delim, q) {
+  nopen = 0
+  nclose = 0
+  code_start = (in_s == 0 && in_d == 0 && hd == "")
+
+  if (hd != "") {
+    rest = line
+    if (hd_strip) { sub(/^\t+/, "", rest) }
+    if (rest == hd) { hd = "" }
+    return
+  }
+
+  n = length(line)
+  for (i = 1; i <= n; i++) {
+    c = substr(line, i, 1)
+
+    if (in_s) {
+      # Single quotes take no escapes: the next one always closes.
+      if (c == SQ) { in_s = 0 }
+      continue
+    }
+    if (in_d) {
+      if (c == "\\") { i++; continue }
+      if (c == "\"") { in_d = 0 }
+      continue
+    }
+    if (c == "\\") { i++; continue }
+    if (c == SQ) { in_s = 1; continue }
+    if (c == "\"") { in_d = 1; continue }
+
+    # A `#` opens a comment only where bash opens one, at the start of a word,
+    # so ${x#foo} and a#b keep their braces.
+    if (c == "#") {
+      if (i == 1) { return }
+      q = substr(line, i - 1, 1)
+      if (q == " " || q == "\t" || q == ";" || q == "&" || q == "|" || q == "(") { return }
+      continue
+    }
+
+    if (c == "<" && substr(line, i + 1, 1) == "<") {
+      # `<<<` is a here-string: one line, no body. Consume all three so the
+      # second `<` cannot read as the start of a heredoc and swallow the file.
+      if (substr(line, i + 2, 1) == "<") { i = i + 2; continue }
+
+      rest = substr(line, i + 2)
+      hd_strip = 0
+      if (substr(rest, 1, 1) == "-") { hd_strip = 1; rest = substr(rest, 2) }
+      sub(/^[ \t]+/, "", rest)
+      q = substr(rest, 1, 1)
+      if (q == SQ || q == "\"") {
+        delim = substr(rest, 2)
+        if (index(delim, q) == 0) {
+          delim = ""
+        } else {
+          sub(q ".*$", "", delim)
+        }
+      } else {
+        delim = rest
+        sub(/[ \t;)&|<>].*$/, "", delim)
+      }
+      # The body starts on the next line, so nothing after the operator on this
+      # one can close the function.
+      if (delim != "") { hd = delim; return }
+      continue
+    }
+
+    if (c == "{") { nopen++ } else if (c == "}") { nclose++ }
+  }
+}
+
+# Feeds one line to the scanner, recording a declaration when it opens and its
+# span when the braces balance. A caller reads the records out of fnn/fns/fne,
+# which is what lets the per-file API below and the batch report share this.
+function bu_fn_line(line, lineno,   stripped, name, after, ok) {
+  bu_scan(line)
+
+  if (in_function == 0 && code_start) {
+    # Pattern 1: function name() { or function name {
+    # Pattern 2: name() { or name () {
+    stripped = line
+    sub(/^[ \t]+/, "", stripped)
+    if (stripped ~ /^function[ \t]/) {
+      sub(/^function/, "", stripped)
+      sub(/^[ \t]+/, "", stripped)
+    }
+
+    # The candidate name is the first word, ending at whitespace, `(` or `{`.
+    name = stripped
+    sub(/[ \t({].*$/, "", name)
+
+    if (name != "") {
+      ok = 1
+      # A candidate holding anything outside the identifier alphabet is not a
+      # function name. Cutting at the first `{` means `VAR="x${Y}"` yields
+      # `VAR="x$`, whose trailing `{Y}"` then looks like a body opener -- every
+      # such assignment became a phantom FN record, and one containing the
+      # record separator `|` shifted the fields and crashed the arithmetic in
+      # report_lcov (#936). Checking only the first character let all of that
+      # through.
+      if (name ~ /[^a-zA-Z0-9_:]/) {
+        ok = 0
+      } else if (name !~ /^[a-zA-Z_]/) {
+        ok = 0
+      } else {
+        # A declaration continues with `()` or `{`; a call does not.
+        after = substr(stripped, length(name) + 1)
+        sub(/^[ \t]+/, "", after)
+        if (substr(after, 1, 2) != "()" && substr(after, 1, 1) != "{") { ok = 0 }
+      }
+
+      if (ok) {
+        in_function = 1
+        current_fn = name
+        fn_start = lineno
+        brace_count = nopen - nclose
+        # Single-line function: braces balance on the same line, both present.
+        if (brace_count == 0 && nopen > 0 && nclose > 0) { bu_fn_emit(lineno) }
+        return
+      }
+    }
+  }
+
+  if (in_function == 1) {
+    brace_count = brace_count + nopen - nclose
+    if (brace_count <= 0) { bu_fn_emit(lineno) }
+  }
+}
+
+function bu_fn_emit(endline) {
+  fn_count++
+  fnn[fn_count] = current_fn
+  fns[fn_count] = fn_start
+  fne[fn_count] = endline
+  in_function = 0
+  current_fn = ""
+  brace_count = 0
+}
+
+# An unclosed function (should not happen in valid code) still gets a record,
+# ending at the last line, so a truncated file cannot drop one silently.
+function bu_fn_finish(lastline) {
+  if (in_function == 1 && current_fn != "") { bu_fn_emit(lastline) }
+}
+
+# Clears the per-file state: quote and heredoc carry-over, the open
+# declaration, and the records collected so far.
+function bu_fn_reset() {
+  in_s = 0; in_d = 0; hd = ""; hd_strip = 0
+  in_function = 0; current_fn = ""; brace_count = 0
+  fn_count = 0
+}
+'
+
+_BASHUNIT_COVERAGE_AWK_FUNCTIONS_MAIN='
+{ bu_fn_line($0, NR) }
+
+END {
+  bu_fn_finish(NR)
+  for (bu_i = 1; bu_i <= fn_count; bu_i++) {
+    print fnn[bu_i] "|" fns[bu_i] "|" fne[bu_i]
+  }
+}
+'
+
 function bashunit::coverage::extract_functions() {
-  local file="$1"
-
-  local lineno=0
-  local in_function=0
-  local brace_count=0
-  local current_fn=""
-  local fn_start=0
-  local line
-
-  while IFS= read -r line || [ -n "$line" ]; do
-    ((++lineno))
-
-    if [ "$in_function" -eq 0 ]; then
-      local fn_name=""
-
-      local stripped="${line#"${line%%[![:space:]]*}"}"
-
-      case "$stripped" in
-      function[\ \	]*)
-        stripped="${stripped#function}"
-        stripped="${stripped#"${stripped%%[![:space:]]*}"}"
-        ;;
-      esac
-
-      fn_name="${stripped%%[[:space:]\(\{]*}"
-
-      if [ -n "$fn_name" ]; then
-        case "$fn_name" in
-
-        *[!a-zA-Z0-9_:]*) fn_name="" ;;
-        [a-zA-Z_]*)
-          local after_name="${stripped#"$fn_name"}"
-          after_name="${after_name#"${after_name%%[![:space:]]*}"}"
-          case "$after_name" in
-          '()'* | '{'*) ;;
-          *) fn_name="" ;;
-          esac
-          ;;
-        *) fn_name="" ;;
-        esac
-      fi
-
-      if [ -n "$fn_name" ]; then
-        in_function=1
-        current_fn="$fn_name"
-        fn_start=$lineno
-        brace_count=0
-
-        local open_braces="${line//[^\{]/}"
-        local close_braces="${line//[^\}]/}"
-        local open_count=${#open_braces}
-        local close_count=${#close_braces}
-        brace_count=$((brace_count + open_count - close_count))
-
-        if [ "$brace_count" -eq 0 ] && [ "$open_count" -gt 0 ] && [ "$close_count" -gt 0 ]; then
-          echo "${current_fn}|${fn_start}|${lineno}"
-          in_function=0
-          current_fn=""
-        fi
-        continue
-      fi
-    fi
-
-    if [ "$in_function" -eq 1 ]; then
-      local open_braces="${line//[^\{]/}"
-      local close_braces="${line//[^\}]/}"
-      brace_count=$((brace_count + ${#open_braces} - ${#close_braces}))
-
-      if [ "$brace_count" -le 0 ]; then
-        echo "${current_fn}|${fn_start}|${lineno}"
-        in_function=0
-        current_fn=""
-        brace_count=0
-      fi
-    fi
-  done <"$file"
-
-  if [ "$in_function" -eq 1 ] && [ -n "$current_fn" ]; then
-    echo "${current_fn}|${fn_start}|${lineno}"
-  fi
+  env LC_ALL=C "$AWK" \
+    "${_BASHUNIT_COVERAGE_AWK_FUNCTIONS}${_BASHUNIT_COVERAGE_AWK_FUNCTIONS_MAIN}" "$1"
 }
 
 # src/coverage/engine.sh
-
-_BASHUNIT_COVERAGE_BUFFER=""
-_BASHUNIT_COVERAGE_BUFFER_COUNT=0
-_BASHUNIT_COVERAGE_BUFFER_LIMIT=100
-_BASHUNIT_COVERAGE_HITS_BUFFER=""
 
 _BASHUNIT_COVERAGE_XTRACE_FS=$'\034'
 
@@ -2379,7 +3473,17 @@ function bashunit::coverage::enable_trap() {
 
   set -T
 
-  trap 'bashunit::coverage::record_line "${BASH_SOURCE[0]:-}" "${LINENO:-}"' DEBUG
+  local record='bashunit::coverage::record_line "${BASH_SOURCE[0]:-}" "${LINENO:-}"'
+  if [ -n "${_BASHUNIT_COVERAGE_TRAP_GLOB:-}" ]; then
+
+    local guarded='case "${BASH_SOURCE[0]:-}" in '
+    guarded="$guarded${_BASHUNIT_COVERAGE_TRAP_GLOB}) $record ;; esac"
+
+    trap "$guarded" DEBUG
+  else
+
+    trap "$record" DEBUG
+  fi
 }
 
 function bashunit::coverage::disable_trap() {
@@ -2390,8 +3494,6 @@ function bashunit::coverage::disable_trap() {
 
   trap - DEBUG
   set +T
-
-  bashunit::coverage::flush_buffer
 }
 
 function bashunit::coverage::_enable_xtrace() {
@@ -2475,6 +3577,7 @@ substr($0, 1, 1) == fsc {
 '
 
 function bashunit::coverage::finalize() {
+  bashunit::coverage::invalidate_hits_aggregation
   if [ "${_BASHUNIT_COVERAGE_ENGINE_RESOLVED:-}" != "xtrace" ]; then
     return 0
   fi
@@ -2525,50 +3628,37 @@ function bashunit::coverage::record_line() {
 
   [ -z "$_BASHUNIT_COVERAGE_DATA_FILE" ] && return 0
 
-  case "$_BASHUNIT_COVERAGE_TRACK_CACHE" in
-  *"|${file}:0|"*) return 0 ;;
-  *"|${file}:1|"*) ;;
-  *)
-
+  local entry="" decision="" normalized_file=""
+  if bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_FILE_" "$file"; then
+    entry="$_BASHUNIT_COVERAGE_LOOKUP_OUT"
+    decision="${entry%% *}"
+    [ "$decision" = "0" ] && return 0
+    normalized_file="${entry#* }"
+  else
     if bashunit::coverage::should_track "$file"; then
-      _BASHUNIT_COVERAGE_TRACK_CACHE="${_BASHUNIT_COVERAGE_TRACK_CACHE}|${file}:1|"
+      decision=1
+      normalized_file=$(bashunit::coverage::normalize_path "$file")
+      bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_FILE_" "$file" \
+        "1 $normalized_file"
     else
-      _BASHUNIT_COVERAGE_TRACK_CACHE="${_BASHUNIT_COVERAGE_TRACK_CACHE}|${file}:0|"
+      bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_FILE_" "$file" "0"
       return 0
     fi
-    ;;
-  esac
+  fi
 
-  local normalized_file=""
-  case "$_BASHUNIT_COVERAGE_PATH_CACHE" in
-  *"|${file}="*)
-
-    normalized_file="${_BASHUNIT_COVERAGE_PATH_CACHE#*"|${file}="}"
-    normalized_file="${normalized_file%%"|"*}"
-    ;;
-  *)
-    normalized_file=$(bashunit::coverage::normalize_path "$file")
-    _BASHUNIT_COVERAGE_PATH_CACHE="${_BASHUNIT_COVERAGE_PATH_CACHE}|${file}=${normalized_file}|"
-    ;;
-  esac
-
-  _BASHUNIT_COVERAGE_BUFFER="${_BASHUNIT_COVERAGE_BUFFER}${normalized_file}:${lineno}
-"
+  bashunit::coverage::_resolve_output_files
+  builtin printf '%s:%s\n' "$normalized_file" "$lineno" \
+    >>"$_BASHUNIT_COVERAGE_DATA_TARGET_OUT"
 
   if [ -n "${_BASHUNIT_COVERAGE_CURRENT_TEST_FILE:-}" ] &&
     [ -n "${_BASHUNIT_COVERAGE_CURRENT_TEST_FN:-}" ]; then
-    _BASHUNIT_COVERAGE_HITS_BUFFER="${_BASHUNIT_COVERAGE_HITS_BUFFER}\
-${normalized_file}:${lineno}|\
-${_BASHUNIT_COVERAGE_CURRENT_TEST_FILE}:${_BASHUNIT_COVERAGE_CURRENT_TEST_FN}
-"
+    builtin printf '%s:%s|%s:%s\n' "$normalized_file" "$lineno" \
+      "$_BASHUNIT_COVERAGE_CURRENT_TEST_FILE" "$_BASHUNIT_COVERAGE_CURRENT_TEST_FN" \
+      >>"$_BASHUNIT_COVERAGE_HITS_TARGET_OUT"
   fi
 
-  _BASHUNIT_COVERAGE_BUFFER_COUNT=$((_BASHUNIT_COVERAGE_BUFFER_COUNT + 1))
-
-  if [ "$_BASHUNIT_COVERAGE_BUFFER_COUNT" -ge \
-    "$_BASHUNIT_COVERAGE_BUFFER_LIMIT" ]; then
-    bashunit::coverage::flush_buffer
-  fi
+  _BASHUNIT_COVERAGE_HITS_AGGREGATED=false
+  _BASHUNIT_COVERAGE_HITS_BY_LINE_FILE=""
 }
 
 function bashunit::coverage::_resolve_output_files() {
@@ -2591,24 +3681,11 @@ function bashunit::coverage::_resolve_output_files() {
 }
 
 function bashunit::coverage::flush_buffer() {
-  [ -z "$_BASHUNIT_COVERAGE_BUFFER" ] && return 0
-
-  bashunit::coverage::_resolve_output_files
-  local data_file="$_BASHUNIT_COVERAGE_DATA_TARGET_OUT"
-  local test_hits_file="$_BASHUNIT_COVERAGE_HITS_TARGET_OUT"
-
-  builtin printf '%s' "$_BASHUNIT_COVERAGE_BUFFER" >>"$data_file"
-
-  if [ -n "$_BASHUNIT_COVERAGE_HITS_BUFFER" ]; then
-    builtin printf '%s' "$_BASHUNIT_COVERAGE_HITS_BUFFER" >>"$test_hits_file"
-  fi
-
-  _BASHUNIT_COVERAGE_BUFFER=""
-  _BASHUNIT_COVERAGE_HITS_BUFFER=""
-  _BASHUNIT_COVERAGE_BUFFER_COUNT=0
+  bashunit::coverage::invalidate_hits_aggregation
 }
 
 function bashunit::coverage::aggregate_parallel() {
+  bashunit::coverage::invalidate_hits_aggregation
 
   local base_file="$_BASHUNIT_COVERAGE_DATA_FILE"
   local tracked_base="$_BASHUNIT_COVERAGE_TRACKED_FILES"
@@ -2659,23 +3736,40 @@ function bashunit::coverage::cleanup() {
 
 # src/coverage/stats.sh
 
-function bashunit::coverage::get_coverage_class() {
+_BASHUNIT_COVERAGE_CLASS_OUT=""
+_BASHUNIT_COVERAGE_COLOR_OUT=""
+
+_BASHUNIT_COVERAGE_TOTAL_EXEC_OUT=0
+_BASHUNIT_COVERAGE_TOTAL_HIT_OUT=0
+
+function bashunit::coverage::class_to_slot() {
   local pct="$1"
   if [ "$pct" -ge "${BASHUNIT_COVERAGE_THRESHOLD_HIGH:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_HIGH}" ]; then
-    echo "high"
+    _BASHUNIT_COVERAGE_CLASS_OUT="high"
   elif [ "$pct" -ge "${BASHUNIT_COVERAGE_THRESHOLD_LOW:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_LOW}" ]; then
-    echo "medium"
+    _BASHUNIT_COVERAGE_CLASS_OUT="medium"
   else
-    echo "low"
+    _BASHUNIT_COVERAGE_CLASS_OUT="low"
   fi
 }
 
-function bashunit::coverage::get_color_for_class() {
+function bashunit::coverage::color_to_slot() {
   case "$1" in
-  high) printf '%s' "$_BASHUNIT_COLOR_PASSED" ;;
-  medium) printf '%s' "$_BASHUNIT_COLOR_SKIPPED" ;;
-  low) printf '%s' "$_BASHUNIT_COLOR_FAILED" ;;
+  high) _BASHUNIT_COVERAGE_COLOR_OUT="$_BASHUNIT_COLOR_PASSED" ;;
+  medium) _BASHUNIT_COVERAGE_COLOR_OUT="$_BASHUNIT_COLOR_SKIPPED" ;;
+  low) _BASHUNIT_COVERAGE_COLOR_OUT="$_BASHUNIT_COLOR_FAILED" ;;
+  *) _BASHUNIT_COVERAGE_COLOR_OUT="" ;;
   esac
+}
+
+function bashunit::coverage::get_coverage_class() {
+  bashunit::coverage::class_to_slot "$1"
+  echo "$_BASHUNIT_COVERAGE_CLASS_OUT"
+}
+
+function bashunit::coverage::get_color_for_class() {
+  bashunit::coverage::color_to_slot "$1"
+  printf '%s' "$_BASHUNIT_COVERAGE_COLOR_OUT"
 }
 
 function bashunit::coverage::calculate_percentage() {
@@ -2697,12 +3791,22 @@ function bashunit::coverage::_compute_file_stats() {
   local file="$1"
   local stats
   stats=$(bashunit::coverage::compute_file_coverage "$file")
-  _BASHUNIT_COVERAGE_FILE_STATS_EXEC_OUT="${stats%%:*}"
-  _BASHUNIT_COVERAGE_FILE_STATS_HIT_OUT="${stats##*:}"
-  _BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT=$(bashunit::coverage::calculate_percentage \
-    "$_BASHUNIT_COVERAGE_FILE_STATS_HIT_OUT" "$_BASHUNIT_COVERAGE_FILE_STATS_EXEC_OUT")
-  _BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT=$(bashunit::coverage::get_coverage_class \
-    "$_BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT")
+  bashunit::coverage::_derive_file_stats "${stats%%:*}" "${stats##*:}"
+}
+
+function bashunit::coverage::_derive_file_stats() {
+  local executable="$1" hit="$2"
+  _BASHUNIT_COVERAGE_FILE_STATS_EXEC_OUT="$executable"
+  _BASHUNIT_COVERAGE_FILE_STATS_HIT_OUT="$hit"
+
+  local pct=0
+  if [ "$executable" -gt 0 ]; then
+    pct=$((hit * 100 / executable))
+  fi
+  _BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT="$pct"
+
+  bashunit::coverage::class_to_slot "$pct"
+  _BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT="$_BASHUNIT_COVERAGE_CLASS_OUT"
 }
 
 function bashunit::coverage::get_file_stats() {
@@ -2717,45 +3821,94 @@ _BASHUNIT_COVERAGE_STATS_HIT=()
 _BASHUNIT_COVERAGE_STATS_PCT=()
 _BASHUNIT_COVERAGE_STATS_CLASS=()
 _BASHUNIT_COVERAGE_STATS_COUNT=0
-_BASHUNIT_COVERAGE_STATS_LOOKUP=""
 
 function bashunit::coverage::precompute_file_stats() {
+
+  bashunit::coverage::seed_tracked_files
+
   _BASHUNIT_COVERAGE_STATS_FILES=()
   _BASHUNIT_COVERAGE_STATS_EXEC=()
   _BASHUNIT_COVERAGE_STATS_HIT=()
   _BASHUNIT_COVERAGE_STATS_PCT=()
   _BASHUNIT_COVERAGE_STATS_CLASS=()
   _BASHUNIT_COVERAGE_STATS_COUNT=0
-  _BASHUNIT_COVERAGE_STATS_LOOKUP=""
+  bashunit::coverage::reset_lookup_namespace "_BASHUNIT_COVLOOKUP_STATS_"
+
+  if bashunit::coverage::_precompute_batch; then
+    return 0
+  fi
 
   local file
   while IFS= read -r file; do
     { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
 
     bashunit::coverage::_compute_file_stats "$file"
-
-    local idx="$_BASHUNIT_COVERAGE_STATS_COUNT"
-    _BASHUNIT_COVERAGE_STATS_FILES[idx]="$file"
-    _BASHUNIT_COVERAGE_STATS_EXEC[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_EXEC_OUT"
-    _BASHUNIT_COVERAGE_STATS_HIT[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_HIT_OUT"
-    _BASHUNIT_COVERAGE_STATS_PCT[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT"
-    _BASHUNIT_COVERAGE_STATS_CLASS[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT"
-    _BASHUNIT_COVERAGE_STATS_COUNT=$((idx + 1))
-    _BASHUNIT_COVERAGE_STATS_LOOKUP="${_BASHUNIT_COVERAGE_STATS_LOOKUP}|${file}=${idx}|"
+    bashunit::coverage::_record_file_stats "$file" \
+      "$_BASHUNIT_COVERAGE_FILE_STATS_EXEC_OUT" "$_BASHUNIT_COVERAGE_FILE_STATS_HIT_OUT"
   done < <(bashunit::coverage::get_tracked_files)
+}
+
+function bashunit::coverage::_record_file_stats() {
+  local file="$1"
+  bashunit::coverage::_derive_file_stats "$2" "$3"
+
+  local idx="$_BASHUNIT_COVERAGE_STATS_COUNT"
+  _BASHUNIT_COVERAGE_STATS_FILES[idx]="$file"
+  _BASHUNIT_COVERAGE_STATS_EXEC[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_EXEC_OUT"
+  _BASHUNIT_COVERAGE_STATS_HIT[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_HIT_OUT"
+  _BASHUNIT_COVERAGE_STATS_PCT[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT"
+  _BASHUNIT_COVERAGE_STATS_CLASS[idx]="$_BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT"
+  _BASHUNIT_COVERAGE_STATS_COUNT=$((idx + 1))
+  bashunit::coverage::lookup_put "_BASHUNIT_COVLOOKUP_STATS_" "$file" "$idx"
+}
+
+function bashunit::coverage::_precompute_batch() {
+  bashunit::coverage::write_batch_manifest "stats-manifest" || return 1
+  local manifest="$_BASHUNIT_COVERAGE_MANIFEST_OUT"
+
+  if [ -z "$manifest" ]; then
+
+    return 0
+  fi
+
+  local executable hit file
+  while IFS="$(printf '\t')" read -r executable hit file; do
+    [ -n "$file" ] || continue
+    bashunit::coverage::_record_file_stats "$file" "$executable" "$hit"
+  done < <(bashunit::coverage::awk_file_stats "$manifest" 2>/dev/null)
+
+  [ "$_BASHUNIT_COVERAGE_STATS_COUNT" -gt 0 ]
+}
+
+function bashunit::coverage::cached_stats_to_slots() {
+  local file="$1"
+
+  if bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_STATS_" "$file"; then
+    local idx="$_BASHUNIT_COVERAGE_LOOKUP_OUT"
+    _BASHUNIT_COVERAGE_SPLIT_EXEC_OUT="${_BASHUNIT_COVERAGE_STATS_EXEC[idx]}"
+    _BASHUNIT_COVERAGE_SPLIT_HIT_OUT="${_BASHUNIT_COVERAGE_STATS_HIT[idx]}"
+    _BASHUNIT_COVERAGE_SPLIT_PCT_OUT="${_BASHUNIT_COVERAGE_STATS_PCT[idx]}"
+    _BASHUNIT_COVERAGE_SPLIT_CLASS_OUT="${_BASHUNIT_COVERAGE_STATS_CLASS[idx]}"
+    return 0
+  fi
+
+  bashunit::coverage::_compute_file_stats "$file"
+  _BASHUNIT_COVERAGE_SPLIT_EXEC_OUT="$_BASHUNIT_COVERAGE_FILE_STATS_EXEC_OUT"
+  _BASHUNIT_COVERAGE_SPLIT_HIT_OUT="$_BASHUNIT_COVERAGE_FILE_STATS_HIT_OUT"
+  _BASHUNIT_COVERAGE_SPLIT_PCT_OUT="$_BASHUNIT_COVERAGE_FILE_STATS_PCT_OUT"
+  _BASHUNIT_COVERAGE_SPLIT_CLASS_OUT="$_BASHUNIT_COVERAGE_FILE_STATS_CLASS_OUT"
 }
 
 function bashunit::coverage::get_cached_stats() {
   local file="$1"
-  case "$_BASHUNIT_COVERAGE_STATS_LOOKUP" in
-  *"|${file}="*)
-    local idx="${_BASHUNIT_COVERAGE_STATS_LOOKUP#*"|${file}="}"
-    idx="${idx%%"|"*}"
+
+  if bashunit::coverage::lookup_get "_BASHUNIT_COVLOOKUP_STATS_" "$file"; then
+    local idx="$_BASHUNIT_COVERAGE_LOOKUP_OUT"
     echo "${_BASHUNIT_COVERAGE_STATS_EXEC[idx]}:${_BASHUNIT_COVERAGE_STATS_HIT[idx]}\
 :${_BASHUNIT_COVERAGE_STATS_PCT[idx]}:${_BASHUNIT_COVERAGE_STATS_CLASS[idx]}"
     return 0
-    ;;
-  esac
+  fi
+
   bashunit::coverage::get_file_stats "$file"
 }
 
@@ -2774,7 +3927,7 @@ function bashunit::coverage::split_stats() {
   _BASHUNIT_COVERAGE_SPLIT_CLASS_OUT="${rest#*:}"
 }
 
-function bashunit::coverage::get_percentage() {
+function bashunit::coverage::totals_to_slots() {
   local total_executable=0
   local total_hit=0
 
@@ -2797,7 +3950,14 @@ function bashunit::coverage::get_percentage() {
     done < <(bashunit::coverage::get_tracked_files)
   fi
 
-  bashunit::coverage::calculate_percentage "$total_hit" "$total_executable"
+  _BASHUNIT_COVERAGE_TOTAL_EXEC_OUT=$total_executable
+  _BASHUNIT_COVERAGE_TOTAL_HIT_OUT=$total_hit
+}
+
+function bashunit::coverage::get_percentage() {
+  bashunit::coverage::totals_to_slots
+  bashunit::coverage::calculate_percentage \
+    "$_BASHUNIT_COVERAGE_TOTAL_HIT_OUT" "$_BASHUNIT_COVERAGE_TOTAL_EXEC_OUT"
 }
 
 function bashunit::coverage::check_threshold() {
@@ -2810,12 +3970,29 @@ function bashunit::coverage::check_threshold() {
   if bashunit::coverage::is_diff_enabled && [ -n "$_BASHUNIT_COVERAGE_DIFF_PCT_OUT" ]; then
     pct="$_BASHUNIT_COVERAGE_DIFF_PCT_OUT"
   else
-    pct=$(bashunit::coverage::get_percentage)
+
+    bashunit::coverage::totals_to_slots
+    pct=$(bashunit::coverage::calculate_percentage \
+      "$_BASHUNIT_COVERAGE_TOTAL_HIT_OUT" "$_BASHUNIT_COVERAGE_TOTAL_EXEC_OUT")
   fi
 
   if [ "$pct" -lt "$BASHUNIT_COVERAGE_MIN" ]; then
-    printf "%sCoverage %d%% is below minimum %d%%%s\n" \
-      "$_BASHUNIT_COLOR_FAILED" "$pct" "$BASHUNIT_COVERAGE_MIN" "$_BASHUNIT_COLOR_DEFAULT"
+    local message
+    if [ "${_BASHUNIT_COVERAGE_TOTAL_EXEC_OUT:-0}" -eq 0 ]; then
+
+      message=$(printf "%sCoverage gate failed: no executable lines were tracked%s\n%s" \
+        "$_BASHUNIT_COLOR_FAILED" "$_BASHUNIT_COLOR_DEFAULT" \
+        "Check --coverage-paths (BASHUNIT_COVERAGE_PATHS): it matched no shell file with executable code.")
+    else
+      message=$(printf "%sCoverage %d%% is below minimum %d%%%s" \
+        "$_BASHUNIT_COLOR_FAILED" "$pct" "$BASHUNIT_COVERAGE_MIN" "$_BASHUNIT_COLOR_DEFAULT")
+    fi
+
+    if bashunit::env::is_machine_output_enabled; then
+      printf "%s\n" "$message" >&2
+    else
+      printf "%s\n" "$message"
+    fi
     return 1
   fi
 
@@ -2922,6 +4099,105 @@ function bashunit::coverage::_branch_emit_loop() {
   loop_depth=$idx
 }
 
+_BASHUNIT_COVERAGE_AWK_BRANCHES='
+function bu_br_append_arm(existing, s, e) {
+  return (existing == "") ? (s ":" e) : (existing "," s ":" e)
+}
+
+# A case-pattern opener ends with `)`, optionally followed by a comment. This
+# does not exclude a `(` earlier on the line -- the reference does not either.
+function bu_br_is_case_pattern(t,   before, after) {
+  if (index(t, ")") == 0) { return 0 }
+  before = t
+  sub(/\).*$/, "", before)
+  after = substr(t, length(before) + 2)
+  sub(/^[ \t]+/, "", after)
+  return (after == "" || substr(after, 1, 1) == "#")
+}
+
+function bu_br_add(decision, kind, arms) {
+  br_count++
+  br_dec[br_count] = decision
+  br_kind[br_count] = kind
+  br_arms[br_count] = arms
+}
+
+function bu_br_line(line, lineno,   trimmed, first, idx) {
+  trimmed = line
+  sub(/^[ \t]+/, "", trimmed)
+  if (trimmed == "" || substr(trimmed, 1, 1) == "#") { return }
+
+  first = trimmed
+  sub(/[ \t;].*$/, "", first)
+
+  if (first == "if") {
+    if_decision_line[if_depth] = lineno
+    if_arms[if_depth] = ""
+    if_arm_start[if_depth] = lineno + 1
+    if_depth++
+  } else if (first == "elif" || first == "else") {
+    if (if_depth > 0) {
+      idx = if_depth - 1
+      if_arms[idx] = bu_br_append_arm(if_arms[idx], if_arm_start[idx], lineno - 1)
+      if_arm_start[idx] = lineno + 1
+    }
+  } else if (first == "fi") {
+    if (if_depth > 0) {
+      idx = if_depth - 1
+      bu_br_add(if_decision_line[idx], "if", bu_br_append_arm(if_arms[idx], if_arm_start[idx], lineno - 1))
+      if_depth = idx
+    }
+  } else if (first == "case") {
+    case_decision_line[case_depth] = lineno
+    case_arms[case_depth] = ""
+    case_arm_start[case_depth] = 0
+    case_in_pattern[case_depth] = 0
+    case_depth++
+  } else if (first == "esac") {
+    if (case_depth > 0) {
+      idx = case_depth - 1
+      if (case_in_pattern[idx] == 1) {
+        case_arms[idx] = bu_br_append_arm(case_arms[idx], case_arm_start[idx], lineno - 1)
+        case_in_pattern[idx] = 0
+      }
+      if (case_arms[idx] != "") { bu_br_add(case_decision_line[idx], "case", case_arms[idx]) }
+      case_depth = idx
+    }
+  } else if (first == "while" || first == "until" || first == "for" || first == "select") {
+    loop_decision_line[loop_depth] = lineno
+    loop_arm_start[loop_depth] = lineno + 1
+    loop_depth++
+  } else if (first == "done") {
+    if (loop_depth > 0) {
+      idx = loop_depth - 1
+      bu_br_add(loop_decision_line[idx], "loop", loop_arm_start[idx] ":" (lineno - 1))
+      loop_depth = idx
+    }
+  } else if (case_depth > 0) {
+    idx = case_depth - 1
+    if (trimmed ~ /^;;&/ || trimmed ~ /^;;/ || trimmed ~ /^;&/) {
+      if (case_in_pattern[idx] == 1) {
+        case_arms[idx] = bu_br_append_arm(case_arms[idx], case_arm_start[idx], lineno - 1)
+        case_in_pattern[idx] = 0
+      }
+    } else if (bu_br_is_case_pattern(trimmed)) {
+      case_arm_start[idx] = lineno + 1
+      case_in_pattern[idx] = 1
+    }
+  }
+}
+
+# The depths must be numeric before they index anything: an uninitialised awk
+# variable is the empty string as a subscript, so the first push would land in
+# arr[""] and the matching pop would read arr[0].
+function bu_br_reset() {
+  if_depth = 0
+  case_depth = 0
+  loop_depth = 0
+  br_count = 0
+}
+'
+
 function bashunit::coverage::extract_branches() {
   local file="$1"
 
@@ -2991,10 +4267,8 @@ function bashunit::coverage::_arm_taken() {
   for ((ln = arm_start; ln <= arm_end; ln++)); do
     bashunit::coverage::is_executable_line \
       "${src_lines[$((ln - 1))]:-}" "$ln" || continue
-    if [ "${_BASHUNIT_COVERAGE_HITS_BY_LINE[$ln]:-0}" -gt 0 ]; then
-      _BASHUNIT_ARM_TAKEN_OUT=1
-      return
-    fi
+    _BASHUNIT_ARM_TAKEN_OUT="${_BASHUNIT_COVERAGE_HITS_BY_LINE[$ln]:-0}"
+    return
   done
   _BASHUNIT_ARM_TAKEN_OUT=0
 }
@@ -3041,6 +4315,13 @@ function bashunit::coverage::print_engine_notice() {
 
   if bashunit::env::is_verbose_enabled; then
     printf "Coverage engine: %s\n" "$(bashunit::coverage::engine_in_use)"
+
+    if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+      printf "%sNote: Bash %s.%s does not report lines run inside a subshell; \
+coverage may read lower than on Bash 4+.%s\n" \
+        "$_BASHUNIT_COLOR_INCOMPLETE" "${BASH_VERSINFO[0]}" "${BASH_VERSINFO[1]}" \
+        "$_BASHUNIT_COLOR_DEFAULT"
+    fi
   fi
 }
 
@@ -3075,7 +4356,8 @@ function bashunit::coverage::report_text() {
     total_hit=$((total_hit + hit))
 
     local color reset="$_BASHUNIT_COLOR_DEFAULT"
-    color=$(bashunit::coverage::get_color_for_class "$class")
+    bashunit::coverage::color_to_slot "$class"
+    color="$_BASHUNIT_COVERAGE_COLOR_OUT"
 
     local display_file="${file#"$(pwd)"/}"
     printf "%s%-40s %3d/%3d lines (%3d%%)%s\n" \
@@ -3092,10 +4374,12 @@ function bashunit::coverage::report_text() {
 
   local total_pct total_class
   total_pct=$(bashunit::coverage::calculate_percentage "$total_hit" "$total_executable")
-  total_class=$(bashunit::coverage::get_coverage_class "$total_pct")
+  bashunit::coverage::class_to_slot "$total_pct"
+  total_class="$_BASHUNIT_COVERAGE_CLASS_OUT"
 
   local color reset="$_BASHUNIT_COLOR_DEFAULT"
-  color=$(bashunit::coverage::get_color_for_class "$total_class")
+  bashunit::coverage::color_to_slot "$total_class"
+  color="$_BASHUNIT_COVERAGE_COLOR_OUT"
 
   printf "%sTotal: %d/%d (%d%%)%s\n" \
     "$color" "$total_hit" "$total_executable" "$total_pct" "$reset"
@@ -3267,9 +4551,14 @@ function bashunit::coverage::report_text_functions() {
         [ "${_BASHUNIT_COVERAGE_HITS_BY_LINE[$ln]:-0}" -gt 0 ] && fn_hit=$((fn_hit + 1))
       done
 
-      fn_pct=$(bashunit::coverage::calculate_percentage "$fn_hit" "$fn_executable")
-      fn_class=$(bashunit::coverage::get_coverage_class "$fn_pct")
-      color=$(bashunit::coverage::get_color_for_class "$fn_class")
+      fn_pct=0
+      if [ "$fn_executable" -gt 0 ]; then
+        fn_pct=$((fn_hit * 100 / fn_executable))
+      fi
+      bashunit::coverage::class_to_slot "$fn_pct"
+      fn_class="$_BASHUNIT_COVERAGE_CLASS_OUT"
+      bashunit::coverage::color_to_slot "$fn_class"
+      color="$_BASHUNIT_COVERAGE_COLOR_OUT"
 
       printf "  %s%-38s %3d/%3d lines (%3d%%)%s\n" \
         "$color" "$fn_name" "$fn_hit" "$fn_executable" "$fn_pct" "$reset"
@@ -3329,6 +4618,43 @@ function bashunit::coverage::changed_line_stats() {
   echo "${total}:${hit}"
 }
 
+function bashunit::coverage::diff_files() {
+  local base=$1
+  local changed
+  changed="$(bashunit::helper::git_changed_files "$base")"
+  [ -n "$changed" ] || return 0
+
+  local tracked
+  tracked="$(bashunit::coverage::get_tracked_files)"
+
+  local file normalized
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    [ -f "$file" ] || continue
+
+    normalized="$(bashunit::coverage::normalize_path "$file")"
+    case "$file" in
+    *.sh) ;;
+    *)
+      case "
+$tracked
+" in
+      *"
+$normalized
+"*) ;;
+      *) continue ;;
+      esac
+      ;;
+    esac
+
+    if bashunit::coverage::should_track "$file"; then
+      printf '%s\n' "$normalized"
+    fi
+  done <<EOF
+$changed
+EOF
+}
+
 function bashunit::coverage::report_diff() {
   local base
   base="$(bashunit::coverage::diff_base)"
@@ -3354,13 +4680,14 @@ function bashunit::coverage::report_diff() {
     total_hit=$((total_hit + hit))
 
     pct=$(bashunit::coverage::diff_percentage "$changed" "$hit")
-    color=$(bashunit::coverage::get_color_for_class \
-      "$(bashunit::coverage::get_coverage_class "$pct")")
+    bashunit::coverage::class_to_slot "$pct"
+    bashunit::coverage::color_to_slot "$_BASHUNIT_COVERAGE_CLASS_OUT"
+    color="$_BASHUNIT_COVERAGE_COLOR_OUT"
 
     local display_file="${file#"$(pwd)"/}"
     printf "%s%-40s %3d/%3d lines (%3d%%)%s\n" \
       "$color" "$display_file" "$hit" "$changed" "$pct" "$reset"
-  done < <(bashunit::coverage::get_tracked_files)
+  done < <(bashunit::coverage::diff_files "$base")
 
   if [ "$has_files" = false ]; then
     echo "No changed executable lines."
@@ -3369,8 +4696,9 @@ function bashunit::coverage::report_diff() {
   echo "---------------"
   local total_pct
   total_pct=$(bashunit::coverage::diff_percentage "$total_changed" "$total_hit")
-  color=$(bashunit::coverage::get_color_for_class \
-    "$(bashunit::coverage::get_coverage_class "$total_pct")")
+  bashunit::coverage::class_to_slot "$total_pct"
+  bashunit::coverage::color_to_slot "$_BASHUNIT_COVERAGE_CLASS_OUT"
+  color="$_BASHUNIT_COVERAGE_COLOR_OUT"
   printf "%sTotal: %d/%d (%d%%)%s\n" \
     "$color" "$total_hit" "$total_changed" "$total_pct" "$reset"
 
@@ -3389,6 +4717,17 @@ function bashunit::coverage::report_lcov() {
   fi
 
   mkdir -p "$(dirname "$output_file")"
+
+  if bashunit::coverage::write_batch_manifest "lcov-manifest"; then
+    if [ -z "$_BASHUNIT_COVERAGE_MANIFEST_OUT" ]; then
+      echo "TN:" >"$output_file"
+      return 0
+    fi
+    if bashunit::coverage::awk_lcov_report "$_BASHUNIT_COVERAGE_MANIFEST_OUT" \
+      >"$output_file" 2>/dev/null && [ -s "$output_file" ]; then
+      return 0
+    fi
+  fi
 
   {
     echo "TN:"
@@ -3439,31 +4778,24 @@ function bashunit::coverage::report_lcov() {
       echo "BRF:$br_total"
       echo "BRH:$br_hit"
 
-      local lineno=0 executable=0 hit=0 line
-      local -a lcov_lines=()
-      local _lli=0 _ll
-      while IFS= read -r _ll || [ -n "$_ll" ]; do
-        lcov_lines[_lli]="$_ll"
-        ((++_lli))
-      done <"$file"
-
-      for line in "${lcov_lines[@]}"; do
-        ((++lineno))
-        bashunit::coverage::is_executable_line "$line" "$lineno" || continue
-        ((++executable))
-        local lh="${_BASHUNIT_COVERAGE_HITS_BY_LINE[$lineno]:-0}"
-        [ "$lh" -gt 0 ] && ((++hit))
-        echo "DA:${lineno},${lh}"
-      done
-
-      echo "LF:$executable"
-      echo "LH:$hit"
+      bashunit::coverage::awk_lcov_lines "$file"
       echo "end_of_record"
     done < <(bashunit::coverage::get_tracked_files)
   } >"$output_file"
 }
 
 # src/coverage/report_cobertura.sh
+
+_BASHUNIT_COBERTURA_ESCAPED_OUT=""
+function bashunit::coverage::__cobertura_escape() {
+  case "$1" in
+  *[\&\<\>\"]*)
+    _BASHUNIT_COBERTURA_ESCAPED_OUT=$(printf '%s' "$1" |
+      sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/"/\&quot;/g')
+    ;;
+  *) _BASHUNIT_COBERTURA_ESCAPED_OUT="$1" ;;
+  esac
+}
 
 _BASHUNIT_COBERTURA_RATE_OUT=""
 function bashunit::coverage::__cobertura_rate() {
@@ -3588,7 +4920,13 @@ condition-coverage=\"${cond_pct}% (${taken}/${arms})\"/>
     bashunit::coverage::__cobertura_rate "$file_br_taken" "$file_br"
     class_branch_rate=$_BASHUNIT_COBERTURA_RATE_OUT
 
-    pkg_classes[p]="${pkg_classes[p]}        <class name=\"$class_name\" filename=\"$rel\" \
+    local esc_class esc_rel
+    bashunit::coverage::__cobertura_escape "$class_name"
+    esc_class=$_BASHUNIT_COBERTURA_ESCAPED_OUT
+    bashunit::coverage::__cobertura_escape "$rel"
+    esc_rel=$_BASHUNIT_COBERTURA_ESCAPED_OUT
+
+    pkg_classes[p]="${pkg_classes[p]}        <class name=\"$esc_class\" filename=\"$esc_rel\" \
 line-rate=\"$class_line_rate\" branch-rate=\"$class_branch_rate\" complexity=\"0.0\">
           <methods/>
           <lines>
@@ -3610,7 +4948,8 @@ $lines_xml          </lines>
       "branches-covered=\"$total_br_taken\" branches-valid=\"$total_br\"" \
       "complexity=\"0.0\" version=\"${BASHUNIT_VERSION:-0}\" timestamp=\"$timestamp\">"
     echo "  <sources>"
-    echo "    <source>$PWD</source>"
+    bashunit::coverage::__cobertura_escape "$PWD"
+    echo "    <source>$_BASHUNIT_COBERTURA_ESCAPED_OUT</source>"
     echo "  </sources>"
     echo "  <packages>"
 
@@ -3621,7 +4960,8 @@ $lines_xml          </lines>
       pkg_line_rate=$_BASHUNIT_COBERTURA_RATE_OUT
       bashunit::coverage::__cobertura_rate "${pkg_br_taken[$s]}" "${pkg_br_total[$s]}"
       pkg_branch_rate=$_BASHUNIT_COBERTURA_RATE_OUT
-      echo "    <package name=\"${pkg_names[$s]}\" line-rate=\"$pkg_line_rate\"" \
+      bashunit::coverage::__cobertura_escape "${pkg_names[$s]}"
+      echo "    <package name=\"$_BASHUNIT_COBERTURA_ESCAPED_OUT\" line-rate=\"$pkg_line_rate\"" \
         "branch-rate=\"$pkg_branch_rate\" complexity=\"0.0\">"
       echo "      <classes>"
       printf '%s' "${pkg_classes[$s]}"
@@ -3639,6 +4979,26 @@ $lines_xml          </lines>
 function bashunit::coverage::html_escape() {
   local text="$1"
   printf "%s" "$text" | sed "s/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g"
+}
+
+_BASHUNIT_COVERAGE_AWK_HTML_ESCAPE='
+{
+  gsub(/&/, "\\&amp;")
+  gsub(/</, "\\&lt;")
+  gsub(/>/, "\\&gt;")
+  print
+}
+'
+
+function bashunit::coverage::emit_block() {
+  local _line
+  while IFS= read -r _line || [ -n "$_line" ]; do
+    printf '%s\n' "$_line"
+  done
+}
+
+function bashunit::coverage::html_escape_file() {
+  env LC_ALL=C "$AWK" "$_BASHUNIT_COVERAGE_AWK_HTML_ESCAPE" "$1"
 }
 
 function bashunit::coverage::report_html() {
@@ -3660,9 +5020,8 @@ function bashunit::coverage::report_html() {
   while IFS= read -r file; do
     { [ -z "$file" ] || [ ! -f "$file" ]; } && continue
 
-    local stats executable hit pct
-    stats=$(bashunit::coverage::get_cached_stats "$file")
-    bashunit::coverage::split_stats "$stats"
+    local executable hit pct
+    bashunit::coverage::cached_stats_to_slots "$file"
     executable="$_BASHUNIT_COVERAGE_SPLIT_EXEC_OUT"
     hit="$_BASHUNIT_COVERAGE_SPLIT_HIT_OUT"
     pct="$_BASHUNIT_COVERAGE_SPLIT_PCT_OUT"
@@ -3670,11 +5029,12 @@ function bashunit::coverage::report_html() {
     total_executable=$((total_executable + executable))
     total_hit=$((total_hit + hit))
 
-    local display_file="${file#"$(pwd)"/}"
-    local safe_filename
-    safe_filename=$(bashunit::coverage::path_to_filename "$file")
+    local display_file="${file#"$PWD"/}"
+    bashunit::coverage::path_to_filename_to_slot "$file"
+    local safe_filename="$_BASHUNIT_COVERAGE_SAFE_NAME_OUT"
 
-    file_data[file_data_count]="$display_file|$hit|$executable|$pct|$safe_filename"
+    file_data[file_data_count]="$display_file$(printf '\037')$hit$(printf '\037')$executable"
+    file_data[file_data_count]="${file_data[file_data_count]}$(printf '\037')$pct$(printf '\037')$safe_filename"
     file_data_count=$((file_data_count + 1))
 
     bashunit::coverage::generate_file_html "$file" "$output_dir/files/${safe_filename}.html"
@@ -3721,7 +5081,8 @@ function bashunit::coverage::generate_index_html() {
   local gauge_offset=$((440 - (440 * total_pct / 100)))
 
   local total_class gauge_color_start gauge_color_end gauge_text_gradient
-  total_class=$(bashunit::coverage::get_coverage_class "$total_pct")
+  bashunit::coverage::class_to_slot "$total_pct"
+  total_class="$_BASHUNIT_COVERAGE_CLASS_OUT"
   case "$total_class" in
   high)
     gauge_color_start="#10b981"
@@ -3741,7 +5102,7 @@ function bashunit::coverage::generate_index_html() {
   esac
 
   {
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -3780,7 +5141,7 @@ function bashunit::coverage::generate_index_html() {
     .gauge-text { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; width: 100%; }
 EOF
     echo "    .gauge-percent { font-size: 3.5rem; font-weight: 800; background: ${gauge_text_gradient}; -webkit-background-clip: text; -webkit-text-fill-color: transparent; background-clip: text; line-height: 1; margin: 0; display: block; }"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
     .gauge-label { color: var(--text-secondary); font-size: 0.9rem; text-transform: uppercase; letter-spacing: 2px; margin: 0; display: block; }
     .gauge-info { flex: 1; }
     .gauge-title { font-size: 1.8rem; font-weight: 700; margin-bottom: 12px; }
@@ -3870,7 +5231,7 @@ EOF
         </div>
 EOF
     echo "        <div class=\"header-badge\">v${BASHUNIT_VERSION:-0.0.0}</div>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
       </div>
       <h1 class="header-title">Code Coverage Report</h1>
       <p class="header-subtitle">Comprehensive line-by-line coverage analysis for your bash scripts</p>
@@ -3885,18 +5246,18 @@ EOF
 EOF
     echo "              <stop offset=\"0%\" style=\"stop-color:${gauge_color_start}\"/>"
     echo "              <stop offset=\"100%\" style=\"stop-color:${gauge_color_end}\"/>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
             </linearGradient>
           </defs>
           <circle class="gauge-bg" cx="80" cy="80" r="70"/>
 EOF
     echo "          <circle class=\"gauge-fill\" cx=\"80\" cy=\"80\" r=\"70\" stroke-dasharray=\"440\" stroke-dashoffset=\"${gauge_offset}\"/>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </svg>
         <div class="gauge-text">
 EOF
     echo "          <div class=\"gauge-percent\">${total_pct}%</div>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           <div class="gauge-label">Coverage</div>
         </div>
       </div>
@@ -3904,7 +5265,7 @@ EOF
         <h2 class="gauge-title">Overall Code Coverage</h2>
 EOF
     echo "        <p class=\"gauge-description\"><strong>${total_hit} of ${total_executable}</strong> executable lines covered across <strong>${file_count} files</strong>.</p>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
 
         <div class="compact-metrics">
           <div class="metrics-group coverage-group">
@@ -3915,21 +5276,21 @@ EOF
                 <span class="breakdown-label">Total:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${total_executable} lines</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
               <div class="breakdown-item">
                 <span class="breakdown-dot covered"></span>
                 <span class="breakdown-label">Covered:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${total_hit} lines</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
               <div class="breakdown-item">
                 <span class="breakdown-dot uncovered"></span>
                 <span class="breakdown-label">Uncovered:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${total_uncovered} lines</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
             </div>
           </div>
@@ -3941,28 +5302,28 @@ EOF
                 <span class="breakdown-label">Files:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${file_count}</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
               <div class="breakdown-item">
                 <span class="breakdown-dot tests"></span>
                 <span class="breakdown-label">Tests:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${tests_total} total</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
               <div class="breakdown-item">
                 <span class="breakdown-dot tests-passed"></span>
                 <span class="breakdown-label">Passed:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${tests_passed}</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
               <div class="breakdown-item">
                 <span class="breakdown-dot tests-failed"></span>
                 <span class="breakdown-label">Failed:</span>
 EOF
     echo "                <span class=\"breakdown-value\">${tests_failed}</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
               </div>
             </div>
           </div>
@@ -3977,19 +5338,19 @@ EOF
             <span class="legend-color high"></span>
 EOF
     echo "            <span>≥${BASHUNIT_COVERAGE_THRESHOLD_HIGH:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_HIGH}% High</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           </div>
           <div class="legend-item">
             <span class="legend-color medium"></span>
 EOF
     echo "            <span>${BASHUNIT_COVERAGE_THRESHOLD_LOW:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_LOW}-${BASHUNIT_COVERAGE_THRESHOLD_HIGH:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_HIGH}% Medium</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           </div>
           <div class="legend-item">
             <span class="legend-color low"></span>
 EOF
     echo "            <span>&lt;${BASHUNIT_COVERAGE_THRESHOLD_LOW:-$_BASHUNIT_DEFAULT_COVERAGE_THRESHOLD_LOW}% Low</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           </div>
         </div>
       </div>
@@ -4006,17 +5367,24 @@ EOF
 EOF
 
     local data display_file hit executable pct safe_filename
+    local _us
+    _us=$(printf '\037')
     for data in ${file_data[@]+"${file_data[@]}"}; do
-      IFS='|' read -r display_file hit executable pct safe_filename <<<"$data"
+      IFS="$_us" read -r display_file hit executable pct safe_filename <<<"$data"
+
+      local esc_name esc_path
+      esc_name=$(bashunit::str::html_escape "${display_file##*/}")
+      esc_path=$(bashunit::str::html_escape "$display_file")
 
       local class
-      class=$(bashunit::coverage::get_coverage_class "$pct")
+      bashunit::coverage::class_to_slot "$pct"
+      class="$_BASHUNIT_COVERAGE_CLASS_OUT"
 
       echo "            <tr onclick=\"window.location='files/${safe_filename}.html'\">"
       echo "              <td>"
       echo "                <div class=\"file-info\">"
-      echo "                  <a href=\"files/${safe_filename}.html\" class=\"file-name\">$(basename "$display_file")</a>"
-      echo "                  <div class=\"file-path\">./${display_file}</div>"
+      echo "                  <a href=\"files/${safe_filename}.html\" class=\"file-name\">${esc_name}</a>"
+      echo "                  <div class=\"file-path\">./${esc_path}</div>"
       echo "                </div>"
       echo "              </td>"
       echo "              <td>"
@@ -4036,7 +5404,7 @@ EOF
       echo "            </tr>"
     done
 
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           </tbody>
         </table>
       </div>
@@ -4059,11 +5427,161 @@ EOF
 
 # src/coverage/html_file.sh
 
+_BASHUNIT_COVERAGE_AWK_HTML_ROWS='
+FILENAME == hitsfile {
+  hits[$1 + 0] = $2 + 0
+  next
+}
+
+FILENAME == testsfile {
+  # "<lineno>|<test_file>:<test_fn>", deduplicated, first-seen order kept.
+  p = index($0, "|")
+  if (p == 0) { next }
+  tln = substr($0, 1, p - 1) + 0
+  info = substr($0, p + 1)
+  key = tln SUBSEP info
+  if (key in seen) { next }
+  seen[key] = 1
+  tests[tln] = (tln in tests) ? tests[tln] "\n" info : info
+  next
+}
+
+{
+  total++
+  sl[total] = $0
+}
+
+function escape(t) {
+  gsub(/&/, "\\&amp;", t)
+  gsub(/</, "\\&lt;", t)
+  gsub(/>/, "\\&gt;", t)
+  return t
+}
+
+END {
+  # The DEBUG trap attributes a multi-line statement to its starting line, so
+  # the count carries forward across the backslash chain (#722).
+  carry = 0
+  for (ln = 1; ln <= total; ln++) {
+    h = (ln in hits) ? hits[ln] : 0
+    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
+    if (h > 0 && bu_ends_with_continuation(sl[ln])) { carry = h } else { carry = 0 }
+  }
+
+  for (ln = 1; ln <= total; ln++) {
+    row_class = ""
+    hits_display = ""
+
+    if (bu_is_executable(sl[ln])) {
+      h = (ln in hits) ? hits[ln] : 0
+      if (h > 0) {
+        row_class = "covered"
+        if (ln in tests) {
+          tooltip = "<div class=\"hits-tooltip\"><div class=\"hits-tooltip-title\">Tests hitting this line</div><ul class=\"hits-tooltip-list\">"
+          n = split(tests[ln], entries, "\n")
+          for (e = 1; e <= n; e++) {
+            if (entries[e] == "") { continue }
+            c = index(entries[e], ":")
+            if (c == 0) { tfile = entries[e]; tfn = "" } else { tfile = substr(entries[e], 1, c - 1); tfn = substr(entries[e], c + 1) }
+            sub(/^.*\//, "", tfile)
+            tooltip = tooltip "<li><span class=\"hits-tooltip-file\">" tfile "</span>:<span class=\"hits-tooltip-fn\">" tfn "</span></li>"
+          }
+          tooltip = tooltip "</ul></div>"
+          hits_display = "<span class=\"hits-badge has-tooltip\">" h times tooltip "</span>"
+        } else {
+          hits_display = "<span class=\"hits-badge\">" h times "</span>"
+        }
+      } else {
+        row_class = "uncovered"
+        hits_display = "<span class=\"hits-badge\">" h times "</span>"
+      }
+    }
+
+    printf "          <tr id=\"line-%s\" class=\"%s line-anchor\">\n", ln, row_class
+    printf "            <td class=\"line-num\">%s</td>\n", ln
+    printf "            <td class=\"hits\">%s</td>\n", hits_display
+    printf "            <td class=\"code\">%s</td>\n", escape(sl[ln])
+    printf "          </tr>\n"
+  }
+}
+'
+
+_BASHUNIT_COVERAGE_AWK_HTML_FUNCTIONS='
+FILENAME == hitsfile {
+  hits[$1 + 0] = $2 + 0
+  next
+}
+
+{
+  total++
+  sl[total] = $0
+}
+
+END {
+  carry = 0
+  for (ln = 1; ln <= total; ln++) {
+    h = (ln in hits) ? hits[ln] : 0
+    if (carry > 0 && h < carry) { h = carry; hits[ln] = h }
+    if (h > 0 && bu_ends_with_continuation(sl[ln])) { carry = h } else { carry = 0 }
+  }
+
+  bu_fn_reset()
+  for (ln = 1; ln <= total; ln++) { bu_fn_line(sl[ln], ln) }
+  bu_fn_finish(total)
+
+  for (i = 1; i <= fn_count; i++) {
+    executable = 0
+    hit = 0
+    for (ln = fns[i]; ln <= fne[i]; ln++) {
+      if (!bu_is_executable(sl[ln])) { continue }
+      executable++
+      if ((ln in hits) && hits[ln] > 0) { hit++ }
+    }
+    print fnn[i] "|" fns[i] "|" fne[i] "|" executable "|" hit
+  }
+}
+'
+
+function bashunit::coverage::html_function_rows() {
+  local file="$1"
+
+  bashunit::coverage::ensure_hits_aggregated
+  bashunit::coverage::hits_file_for "$file"
+  local hits_file="$_BASHUNIT_COVERAGE_HITS_FILE_OUT"
+  if [ -z "$hits_file" ] || [ ! -f "$hits_file" ]; then
+    hits_file="/dev/null"
+  fi
+
+  env LC_ALL=C "$AWK" -v hitsfile="$hits_file" \
+    "${_BASHUNIT_COVERAGE_AWK_RULES}${_BASHUNIT_COVERAGE_AWK_FUNCTIONS}\
+${_BASHUNIT_COVERAGE_AWK_HTML_FUNCTIONS}" \
+    "$hits_file" "$file"
+}
+
+function bashunit::coverage::html_code_rows() {
+  local file="$1" tests_file="$2"
+
+  bashunit::coverage::ensure_hits_aggregated
+  bashunit::coverage::hits_file_for "$file"
+  local hits_file="$_BASHUNIT_COVERAGE_HITS_FILE_OUT"
+  if [ -z "$hits_file" ] || [ ! -f "$hits_file" ]; then
+    hits_file="/dev/null"
+  fi
+
+  env LC_ALL=C "$AWK" -v hitsfile="$hits_file" -v testsfile="$tests_file" -v times="×" \
+    "${_BASHUNIT_COVERAGE_AWK_RULES}${_BASHUNIT_COVERAGE_AWK_HTML_ROWS}" \
+    "$hits_file" "$tests_file" "$file"
+}
+
 function bashunit::coverage::generate_file_html() {
   local file="$1"
   local output_file="$2"
 
-  local display_file="${file#"$(pwd)"/}"
+  local display_file="${file#"$PWD"/}"
+
+  local esc_file esc_base
+  esc_file=$(bashunit::str::html_escape "$display_file")
+  esc_base=$(bashunit::str::html_escape "${display_file##*/}")
   local executable hit pct class stats
   stats=$(bashunit::coverage::get_cached_stats "$file")
   bashunit::coverage::split_stats "$stats"
@@ -4082,41 +5600,24 @@ function bashunit::coverage::generate_file_html() {
     ((++_fli))
   done <"$file"
 
-  local -a tests_by_line=()
-  local _line_and_test
-  while IFS= read -r _line_and_test; do
-    [ -z "$_line_and_test" ] && continue
-    local _tln="${_line_and_test%%|*}"
-    local _tinfo="${_line_and_test#*|}"
-    if [ -n "${tests_by_line[_tln]:-}" ]; then
+  local tests_file="${_BASHUNIT_COVERAGE_DATA_FILE%/*}/page-tests"
+  if ! bashunit::coverage::get_all_line_tests "$file" >"$tests_file" 2>/dev/null; then
+    : >"$tests_file"
+  fi
 
-      case $'\n'"${tests_by_line[_tln]}"$'\n' in
-      *$'\n'"$_tinfo"$'\n'*)
-        # already present, skip
-        ;;
-      *)
-        tests_by_line[_tln]="${tests_by_line[_tln]}"$'\n'"${_tinfo}"
-        ;;
-      esac
-    else
-      tests_by_line[_tln]="$_tinfo"
-    fi
-  done < <(bashunit::coverage::get_all_line_tests "$file")
-
-  local total_lines
-  total_lines=$(wc -l <"$file" | tr -d ' ')
+  local total_lines="${#file_lines[@]}"
   local non_executable=$((total_lines - executable))
 
   {
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
 <!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 EOF
-    echo "  <title>$(basename "$display_file") | Coverage Report</title>"
-    cat <<'EOF'
+    echo "  <title>${esc_base} | Coverage Report</title>"
+    bashunit::coverage::emit_block <<'EOF'
   <style>
     :root {
       --primary: #6366f1; --primary-dark: #4f46e5; --primary-light: #818cf8;
@@ -4254,21 +5755,21 @@ EOF
         <a href="../index.html" class="back-btn">← Back to Overview</a>
         <div class="file-title">
 EOF
-    echo "          <span class=\"file-name\">$(basename "$display_file")</span>"
-    cat <<'EOF'
+    echo "          <span class=\"file-name\">${esc_base}</span>"
+    bashunit::coverage::emit_block <<'EOF'
         </div>
       </div>
       <div class="stats-section">
         <div class="stat-item">
 EOF
     echo "          <span class=\"stat-badge coverage $class\">${pct}%</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           <span class="stat-label">Coverage</span>
         </div>
         <div class="stat-item">
 EOF
     echo "          <span class=\"stat-badge lines\">${hit}/${executable}</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
           <span class="stat-label">Lines</span>
         </div>
       </div>
@@ -4281,12 +5782,12 @@ EOF
           <span class="progress-label">Line Coverage Progress</span>
 EOF
     echo "          <span class=\"progress-percent $class\">${pct}%</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </div>
         <div class="progress-bar">
 EOF
     echo "          <div class=\"progress-fill $class\" style=\"width: ${pct}%;\"></div>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </div>
       </div>
       <div class="legend">
@@ -4294,19 +5795,19 @@ EOF
           <span class="legend-color covered"></span>
 EOF
     echo "          <span>${hit} lines covered</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </div>
         <div class="legend-item">
           <span class="legend-color uncovered"></span>
 EOF
     echo "          <span>${uncovered} lines uncovered</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </div>
         <div class="legend-item">
           <span class="legend-color neutral"></span>
 EOF
     echo "          <span>${non_executable} non-executable</span>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </div>
       </div>
     </div>
@@ -4314,10 +5815,10 @@ EOF
 EOF
 
     local functions_data
-    functions_data=$(bashunit::coverage::extract_functions "$file")
+    functions_data=$(bashunit::coverage::html_function_rows "$file")
 
     if [ -n "$functions_data" ]; then
-      cat <<'EOF'
+      bashunit::coverage::emit_block <<'EOF'
   <div class="function-summary">
     <table class="function-table">
       <thead>
@@ -4332,30 +5833,24 @@ EOF
       local fn_entry
       while IFS= read -r fn_entry; do
         [ -z "$fn_entry" ] && continue
-        local fn_name fn_start fn_end
-        fn_name="${fn_entry%%|*}"
-        local rest="${fn_entry#*|}"
-        fn_start="${rest%%|*}"
-        fn_end="${rest#*|}"
 
-        local fn_executable=0
-        local fn_hit=0
-        local ln
-        for ((ln = fn_start; ln <= fn_end; ln++)); do
-          local ln_content
-          ln_content="${file_lines[$((ln - 1))]:-}"
-          if bashunit::coverage::is_executable_line "$ln_content" "$ln"; then
-            ((++fn_executable))
-            local ln_hits=${_BASHUNIT_COVERAGE_HITS_BY_LINE[$ln]:-0}
-            if [ "$ln_hits" -gt 0 ]; then
-              ((++fn_hit))
-            fi
-          fi
-        done
+        local fn_name fn_start fn_executable fn_hit rest
+        fn_name="${fn_entry%%|*}"
+        rest="${fn_entry#*|}"
+        fn_start="${rest%%|*}"
+
+        rest="${rest#*|}"
+        rest="${rest#*|}"
+        fn_executable="${rest%%|*}"
+        fn_hit="${rest#*|}"
 
         local fn_pct fn_class row_class
-        fn_pct=$(bashunit::coverage::calculate_percentage "$fn_hit" "$fn_executable")
-        fn_class=$(bashunit::coverage::get_coverage_class "$fn_pct")
+        fn_pct=0
+        if [ "$fn_executable" -gt 0 ]; then
+          fn_pct=$((fn_hit * 100 / fn_executable))
+        fi
+        bashunit::coverage::class_to_slot "$fn_pct"
+        fn_class="$_BASHUNIT_COVERAGE_CLASS_OUT"
         case "$fn_class" in
         high) row_class="fn-covered" ;;
         medium) row_class="fn-partial" ;;
@@ -4374,76 +5869,31 @@ EOF
         echo "        </tr>"
       done <<<"$functions_data"
 
-      cat <<'EOF'
+      bashunit::coverage::emit_block <<'EOF'
       </tbody>
     </table>
   </div>
 EOF
     fi
 
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
   <div class="code-container">
     <div class="code-wrapper">
       <div class="code-header">
 EOF
-    echo "        <span class=\"code-path\">./${display_file}</span>"
+    echo "        <span class=\"code-path\">./${esc_file}</span>"
     echo "        <div class=\"code-stats\">"
     echo "          <span>${total_lines} total lines</span>"
     echo "        </div>"
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
       </div>
       <div class="code-body">
         <table class="code-table">
 EOF
 
-    local lineno=0
-    local line
-    for line in "${file_lines[@]}"; do
-      ((++lineno))
+    bashunit::coverage::html_code_rows "$file" "$tests_file"
 
-      local escaped_line
-      escaped_line=$(bashunit::coverage::html_escape "$line")
-
-      local row_class=""
-      local hits_display=""
-
-      if bashunit::coverage::is_executable_line "$line" "$lineno"; then
-
-        local hits=${_BASHUNIT_COVERAGE_HITS_BY_LINE[$lineno]:-0}
-
-        if [ "$hits" -gt 0 ]; then
-          row_class="covered"
-
-          local test_info="${tests_by_line[$lineno]:-}"
-          if [ -n "$test_info" ]; then
-
-            local tooltip_html="<div class=\"hits-tooltip\"><div class=\"hits-tooltip-title\">Tests hitting this line</div><ul class=\"hits-tooltip-list\">"
-            local test_file test_fn
-            while IFS=':' read -r test_file test_fn; do
-              [ -z "$test_file" ] && continue
-              local short_file
-              short_file=$(basename "$test_file")
-              tooltip_html="$tooltip_html<li><span class=\"hits-tooltip-file\">${short_file}</span>:<span class=\"hits-tooltip-fn\">${test_fn}</span></li>"
-            done <<<"$test_info"
-            tooltip_html="$tooltip_html</ul></div>"
-            hits_display="<span class=\"hits-badge has-tooltip\">${hits}×${tooltip_html}</span>"
-          else
-            hits_display="<span class=\"hits-badge\">${hits}×</span>"
-          fi
-        else
-          row_class="uncovered"
-          hits_display="<span class=\"hits-badge\">${hits}×</span>"
-        fi
-      fi
-
-      echo "          <tr id=\"line-${lineno}\" class=\"$row_class line-anchor\">"
-      echo "            <td class=\"line-num\">$lineno</td>"
-      echo "            <td class=\"hits\">$hits_display</td>"
-      echo "            <td class=\"code\">$escaped_line</td>"
-      echo "          </tr>"
-    done
-
-    cat <<'EOF'
+    bashunit::coverage::emit_block <<'EOF'
         </table>
       </div>
     </div>
@@ -4581,6 +6031,7 @@ function bashunit::state::add_assertions_snapshot() {
 
 _BASHUNIT_DUPLICATED_FUNCTION_NAMES=""
 _BASHUNIT_FILE_WITH_DUPLICATED_FUNCTION_NAMES=""
+_BASHUNIT_DUPLICATED_FUNCTION_DETAILS=""
 _BASHUNIT_DUPLICATED_TEST_FUNCTIONS_FOUND=false
 
 function bashunit::state::is_duplicated_test_functions_found() {
@@ -4607,10 +6058,19 @@ function bashunit::state::set_file_with_duplicated_function_names() {
   _BASHUNIT_FILE_WITH_DUPLICATED_FUNCTION_NAMES="$1"
 }
 
+function bashunit::state::get_duplicated_function_details() {
+  echo "$_BASHUNIT_DUPLICATED_FUNCTION_DETAILS"
+}
+
+function bashunit::state::set_duplicated_function_details() {
+  _BASHUNIT_DUPLICATED_FUNCTION_DETAILS="$1"
+}
+
 function bashunit::state::set_duplicated_functions_merged() {
   bashunit::state::set_duplicated_test_functions_found
   bashunit::state::set_file_with_duplicated_function_names "$1"
   bashunit::state::set_duplicated_function_names "$2"
+  bashunit::state::set_duplicated_function_details "${3:-}"
 }
 
 # src/state/context.sh
@@ -4733,6 +6193,8 @@ function bashunit::state::aggregate_parallel_results() {
 
   local script_dir=""
   for script_dir in "$temp_dir_parallel_test_suite"/*; do
+
+    [ -d "$script_dir" ] || continue
     shopt -s nullglob
 
     local result_files
@@ -4740,7 +6202,8 @@ function bashunit::state::aggregate_parallel_results() {
     shopt -u nullglob
 
     if [ ${#result_files[@]} -eq 0 ]; then
-      printf "%sNo tests found%s" "$_BASHUNIT_COLOR_SKIPPED" "$_BASHUNIT_COLOR_DEFAULT"
+
+      printf "%sNo tests found%s\n" "$_BASHUNIT_COLOR_SKIPPED" "$_BASHUNIT_COLOR_DEFAULT"
       continue
     fi
 
@@ -4858,7 +6321,9 @@ function bashunit::state::aggregate_parallel_results() {
 
 # src/console/colors.sh
 
-bashunit::sgr() {
+_BASHUNIT_SGR_OUT=""
+
+function bashunit::sgr_to_slot() {
   local codes=${1:-0}
   shift
 
@@ -4867,7 +6332,12 @@ bashunit::sgr() {
     codes="$codes;$c"
   done
 
-  echo $'\e'"[${codes}m"
+  _BASHUNIT_SGR_OUT=$'\e'"[${codes}m"
+}
+
+bashunit::sgr() {
+  bashunit::sgr_to_slot "$@"
+  echo "$_BASHUNIT_SGR_OUT"
 }
 
 if bashunit::env::is_no_color_enabled; then
@@ -4888,23 +6358,43 @@ if bashunit::env::is_no_color_enabled; then
   _BASHUNIT_COLOR_RETURN_RISKY=""
   _BASHUNIT_COLOR_DEFAULT=""
 else
-  _BASHUNIT_COLOR_BOLD="$(bashunit::sgr 1)"
+  bashunit::sgr_to_slot 1
+  _BASHUNIT_COLOR_BOLD=$_BASHUNIT_SGR_OUT
 
-  _BASHUNIT_COLOR_FAINT="$(bashunit::sgr 90)"
-  _BASHUNIT_COLOR_BLACK="$(bashunit::sgr 30)"
-  _BASHUNIT_COLOR_FAILED="$(bashunit::sgr 31)"
-  _BASHUNIT_COLOR_PASSED="$(bashunit::sgr 32)"
-  _BASHUNIT_COLOR_SKIPPED="$(bashunit::sgr 33)"
-  _BASHUNIT_COLOR_INCOMPLETE="$(bashunit::sgr 36)"
-  _BASHUNIT_COLOR_SNAPSHOT="$(bashunit::sgr 34)"
-  _BASHUNIT_COLOR_RISKY="$(bashunit::sgr 35)"
-  _BASHUNIT_COLOR_RETURN_ERROR="$(bashunit::sgr 41)$_BASHUNIT_COLOR_BLACK$_BASHUNIT_COLOR_BOLD"
-  _BASHUNIT_COLOR_RETURN_SUCCESS="$(bashunit::sgr 42)$_BASHUNIT_COLOR_BLACK$_BASHUNIT_COLOR_BOLD"
-  _BASHUNIT_COLOR_RETURN_SKIPPED="$(bashunit::sgr 43)$_BASHUNIT_COLOR_BLACK$_BASHUNIT_COLOR_BOLD"
-  _BASHUNIT_COLOR_RETURN_INCOMPLETE="$(bashunit::sgr 46)$_BASHUNIT_COLOR_BLACK$_BASHUNIT_COLOR_BOLD"
-  _BASHUNIT_COLOR_RETURN_SNAPSHOT="$(bashunit::sgr 44)$_BASHUNIT_COLOR_BLACK$_BASHUNIT_COLOR_BOLD"
-  _BASHUNIT_COLOR_RETURN_RISKY="$(bashunit::sgr 45)$_BASHUNIT_COLOR_BLACK$_BASHUNIT_COLOR_BOLD"
-  _BASHUNIT_COLOR_DEFAULT="$(bashunit::sgr 0)"
+  bashunit::sgr_to_slot 90
+  _BASHUNIT_COLOR_FAINT=$_BASHUNIT_SGR_OUT
+  bashunit::sgr_to_slot 30
+  _BASHUNIT_COLOR_BLACK=$_BASHUNIT_SGR_OUT
+  bashunit::sgr_to_slot 31
+  _BASHUNIT_COLOR_FAILED=$_BASHUNIT_SGR_OUT
+  bashunit::sgr_to_slot 32
+  _BASHUNIT_COLOR_PASSED=$_BASHUNIT_SGR_OUT
+  bashunit::sgr_to_slot 33
+  _BASHUNIT_COLOR_SKIPPED=$_BASHUNIT_SGR_OUT
+  bashunit::sgr_to_slot 36
+  _BASHUNIT_COLOR_INCOMPLETE=$_BASHUNIT_SGR_OUT
+  bashunit::sgr_to_slot 34
+  _BASHUNIT_COLOR_SNAPSHOT=$_BASHUNIT_SGR_OUT
+  bashunit::sgr_to_slot 35
+  _BASHUNIT_COLOR_RISKY=$_BASHUNIT_SGR_OUT
+
+  _bashunit_banner_suffix="$_BASHUNIT_COLOR_BLACK$_BASHUNIT_COLOR_BOLD"
+  bashunit::sgr_to_slot 41
+  _BASHUNIT_COLOR_RETURN_ERROR="$_BASHUNIT_SGR_OUT$_bashunit_banner_suffix"
+  bashunit::sgr_to_slot 42
+  _BASHUNIT_COLOR_RETURN_SUCCESS="$_BASHUNIT_SGR_OUT$_bashunit_banner_suffix"
+  bashunit::sgr_to_slot 43
+  _BASHUNIT_COLOR_RETURN_SKIPPED="$_BASHUNIT_SGR_OUT$_bashunit_banner_suffix"
+  bashunit::sgr_to_slot 46
+  _BASHUNIT_COLOR_RETURN_INCOMPLETE="$_BASHUNIT_SGR_OUT$_bashunit_banner_suffix"
+  bashunit::sgr_to_slot 44
+  _BASHUNIT_COLOR_RETURN_SNAPSHOT="$_BASHUNIT_SGR_OUT$_bashunit_banner_suffix"
+  bashunit::sgr_to_slot 45
+  _BASHUNIT_COLOR_RETURN_RISKY="$_BASHUNIT_SGR_OUT$_bashunit_banner_suffix"
+  unset _bashunit_banner_suffix
+
+  bashunit::sgr_to_slot 0
+  _BASHUNIT_COLOR_DEFAULT=$_BASHUNIT_SGR_OUT
 fi
 
 # src/console/header.sh
@@ -4984,7 +6474,6 @@ Commands:
   assert <fn> <args>  Run standalone assertion
   doc [filter]        Display assertion documentation
   init [dir]          Initialize a new test directory
-  learn               Start interactive tutorial
   watch [path]        Watch files and re-run tests on change
   upgrade             Upgrade bashunit to latest version
 
@@ -5023,9 +6512,13 @@ Options:
   -e, --env, --boot <file>    Load a custom env/bootstrap file  (supports args)
   -f, --filter <name>         Only run tests matching the name
   --exclude-filter <name>     Skip tests whose name matches (repeatable)
+  --suite <name>              Run a [suite:<name>] from .bashunitrc (repeatable)
+  --list-suites               Print the suites defined in .bashunitrc and exit
   --tag <expr>                Only run tests with matching @tag (repeatable, OR logic).
                               Supports 'a&&b' (AND) and '!a' (NOT)
   --exclude-tag <name>        Skip tests with matching @tag (repeatable, exclude wins)
+  --sandbox                   Fail a test that runs an external command it did not mock
+  --sandbox-allow <cmd,...>   Commands the sandbox still allows (repeatable)
   --log-junit, --report-junit <file>  Write JUnit XML report
   --log-gha <file>            Write GitHub Actions annotations to a file
   --gha-annotations <mode>    Annotations on stdout: auto (in GitHub Actions), always or never
@@ -5038,9 +6531,10 @@ Options:
   --report-md <file>          Write a Markdown summary (auto-appended to \$GITHUB_STEP_SUMMARY)
   -s, --simple                Simple output (dots)
   --detailed                  Detailed output (default)
-  --output <format>           Output format: tap (TAP version 13)
+  --output <format>           Report on stdout: text (default), tap, json or junit
   -R, --run-all               Run all assertions (don't stop on first failure)
   -S, --stop-on-failure       Stop on first failure
+      --pass-with-no-tests    Exit 0 when the run selects no tests
   --test-timeout <seconds>    Fail a test if it runs longer than N seconds (0 = off)
   --retry <n>                 Re-run a failed test up to N extra times (0 = off)
   --repeat <n>                Run each selected test N times; it fails if any iteration fails
@@ -5052,9 +6546,11 @@ Options:
   --changed [<ref>]           Run only the test files changed since <ref> (default: origin/HEAD, then HEAD)
   --list, --dry-run           Print the tests that would run, then exit without running them
   --list-format <fmt>         Rendering for --list: text (default) or json
-  --snapshot-update           Rewrite existing snapshots from the actual value (combine with --filter)
+  --list-tags                 Print the tags of the selected files, one per line, then exit
+  -u, --snapshot-update       Rewrite existing snapshots from the actual value (combine with --filter)
   --no-snapshot-create        Fail on a missing snapshot instead of recording it (for CI)
   --snapshot-report-unused    List snapshot files no test resolved (full runs only, deletes nothing)
+  --snapshot-prune            Delete the snapshot files no test resolved (full runs only)
   -vvv, --verbose             Show execution details
   --debug [file]              Enable shell debug mode
   --no-output                 Suppress all output
@@ -5108,6 +6604,11 @@ Arguments:
 Options:
   -e, --env, --boot <file>    Load a custom env/bootstrap file (supports args)
   -f, --filter <name>         Only run benchmarks matching the name
+  --baseline <file>           Compare against a previous --report-json result
+  --baseline-tolerance <pct>  Allowed regression before failing (default: 10)
+  --baseline-update <file>    Write this run as the new baseline
+  --report-json <file>        Write machine-readable benchmark results
+  --report-junit <file>       Write JUnit XML benchmark results
   -s, --simple                Simple output
   --detailed                  Detailed output (default)
   -vvv, --verbose             Show execution details
@@ -5120,6 +6621,8 @@ Examples:
   bashunit bench
   bashunit bench benchmarks/
   bashunit bench --filter "parse"
+  bashunit bench --report-json bench.json
+  bashunit bench --baseline bench.json --baseline-tolerance 5
 EOF
 }
 
@@ -5161,28 +6664,6 @@ Creates:
 Examples:
   bashunit init               Create tests/ directory
   bashunit init spec          Create spec/ directory
-EOF
-}
-
-function bashunit::console_header::print_learn_help() {
-  cat <<EOF
-Usage: bashunit learn
-
-Start the interactive learning tutorial.
-
-The tutorial includes 10 progressive lessons:
-  1. Basics - Your First Test
-  2. Assertions - Testing Different Conditions
-  3. Setup & Teardown - Managing Test Lifecycle
-  4. Testing Functions - Unit Testing Patterns
-  5. Testing Scripts - Integration Testing
-  6. Mocking - Test Doubles and Mocks
-  7. Spies - Verifying Function Calls
-  8. Data Providers - Parameterized Tests
-  9. Exit Codes - Testing Success and Failure
-  10. Complete Challenge - Real World Scenario
-
-Your progress is saved automatically.
 EOF
 }
 
@@ -5272,6 +6753,10 @@ function bashunit::console_results::print_line() {
     return
   fi
 
+  if bashunit::env::is_machine_output_enabled; then
+    return
+  fi
+
   if ! bashunit::env::is_simple_output_enabled; then
     printf "%s\n" "$line"
     return
@@ -5314,12 +6799,15 @@ function bashunit::console_results::print_tap_line() {
   test_name=$(printf "%s" "$test_name" |
     sed 's/[[:space:]]*[0-9][0-9]*m\{0,1\}[[:space:]]*[0-9.]*[ms]*[[:space:]]*$//')
 
+  local tap_name
+  tap_name=$(bashunit::reports::__tap_description "$test_name")
+
   case "$type" in
   successful)
-    printf "ok %d - %s\n" "$_BASHUNIT_TOTAL_TESTS_COUNT" "$test_name"
+    printf "ok %d - %s\n" "$_BASHUNIT_TOTAL_TESTS_COUNT" "$tap_name"
     ;;
   failure | failed | failed_snapshot | error)
-    printf "not ok %d - %s\n" "$_BASHUNIT_TOTAL_TESTS_COUNT" "$test_name"
+    printf "not ok %d - %s\n" "$_BASHUNIT_TOTAL_TESTS_COUNT" "$tap_name"
     local detail_line
     printf "  ---\n"
     while IFS= read -r detail_line; do
@@ -5339,27 +6827,28 @@ function bashunit::console_results::print_tap_line() {
     skip_reason="${skip_reason#"${skip_reason%%[![:space:]]*}"}"
     if [ -n "$skip_reason" ]; then
       printf "ok %d - %s # SKIP %s\n" \
-        "$_BASHUNIT_TOTAL_TESTS_COUNT" "$skip_name" "$skip_reason"
+        "$_BASHUNIT_TOTAL_TESTS_COUNT" \
+        "$(bashunit::reports::__tap_description "$skip_name")" "$skip_reason"
     else
       printf "ok %d - %s # SKIP\n" \
-        "$_BASHUNIT_TOTAL_TESTS_COUNT" "$test_name"
+        "$_BASHUNIT_TOTAL_TESTS_COUNT" "$tap_name"
     fi
     ;;
   incomplete)
     printf "ok %d - %s # TODO incomplete\n" \
-      "$_BASHUNIT_TOTAL_TESTS_COUNT" "$test_name"
+      "$_BASHUNIT_TOTAL_TESTS_COUNT" "$tap_name"
     ;;
   snapshot)
     printf "ok %d - %s # snapshot\n" \
-      "$_BASHUNIT_TOTAL_TESTS_COUNT" "$test_name"
+      "$_BASHUNIT_TOTAL_TESTS_COUNT" "$tap_name"
     ;;
   risky)
     printf "ok %d - %s # RISKY no assertions\n" \
-      "$_BASHUNIT_TOTAL_TESTS_COUNT" "$test_name"
+      "$_BASHUNIT_TOTAL_TESTS_COUNT" "$tap_name"
     ;;
   *)
     printf "not ok %d - %s\n" \
-      "$_BASHUNIT_TOTAL_TESTS_COUNT" "$test_name"
+      "$_BASHUNIT_TOTAL_TESTS_COUNT" "$tap_name"
     ;;
   esac
 }
@@ -5732,8 +7221,8 @@ function bashunit::console_results::print_worker_stderr() {
   local stderr_file="$2"
 
   printf "\n%sStderr from %s%s\n" \
-    "$_BASHUNIT_COLOR_SKIPPED" "$test_file" "$_BASHUNIT_COLOR_DEFAULT"
-  sed 's/^/|/' "$stderr_file"
+    "$_BASHUNIT_COLOR_SKIPPED" "$test_file" "$_BASHUNIT_COLOR_DEFAULT" >&2
+  sed 's/^/|/' "$stderr_file" >&2
 }
 
 # src/console/deferred.sh
@@ -5827,18 +7316,89 @@ function bashunit::console_results::print_risky_tests_and_reset() {
 
 # src/console/summary.sh
 
+function bashunit::console_results::print_tag_hint() {
+  local tag_filter="${_BASHUNIT_ACTIVE_TAG_FILTER:-}"
+  [ -n "$tag_filter" ] || return 0
+
+  if [ -n "${_BASHUNIT_SEEN_TAGS:-}" ]; then
+    printf "%sNo test matches tag '%s'. Tags in the selected files: %s.%s\n" \
+      "${_BASHUNIT_COLOR_FAINT:-}" "$tag_filter" "$_BASHUNIT_SEEN_TAGS" \
+      "${_BASHUNIT_COLOR_DEFAULT:-}"
+    return 0
+  fi
+
+  printf "%sNo test matches tag '%s'. No test in the selected files carries a '# @tag'.%s\n" \
+    "${_BASHUNIT_COLOR_FAINT:-}" "$tag_filter" "${_BASHUNIT_COLOR_DEFAULT:-}"
+}
+
+function bashunit::console_results::print_filter_hint() {
+  local filter="${_BASHUNIT_ACTIVE_FILTER:-}"
+  [ -n "$filter" ] || return 0
+
+  local needle="${filter#test_}"
+  local suggestion=""
+  if [ -n "$needle" ]; then
+    local lowered
+    lowered="$(printf '%s' "$needle" | tr '[:upper:]' '[:lower:]')"
+
+    local underscored="${lowered// /_}"
+    local fn
+    for fn in ${_BASHUNIT_CACHED_ALL_FUNCTIONS:-}; do
+      case "$fn" in
+      test_*"$lowered"* | test_*"$underscored"*)
+        suggestion="$fn"
+        break
+        ;;
+      esac
+    done
+  fi
+
+  if [ -n "$suggestion" ]; then
+    printf "%sNo test matches '%s'. Filters match the function name, not the title: did you mean '%s'?%s\n" \
+      "${_BASHUNIT_COLOR_FAINT:-}" "$filter" "$suggestion" "${_BASHUNIT_COLOR_DEFAULT:-}"
+    return 0
+  fi
+
+  printf "%sNo test matches '%s'. Filters match the function name (test_...), not the title in the report.%s\n" \
+    "${_BASHUNIT_COLOR_FAINT:-}" "$filter" "${_BASHUNIT_COLOR_DEFAULT:-}"
+}
+
 function bashunit::console_results::render_result() {
   if [ "$(bashunit::state::is_duplicated_test_functions_found)" = true ]; then
-    bashunit::console_results::print_execution_time
-    printf "%s%s%s\n" "${_BASHUNIT_COLOR_RETURN_ERROR}" "Duplicate test functions found" "${_BASHUNIT_COLOR_DEFAULT}"
-    printf "File with duplicate functions: %s\n" "$(bashunit::state::get_file_with_duplicated_function_names)"
-    printf "Duplicate functions: %s\n" "$(bashunit::state::get_duplicated_function_names)"
+
+    local _dup_detail
+    _dup_detail="$(bashunit::state::get_duplicated_function_details)"
+    if [ -z "$_dup_detail" ]; then
+      _dup_detail="$(bashunit::state::get_duplicated_function_names)"
+    fi
+    {
+      bashunit::console_results::print_execution_time
+      printf "%s%s%s\n" "${_BASHUNIT_COLOR_RETURN_ERROR}" "Duplicate test functions found" "${_BASHUNIT_COLOR_DEFAULT}"
+      printf "File with duplicate functions: %s\n" "$(bashunit::state::get_file_with_duplicated_function_names)"
+      printf "Duplicate functions: %s\n" "$_dup_detail"
+    } >&2
     return 1
   fi
 
   if bashunit::env::is_tap_output_enabled; then
     printf "1..%d\n" "$_BASHUNIT_TOTAL_TESTS_COUNT"
     if [ "$_BASHUNIT_TESTS_FAILED" -gt 0 ]; then
+      return 1
+    fi
+    return 0
+  fi
+
+  if bashunit::env::is_machine_output_enabled; then
+    if [ "$_BASHUNIT_TESTS_FAILED" -gt 0 ]; then
+      return 1
+    fi
+    if [ "$_BASHUNIT_TESTS_FLAKY" -gt 0 ] && bashunit::env::is_fail_on_flaky_enabled; then
+      return 1
+    fi
+    local machine_total=$((_BASHUNIT_TESTS_PASSED + _BASHUNIT_TESTS_SKIPPED + \
+      _BASHUNIT_TESTS_INCOMPLETE + _BASHUNIT_TESTS_SNAPSHOT + \
+      _BASHUNIT_TESTS_FAILED + _BASHUNIT_TESTS_RISKY))
+    if [ "$machine_total" -eq 0 ]; then
       return 1
     fi
     return 0
@@ -5960,8 +7520,18 @@ function bashunit::console_results::render_result() {
   fi
 
   if [ "$total_tests" -eq 0 ]; then
-    printf "\n%s%s%s\n" "$_BASHUNIT_COLOR_RETURN_ERROR" " No tests found " "$_BASHUNIT_COLOR_DEFAULT"
+
+    local empty_colour="$_BASHUNIT_COLOR_RETURN_ERROR"
+    if bashunit::env::is_pass_with_no_tests_enabled; then
+      empty_colour="$_BASHUNIT_COLOR_RETURN_SKIPPED"
+    fi
+    printf "\n%s%s%s\n" "$empty_colour" " No tests found " "$_BASHUNIT_COLOR_DEFAULT"
+    bashunit::console_results::print_filter_hint
+    bashunit::console_results::print_tag_hint
     bashunit::console_results::print_execution_time
+    if bashunit::env::is_pass_with_no_tests_enabled; then
+      return 0
+    fi
     return 1
   fi
 
@@ -5979,10 +7549,15 @@ function bashunit::console_results::print_execution_time() {
   time=$(bashunit::clock::total_runtime_in_milliseconds)
 
   time="${time%%.*}"
-  time="${time:-0}"
 
-  local formatted
-  formatted=$(bashunit::console_results::format_duration "$time")
+  local formatted="unknown"
+  case "$time" in
+  '' | *[!0-9-]*) ;;
+  *)
+
+    formatted=$(bashunit::console_results::format_duration "$time")
+    ;;
+  esac
 
   printf "${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" \
     "Time taken: ${formatted}"
@@ -6006,7 +7581,7 @@ function bashunit::console_results::print_hook_completed() {
     return
   fi
 
-  if bashunit::env::is_tap_output_enabled; then
+  if bashunit::env::is_machine_output_enabled; then
     return
   fi
 
@@ -6362,6 +7937,96 @@ $normalized
 
 _BASHUNIT_HELPER_TOTAL_TESTS_OUT=0
 
+# src/helper/annotations.sh
+
+_BASHUNIT_ANNOT_MAP_FNS=()
+_BASHUNIT_ANNOT_MAP_TIMEOUTS=()
+_BASHUNIT_ANNOT_MAP_RETRIES=()
+_BASHUNIT_ANNOT_MAP_SKIPS=()
+_BASHUNIT_ANNOT_MAP_REASONS=()
+
+_BASHUNIT_ANNOT_TIMEOUT_OUT=""
+_BASHUNIT_ANNOT_RETRY_OUT=""
+_BASHUNIT_ANNOT_SKIP_OUT="false"
+_BASHUNIT_ANNOT_REASON_OUT=""
+
+function bashunit::helper::annotations_reset() {
+  _BASHUNIT_ANNOT_MAP_FNS=()
+  _BASHUNIT_ANNOT_MAP_TIMEOUTS=()
+  _BASHUNIT_ANNOT_MAP_RETRIES=()
+  _BASHUNIT_ANNOT_MAP_SKIPS=()
+  _BASHUNIT_ANNOT_MAP_REASONS=()
+}
+
+function bashunit::helper::annotations_record() {
+  local count=${#_BASHUNIT_ANNOT_MAP_FNS[@]}
+  _BASHUNIT_ANNOT_MAP_FNS[count]="$1"
+  _BASHUNIT_ANNOT_MAP_TIMEOUTS[count]="${2-}"
+  _BASHUNIT_ANNOT_MAP_RETRIES[count]="${3-}"
+  _BASHUNIT_ANNOT_MAP_SKIPS[count]="${4-}"
+  _BASHUNIT_ANNOT_MAP_REASONS[count]="${5-}"
+}
+
+function bashunit::helper::annotations_for_function() {
+  local function_name=$1
+  local i=0
+  local total=${#_BASHUNIT_ANNOT_MAP_FNS[@]}
+
+  _BASHUNIT_ANNOT_TIMEOUT_OUT=""
+  _BASHUNIT_ANNOT_RETRY_OUT=""
+  _BASHUNIT_ANNOT_SKIP_OUT="false"
+  _BASHUNIT_ANNOT_REASON_OUT=""
+
+  while [ "$i" -lt "$total" ]; do
+    if [ "${_BASHUNIT_ANNOT_MAP_FNS[i]}" = "$function_name" ]; then
+      _BASHUNIT_ANNOT_TIMEOUT_OUT="${_BASHUNIT_ANNOT_MAP_TIMEOUTS[i]}"
+      _BASHUNIT_ANNOT_RETRY_OUT="${_BASHUNIT_ANNOT_MAP_RETRIES[i]}"
+      if [ "${_BASHUNIT_ANNOT_MAP_SKIPS[i]}" = "1" ]; then
+        _BASHUNIT_ANNOT_SKIP_OUT="true"
+      fi
+      _BASHUNIT_ANNOT_REASON_OUT="${_BASHUNIT_ANNOT_MAP_REASONS[i]}"
+      return
+    fi
+    i=$((i + 1))
+  done
+}
+
+function bashunit::helper::_annotations_is_count() {
+  case "$1" in
+  '' | *[!0-9]*) return 1 ;;
+  esac
+  return 0
+}
+
+function bashunit::helper::annotations_validate_or_exit() {
+  local script=$1
+  local i=0
+  local total=${#_BASHUNIT_ANNOT_MAP_FNS[@]}
+  local fn value
+
+  while [ "$i" -lt "$total" ]; do
+    fn="${_BASHUNIT_ANNOT_MAP_FNS[i]}"
+
+    value="${_BASHUNIT_ANNOT_MAP_TIMEOUTS[i]}"
+    if [ -n "$value" ] && ! bashunit::helper::_annotations_is_count "$value"; then
+      bashunit::helper::_annotations_reject "$script" "$fn" "timeout" "$value"
+    fi
+
+    value="${_BASHUNIT_ANNOT_MAP_RETRIES[i]}"
+    if [ -n "$value" ] && ! bashunit::helper::_annotations_is_count "$value"; then
+      bashunit::helper::_annotations_reject "$script" "$fn" "retry" "$value"
+    fi
+
+    i=$((i + 1))
+  done
+}
+
+function bashunit::helper::_annotations_reject() {
+  printf "%sError: @%s '%s' above %s in %s is not a non-negative integer.%s\n" \
+    "${_BASHUNIT_COLOR_FAILED}" "$3" "$4" "$2" "$1" "${_BASHUNIT_COLOR_DEFAULT}" >&2
+  exit 1
+}
+
 # src/helper/provider.sh
 
 _BASHUNIT_PROVIDER_RESOLVED_OUT=""
@@ -6388,6 +8053,7 @@ function bashunit::helper::build_provider_map() {
     _BASHUNIT_PROVIDER_MAP_FNS=()
     _BASHUNIT_PROVIDER_MAP_PROVIDERS=()
     _BASHUNIT_PROVIDER_MAP_NO_PARALLEL=false
+    bashunit::helper::annotations_reset
     return
   fi
 
@@ -6400,19 +8066,28 @@ function bashunit::helper::build_provider_map() {
   _BASHUNIT_PROVIDER_MAP_PROVIDERS=()
   _BASHUNIT_PROVIDER_MAP_NO_PARALLEL=false
 
-  local count=0
-  local fn provider
+  bashunit::helper::annotations_reset
 
-  while IFS=$'\t' read -r fn provider; do
+  local count=0
+  local fn provider annot_timeout annot_retry annot_skip annot_reason
+
+  while IFS=$'\t' read -r fn provider annot_timeout annot_retry annot_skip annot_reason; do
     [ -z "$fn" ] && continue
     if [ "$fn" = "@@no_parallel@@" ]; then
       [ "$provider" = "1" ] && _BASHUNIT_PROVIDER_MAP_NO_PARALLEL=true
       continue
     fi
+    if [ "$fn" = "@@annot@@" ]; then
+      [ "$annot_timeout" = "@@none@@" ] && annot_timeout=""
+      [ "$annot_retry" = "@@none@@" ] && annot_retry=""
+      bashunit::helper::annotations_record \
+        "$provider" "$annot_timeout" "$annot_retry" "$annot_skip" "$annot_reason"
+      continue
+    fi
     _BASHUNIT_PROVIDER_MAP_FNS[count]="$fn"
     _BASHUNIT_PROVIDER_MAP_PROVIDERS[count]="$provider"
     count=$((count + 1))
-  done < <(awk '
+  done <<<"$(awk '
     /^# bashunit: no-parallel-tests/ { no_parallel = 1; next }
     /^[[:space:]]*#[[:space:]]*@?data_provider[[:space:]]+/ {
       p = $0
@@ -6422,21 +8097,66 @@ function bashunit::helper::build_provider_map() {
       pending_line = NR
       next
     }
+    /^[[:space:]]*#[[:space:]]*@timeout([[:space:]]|=)/ {
+      v = $0
+      sub(/^[[:space:]]*#[[:space:]]*@timeout[[:space:]=]+/, "", v)
+      sub(/[[:space:]]+$/, "", v)
+      a_timeout = v
+      next
+    }
+    /^[[:space:]]*#[[:space:]]*@retry([[:space:]]|=)/ {
+      v = $0
+      sub(/^[[:space:]]*#[[:space:]]*@retry[[:space:]=]+/, "", v)
+      sub(/[[:space:]]+$/, "", v)
+      a_retry = v
+      next
+    }
+    /^[[:space:]]*#[[:space:]]*@skip([[:space:]]|$)/ {
+      v = $0
+      sub(/^[[:space:]]*#[[:space:]]*@skip[[:space:]]*/, "", v)
+      sub(/[[:space:]]+$/, "", v)
+      a_skip = 1
+      a_reason = v
+      next
+    }
+    # Any other comment keeps the block open, the same rule @tag follows.
+    /^[[:space:]]*#/ { next }
     {
+      is_fn = match($0, /^[[:space:]]*(function[[:space:]]+)?[A-Za-z_][A-Za-z0-9_:]*[[:space:]]*\(\)/)
+      if (is_fn) {
+        fn = $0
+        sub(/^[[:space:]]*(function[[:space:]]+)?/, "", fn)
+        sub(/[[:space:]]*\(\).*/, "", fn)
+      }
+
       if (pending != "" && NR - pending_line <= 2) {
-        if (match($0, /^[[:space:]]*(function[[:space:]]+)?[A-Za-z_][A-Za-z0-9_:]*[[:space:]]*\(\)/)) {
-          fn = $0
-          sub(/^[[:space:]]*(function[[:space:]]+)?/, "", fn)
-          sub(/[[:space:]]*\(\).*/, "", fn)
+        if (is_fn) {
           printf "%s\t%s\n", fn, pending
           pending = ""
         }
       } else if (pending != "" && NR - pending_line > 2) {
         pending = ""
       }
+
+      if (is_fn && (a_timeout != "" || a_retry != "" || a_skip != "")) {
+        # Tab is an IFS whitespace character, so `read` collapses a run of them
+        # and an empty interior field would shift every later one. Absent
+        # values therefore travel as a sentinel; the reason is last and may be
+        # empty.
+        printf "@@annot@@\t%s\t%s\t%s\t%s\t%s\n", fn,
+          (a_timeout == "" ? "@@none@@" : a_timeout),
+          (a_retry == "" ? "@@none@@" : a_retry),
+          (a_skip == "" ? "0" : a_skip), a_reason
+      }
+      # A blank or code line ends the block for the next definition, whether or
+      # not this line was one.
+      a_timeout = ""
+      a_retry = ""
+      a_skip = ""
+      a_reason = ""
     }
     END { printf "@@no_parallel@@\t%d\n", no_parallel }
-  ' "$script" 2>/dev/null)
+  ' "$script" 2>/dev/null)"
 }
 
 function bashunit::helper::provider_for_function() {
@@ -6466,6 +8186,8 @@ function bashunit::helper::get_provider_data() {
 }
 
 # src/helper/tags.sh
+
+_BASHUNIT_SEEN_TAGS=""
 
 function bashunit::helper::build_tags_map() {
   local script=$1
@@ -6497,8 +8219,19 @@ function bashunit::helper::build_tags_map() {
     [ -z "$fn" ] && continue
     _BASHUNIT_TAGS_MAP_FNS[count]="$fn"
     _BASHUNIT_TAGS_MAP_TAGS[count]="$tags"
+
+    local _seen_tag
+    local _old_ifs=$IFS
+    IFS=','
+    for _seen_tag in $tags; do
+      case ",$_BASHUNIT_SEEN_TAGS," in
+      *",$_seen_tag,"*) ;;
+      *) _BASHUNIT_SEEN_TAGS="${_BASHUNIT_SEEN_TAGS:+$_BASHUNIT_SEEN_TAGS,}$_seen_tag" ;;
+      esac
+    done
+    IFS=$_old_ifs
     count=$((count + 1))
-  done < <(awk '
+  done <<<"$(awk '
     # An uninitialised awk variable used as a subscript is the empty string,
     # not 0, so the first function would land in order[""] and be unreachable
     # from the numeric loop in END.
@@ -6554,7 +8287,7 @@ function bashunit::helper::build_tags_map() {
         if (out != "") { printf "%s\t%s\n", order[i], out }
       }
     }
-  ' "$script" 2>/dev/null)
+  ' "$script" 2>/dev/null)"
 }
 
 function bashunit::helper::tags_for_function() {
@@ -6681,6 +8414,13 @@ function bashunit::helper::check_duplicate_functions() {
           if (++seen[name] == 2) {
             dup[name] = 1
           }
+          # Recorded for every occurrence, the first included: the report needs
+          # both definitions to be worth anything.
+          if (lines[name] == "") {
+            lines[name] = FNR
+          } else {
+            lines[name] = lines[name] ", " FNR
+          }
           break
         }
       }
@@ -6700,12 +8440,30 @@ function bashunit::helper::check_duplicate_functions() {
         names[j + 1] = v
       }
       for (i = 1; i <= n; i++) {
-        print names[i]
+        print names[i] "\t" lines[names[i]]
       }
     }
   ' "$script")
   if [ -n "$duplicates" ]; then
-    bashunit::state::set_duplicated_functions_merged "$script" "$duplicates"
+
+    local names=""
+    local detail=""
+    local dup_name dup_lines
+    while IFS="$(printf '\t')" read -r dup_name dup_lines; do
+      if [ -z "$dup_name" ]; then
+        continue
+      fi
+      names="$names$dup_name
+"
+      detail="$detail$dup_name (lines $dup_lines)
+"
+    done <<EOF
+$duplicates
+EOF
+    bashunit::state::set_duplicated_functions_merged \
+      "$script" "${names%
+}" "${detail%
+}"
     return 1
   fi
   return 0
@@ -7176,10 +8934,10 @@ trailing label override, so `assert_contains "zzz" "abc" "my label"` searches
 | **Numbers** | [assert_less_than](#assert-less-than) · [assert_less_or_equal_than](#assert-less-or-equal-than) · [assert_greater_than](#assert-greater-than) · [assert_greater_or_equal_than](#assert-greater-or-equal-than) · [assert_between](#assert-between) · [assert_not_between](#assert-not-between) · [assert_within_delta](#assert-within-delta) |
 | **Dates** | [assert_date_equals](#assert-date-equals) · [assert_date_before](#assert-date-before) · [assert_date_after](#assert-date-after) · [assert_date_within_range](#assert-date-within-range) · [assert_date_within_delta](#assert-date-within-delta) |
 | **Exit codes and commands** | [assert_exit_code](#assert-exit-code) · [assert_successful_code](#assert-successful-code) · [assert_unsuccessful_code](#assert-unsuccessful-code) · [assert_general_error](#assert-general-error) · [assert_command_available](#assert-command-available) · [assert_command_not_found](#assert-command-not-found) · [assert_exec](#assert-exec) |
-| **Files** | [assert_file_exists](#assert-file-exists) · [assert_file_not_exists](#assert-file-not-exists) · [assert_file_contains](#assert-file-contains) · [assert_file_not_contains](#assert-file-not-contains) · [assert_is_file](#assert-is-file) · [assert_is_file_empty](#assert-is-file-empty) · [assert_is_symlink](#assert-is-symlink) · [assert_is_not_symlink](#assert-is-not-symlink) · [assert_symlink_to](#assert-symlink-to) · [assert_file_permissions](#assert-file-permissions) · [assert_files_equals](#assert-files-equals) · [assert_files_not_equals](#assert-files-not-equals) |
+| **Files** | [assert_file_exists](#assert-file-exists) · [assert_file_not_exists](#assert-file-not-exists) · [assert_file_contains](#assert-file-contains) · [assert_file_not_contains](#assert-file-not-contains) · [assert_is_file](#assert-is-file) · [assert_is_file_empty](#assert-is-file-empty) · [assert_is_file_not_empty](#assert-is-file-not-empty) · [assert_is_file_readable](#assert-is-file-readable) · [assert_is_file_not_readable](#assert-is-file-not-readable) · [assert_is_file_writable](#assert-is-file-writable) · [assert_is_file_not_writable](#assert-is-file-not-writable) · [assert_is_file_executable](#assert-is-file-executable) · [assert_is_file_not_executable](#assert-is-file-not-executable) · [assert_is_symlink](#assert-is-symlink) · [assert_is_not_symlink](#assert-is-not-symlink) · [assert_symlink_to](#assert-symlink-to) · [assert_file_permissions](#assert-file-permissions) · [assert_files_equals](#assert-files-equals) · [assert_files_not_equals](#assert-files-not-equals) |
 | **Directories** | [assert_directory_exists](#assert-directory-exists) · [assert_directory_not_exists](#assert-directory-not-exists) · [assert_is_directory](#assert-is-directory) · [assert_is_directory_empty](#assert-is-directory-empty) · [assert_is_directory_not_empty](#assert-is-directory-not-empty) · [assert_is_directory_readable](#assert-is-directory-readable) · [assert_is_directory_not_readable](#assert-is-directory-not-readable) · [assert_is_directory_writable](#assert-is-directory-writable) · [assert_is_directory_not_writable](#assert-is-directory-not-writable) |
 | **Arrays** | [assert_arrays_equal](#assert-arrays-equal) · [assert_array_contains](#assert-array-contains) · [assert_array_not_contains](#assert-array-not-contains) · [assert_array_length](#assert-array-length) |
-| **JSON** | [assert_json_equals](#assert-json-equals) · [assert_json_contains](#assert-json-contains) · [assert_json_key_exists](#assert-json-key-exists) |
+| **JSON** | [assert_json_equals](#assert-json-equals) · [assert_json_contains](#assert-json-contains) · [assert_json_key_exists](#assert-json-key-exists) · [assert_json_key_not_exists](#assert-json-key-not-exists) · [assert_json_length](#assert-json-length) |
 | **Duration** | [assert_duration](#assert-duration) · [assert_duration_less_than](#assert-duration-less-than) · [assert_duration_greater_than](#assert-duration-greater-than) |
 | **Snapshots** | [assert_match_snapshot](#assert-match-snapshot) · [assert_match_named_snapshot](#assert-match-named-snapshot) · [assert_match_snapshot_ignore_colors](#assert-match-snapshot-ignore-colors) · [assert_match_named_snapshot_ignore_colors](#assert-match-named-snapshot-ignore-colors) |
 | **Spies** | [assert_have_been_called](#assert-have-been-called) · [assert_not_called](#assert-not-called) · [assert_have_been_called_with](#assert-have-been-called-with) · [assert_have_been_called_with_any](#assert-have-been-called-with-any) · [assert_have_been_called_with_args](#assert-have-been-called-with-args) · [assert_have_been_called_nth_with](#assert-have-been-called-nth-with) · [assert_have_been_called_times](#assert-have-been-called-times) |
@@ -7298,6 +9056,10 @@ function test_failure() {
 
 Reports an error if the two variables `expected` and `actual` are not equal ignoring the special chars like ANSI Escape Sequences (colors) and other special chars like tabs and new lines.
 
+Those are *characters*, not escape sequences. A backslash followed by `t` is
+two characters and stays two characters, so comparing it against a real tab
+fails; only the tab itself is stripped.
+
 - [assert_same](#assert-same) is similar but including special chars.
 
 ::: code-group
@@ -7389,6 +9151,20 @@ function test_failure() {
   assert_matches "^bar" "foobar"
 }
 ```
+:::
+
+::: tip Cost in a hot loop
+This assertion runs `grep -E` in a subprocess for every call, so it is far more
+expensive than a string comparison: measured here, 500 `assert_matches` take
+~1.25 s against ~130 ms for 2000 `assert_same` — about **38x per call**.
+
+That subprocess is deliberate. Bash 3.2 changed whether a quoted right-hand side
+of `[[ =~ ]]` is a regex or a literal, so at bashunit's Bash 3.0 floor the same
+pattern would match differently across supported versions.
+
+It is irrelevant for ordinary suites. If you are asserting inside a large loop
+and the pattern is a fixed substring or a glob, prefer
+[assert_contains](#assert-contains).
 :::
 
 ## assert_string_starts_with
@@ -7974,6 +9750,25 @@ function test_failure() {
 ```
 :::
 
+::: warning Under `set -e`, pass the code as the third argument
+A non-zero exit aborts the test before the assertion runs, so the code has to
+be captured first — and capturing it sets `$?` to zero:
+
+```bash
+local code=0
+some_command || code=$?
+
+assert_successful_code            # reads $? — the assignment's 0
+assert_successful_code "$code"    # the first argument is ignored, same result
+
+assert_successful_code "" "" "$code"   # correct: read from the third argument
+```
+
+`assert_exit_code` takes a captured code the same way, but its first argument
+is the *expected* code: `assert_exit_code 7 "" "$code"`.
+:::
+
+
 ## assert_unsuccessful_code
 > `assert_unsuccessful_code`
 
@@ -8019,6 +9814,25 @@ function test_failure() {
 ```
 :::
 
+::: warning Under `set -e`, pass the code as the third argument
+A non-zero exit aborts the test before the assertion runs, so the code has to
+be captured first — and capturing it sets `$?` to zero:
+
+```bash
+local code=0
+some_command || code=$?
+
+assert_unsuccessful_code            # reads $? — the assignment's 0
+assert_unsuccessful_code "$code"    # the first argument is ignored, same result
+
+assert_unsuccessful_code "" "" "$code"   # correct: read from the third argument
+```
+
+`assert_exit_code` takes a captured code the same way, but its first argument
+is the *expected* code: `assert_exit_code 7 "" "$code"`.
+:::
+
+
 ## assert_general_error
 > `assert_general_error`
 
@@ -8063,6 +9877,25 @@ function test_failure() {
 }
 ```
 :::
+
+::: warning Under `set -e`, pass the code as the third argument
+A non-zero exit aborts the test before the assertion runs, so the code has to
+be captured first — and capturing it sets `$?` to zero:
+
+```bash
+local code=0
+some_command || code=$?
+
+assert_general_error            # reads $? — the assignment's 0
+assert_general_error "$code"    # the first argument is ignored, same result
+
+assert_general_error "" "" "$code"   # correct: read from the third argument
+```
+
+`assert_exit_code` takes a captured code the same way, but its first argument
+is the *expected* code: `assert_exit_code 7 "" "$code"`.
+:::
+
 
 ## assert_command_available
 > `assert_command_available "command"`
@@ -8121,6 +9954,25 @@ function test_failure_with_existing_command() {
 }
 ```
 :::
+
+::: warning Under `set -e`, pass the code as the third argument
+A non-zero exit aborts the test before the assertion runs, so the code has to
+be captured first — and capturing it sets `$?` to zero:
+
+```bash
+local code=0
+some_command || code=$?
+
+assert_command_not_found            # reads $? — the assignment's 0
+assert_command_not_found "$code"    # the first argument is ignored, same result
+
+assert_command_not_found "" "" "$code"   # correct: read from the third argument
+```
+
+`assert_exit_code` takes a captured code the same way, but its first argument
+is the *expected* code: `assert_exit_code 7 "" "$code"`.
+:::
+
 
 ## assert_file_exists
 > `assert_file_exists "file"`
@@ -8297,6 +10149,129 @@ function test_failure() {
 ```
 :::
 
+
+## assert_is_file_not_empty
+> `assert_is_file_not_empty "file"`
+
+Reports an error if `file` is empty. A file holding a single newline counts as
+not empty.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  generate_report > report.txt
+
+  assert_is_file_not_empty "report.txt"
+}
+```
+:::
+
+## assert_is_file_readable
+> `assert_is_file_readable "file"`
+
+Reports an error if `file` is not readable.
+
+The failure says which of the three things went wrong: the path does not exist,
+it exists but is not a file, or it is a file the current user cannot read. The
+same applies to every assertion below.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_is_file_readable "/etc/hosts"
+}
+```
+```[Output]
+✗ Failed: Success
+    Expected '/tmp/nope'
+    to be readable
+    but does not exist
+```
+:::
+
+## assert_is_file_not_readable
+> `assert_is_file_not_readable "file"`
+
+Reports an error if `file` is readable.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  chmod 000 "$secret"
+
+  assert_is_file_not_readable "$secret"
+}
+```
+:::
+
+::: warning
+Running as root bypasses the permission bits, so this assertion passes for
+nothing under `sudo` or in a root container. Skip such a test there:
+`bashunit::skip_if "[ \"$(id -u)\" -eq 0 ]" "root reads anything"`.
+:::
+
+## assert_is_file_writable
+> `assert_is_file_writable "file"`
+
+Reports an error if `file` is not writable.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_is_file_writable "$log_file"
+}
+```
+:::
+
+## assert_is_file_not_writable
+> `assert_is_file_not_writable "file"`
+
+Reports an error if `file` is writable.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  chmod 444 "$config"
+
+  assert_is_file_not_writable "$config"
+}
+```
+:::
+
+## assert_is_file_executable
+> `assert_is_file_executable "file"`
+
+Reports an error if `file` is not executable — the thing a shell project most
+often wants to assert about a file it generated.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  ./build.sh
+
+  assert_is_file_executable "bin/tool"
+}
+```
+```[Output]
+✗ Failed: Success
+    Expected 'bin/tool'
+    to be executable
+    but is not executable
+```
+:::
+
+## assert_is_file_not_executable
+> `assert_is_file_not_executable "file"`
+
+Reports an error if `file` is executable.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_is_file_not_executable "README.md"
+}
+```
+:::
 ## assert_directory_exists
 > `assert_directory_exists "directory"`
 
@@ -8871,6 +10846,25 @@ function test_failure() {
 ```
 :::
 
+## assert_json_key_not_exists
+> `assert_json_key_not_exists "key" "json"`
+
+Reports an error if `key` exists in the JSON string. Uses [jq](https://jqlang.github.io/jq/) syntax for key paths. Requires `jq` to be installed; if missing the test is skipped.
+
+A key with a `null` value still exists and makes this assertion fail. Invalid JSON also fails the assertion.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_json_key_not_exists ".user.password" '{"user":{"name":"bashunit"}}'
+}
+
+function test_failure() {
+  assert_json_key_not_exists ".user.password" '{"user":{"password":null}}'
+}
+```
+:::
+
 ## assert_json_equals
 > `assert_json_equals "expected" "actual"`
 
@@ -8884,6 +10878,25 @@ function test_success() {
 
 function test_failure() {
   assert_json_equals '{"a":1}' '{"a":2}'
+}
+```
+:::
+
+## assert_json_length
+> `assert_json_length "expected" "key" "json"`
+
+Reports an error if the array, object, or string at `key` does not have the expected length. Arrays count elements, objects count key-value pairs, and strings count Unicode codepoints, following `jq`'s `length` behavior. A missing path, unsupported value type, invalid JSON, or non-numeric expected length fails instead of being compared as empty or zero. Requires `jq` to be installed; if missing the test is skipped.
+
+::: code-group
+```bash [Example]
+function test_success() {
+  assert_json_length 3 ".items" '{"items":[1,2,3]}'
+  assert_json_length 2 ".metadata" '{"metadata":{"page":1,"total":3}}'
+}
+
+function test_failure() {
+  assert_json_length 2 ".items" '{"items":[1,2,3]}'
+  assert_json_length 0 ".missing" '{"items":[]}'
 }
 ```
 :::
@@ -8949,6 +10962,30 @@ function test_failure() {
 Reports an error if `actual` differs from the stored snapshot. On the first run no snapshot exists, so one is written from `actual` and the assertion passes — review and commit that file.
 
 Pass `snapshot_file` to share one snapshot between tests; by default each test gets its own, named after the test function.
+
+::: warning A `@data_provider` test shares one snapshot
+The filename comes from the test **function**, and a provider runs that function
+once per value — so every value compares against the same file. The first value
+to run creates it; the rest fail with `Expected to match the snapshot` even
+though nothing is wrong with them:
+
+```bash
+function provide_values() { echo "alpha"; echo "beta"; }
+
+# @data_provider provide_values
+function test_shared() {
+  assert_match_snapshot "value is $1"        # one file for both values
+}
+
+# @data_provider provide_values
+function test_per_value() {
+  assert_match_named_snapshot "$1" "value is $1"   # one file per value
+}
+```
+
+Use [assert_match_named_snapshot](#assert-match-named-snapshot) with the value
+as the name to give each data set its own.
+:::
 
 See [Snapshots](/snapshots) for the full workflow, including how to update a snapshot after an intentional change.
 
@@ -9480,16 +11517,23 @@ SH
   local env_file=".env"
   local env_line="BASHUNIT_BOOTSTRAP=$bootstrap_file"
   if [ -f "$env_file" ]; then
-    if grep -q "^BASHUNIT_BOOTSTRAP=" "$env_file"; then
-      if bashunit::check_os::is_macos; then
-        sed -i '' -e "s/^BASHUNIT_BOOTSTRAP=/#&/" "$env_file"
-      else
-        sed -i -e "s/^BASHUNIT_BOOTSTRAP=/#&/" "$env_file"
+
+    if grep -Fxq "$env_line" "$env_file"; then
+      echo "> $env_file already sets BASHUNIT_BOOTSTRAP"
+    else
+      if grep -q "^BASHUNIT_BOOTSTRAP=" "$env_file"; then
+        if bashunit::check_os::is_macos; then
+          sed -i '' -e "s/^BASHUNIT_BOOTSTRAP=/#&/" "$env_file"
+        else
+          sed -i -e "s/^BASHUNIT_BOOTSTRAP=/#&/" "$env_file"
+        fi
       fi
+      echo "$env_line" >>"$env_file"
+      echo "> Updated $env_file"
     fi
-    echo "$env_line" >>"$env_file"
   else
     echo "$env_line" >"$env_file"
+    echo "> Created $env_file"
   fi
 
   echo "> bashunit initialized in $tests_dir"
@@ -10062,12 +12106,13 @@ function assert_exec() {
     local stdin_file
     stdin_file=$("$MKTEMP")
     printf '%s' "$stdin_input" >"$stdin_file"
-    eval "$cmd" <"$stdin_file" >"$stdout_file" 2>"$stderr_file"
-    local exit_code=$?
+
+    local exit_code=0
+    eval "$cmd" <"$stdin_file" >"$stdout_file" 2>"$stderr_file" || exit_code=$?
     rm -f "$stdin_file"
   else
-    eval "$cmd" >"$stdout_file" 2>"$stderr_file"
-    local exit_code=$?
+    local exit_code=0
+    eval "$cmd" >"$stdout_file" 2>"$stderr_file" || exit_code=$?
   fi
 
   local stdout
@@ -11384,6 +13429,221 @@ function assert_is_file_empty() {
   bashunit::state::add_assertions_passed
 }
 
+function bashunit::assert::file_state() {
+  local path=$1
+  if [ ! -e "$path" ]; then
+    _BASHUNIT_ASSERT_FILE_STATE_OUT="missing"
+  elif [ ! -f "$path" ]; then
+    _BASHUNIT_ASSERT_FILE_STATE_OUT="not-a-file"
+  else
+    _BASHUNIT_ASSERT_FILE_STATE_OUT="file"
+  fi
+}
+_BASHUNIT_ASSERT_FILE_STATE_OUT=""
+
+function assert_is_file_readable() {
+  bashunit::assert::should_skip && return 0
+
+  if [ $# -lt 1 ]; then
+    bashunit::assert::usage_error "${FUNCNAME[0]}" 1 "path" "$#"
+    return 2
+  fi
+
+  local expected="$1"
+  bashunit::assert::file_state "$expected"
+  case "$_BASHUNIT_ASSERT_FILE_STATE_OUT" in
+  missing)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to be readable" "but does not exist"
+    return
+    ;;
+  not-a-file)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to be readable" "but is not a file"
+    return
+    ;;
+  esac
+
+  if [ ! -r "$expected" ]; then
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to be readable" "but is not readable"
+    return
+  fi
+
+  bashunit::state::add_assertions_passed
+}
+
+function assert_is_file_not_readable() {
+  bashunit::assert::should_skip && return 0
+
+  if [ $# -lt 1 ]; then
+    bashunit::assert::usage_error "${FUNCNAME[0]}" 1 "path" "$#"
+    return 2
+  fi
+
+  local expected="$1"
+  bashunit::assert::file_state "$expected"
+  case "$_BASHUNIT_ASSERT_FILE_STATE_OUT" in
+  missing)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to not be readable" "but does not exist"
+    return
+    ;;
+  not-a-file)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to not be readable" "but is not a file"
+    return
+    ;;
+  esac
+
+  if [ -r "$expected" ]; then
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to not be readable" "but is readable"
+    return
+  fi
+
+  bashunit::state::add_assertions_passed
+}
+
+function assert_is_file_writable() {
+  bashunit::assert::should_skip && return 0
+
+  if [ $# -lt 1 ]; then
+    bashunit::assert::usage_error "${FUNCNAME[0]}" 1 "path" "$#"
+    return 2
+  fi
+
+  local expected="$1"
+  bashunit::assert::file_state "$expected"
+  case "$_BASHUNIT_ASSERT_FILE_STATE_OUT" in
+  missing)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to be writable" "but does not exist"
+    return
+    ;;
+  not-a-file)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to be writable" "but is not a file"
+    return
+    ;;
+  esac
+
+  if [ ! -w "$expected" ]; then
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to be writable" "but is not writable"
+    return
+  fi
+
+  bashunit::state::add_assertions_passed
+}
+
+function assert_is_file_not_writable() {
+  bashunit::assert::should_skip && return 0
+
+  if [ $# -lt 1 ]; then
+    bashunit::assert::usage_error "${FUNCNAME[0]}" 1 "path" "$#"
+    return 2
+  fi
+
+  local expected="$1"
+  bashunit::assert::file_state "$expected"
+  case "$_BASHUNIT_ASSERT_FILE_STATE_OUT" in
+  missing)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to not be writable" "but does not exist"
+    return
+    ;;
+  not-a-file)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to not be writable" "but is not a file"
+    return
+    ;;
+  esac
+
+  if [ -w "$expected" ]; then
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to not be writable" "but is writable"
+    return
+  fi
+
+  bashunit::state::add_assertions_passed
+}
+
+function assert_is_file_executable() {
+  bashunit::assert::should_skip && return 0
+
+  if [ $# -lt 1 ]; then
+    bashunit::assert::usage_error "${FUNCNAME[0]}" 1 "path" "$#"
+    return 2
+  fi
+
+  local expected="$1"
+  bashunit::assert::file_state "$expected"
+  case "$_BASHUNIT_ASSERT_FILE_STATE_OUT" in
+  missing)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to be executable" "but does not exist"
+    return
+    ;;
+  not-a-file)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to be executable" "but is not a file"
+    return
+    ;;
+  esac
+
+  if [ ! -x "$expected" ]; then
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to be executable" "but is not executable"
+    return
+  fi
+
+  bashunit::state::add_assertions_passed
+}
+
+function assert_is_file_not_executable() {
+  bashunit::assert::should_skip && return 0
+
+  if [ $# -lt 1 ]; then
+    bashunit::assert::usage_error "${FUNCNAME[0]}" 1 "path" "$#"
+    return 2
+  fi
+
+  local expected="$1"
+  bashunit::assert::file_state "$expected"
+  case "$_BASHUNIT_ASSERT_FILE_STATE_OUT" in
+  missing)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to not be executable" "but does not exist"
+    return
+    ;;
+  not-a-file)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to not be executable" "but is not a file"
+    return
+    ;;
+  esac
+
+  if [ -x "$expected" ]; then
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to not be executable" "but is executable"
+    return
+  fi
+
+  bashunit::state::add_assertions_passed
+}
+
+function assert_is_file_not_empty() {
+  bashunit::assert::should_skip && return 0
+
+  if [ $# -lt 1 ]; then
+    bashunit::assert::usage_error "${FUNCNAME[0]}" 1 "path" "$#"
+    return 2
+  fi
+
+  local expected="$1"
+  bashunit::assert::file_state "$expected"
+  case "$_BASHUNIT_ASSERT_FILE_STATE_OUT" in
+  missing)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to not be empty" "but does not exist"
+    return
+    ;;
+  not-a-file)
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to not be empty" "but is not a file"
+    return
+    ;;
+  esac
+
+  if [ ! -s "$expected" ]; then
+    bashunit::assert::fail_with "${2:-}" "${expected}" "to not be empty" "but is empty"
+    return
+  fi
+
+  bashunit::state::add_assertions_passed
+}
+
 function assert_files_equals() {
   bashunit::assert::should_skip && return 0
 
@@ -11420,7 +13680,7 @@ function assert_file_contains() {
   local file="$1"
   local string="$2"
 
-  if ! grep -F -q "$string" "$file"; then
+  if ! grep -F -q -e "$string" -- "$file"; then
     bashunit::assert::fail_with "" "${file}" "to contain" "${string}"
     return
   fi
@@ -11434,7 +13694,7 @@ function assert_file_not_contains() {
   local file="$1"
   local string="$2"
 
-  if grep -q "$string" "$file"; then
+  if grep -F -q -e "$string" -- "$file"; then
     bashunit::assert::fail_with "" "${file}" "to not contain" "${string}"
     return
   fi
@@ -11655,7 +13915,7 @@ function assert_is_directory_not_writable() {
 
 function bashunit::assert_json::require_jq() {
   if ! command -v jq >/dev/null 2>&1; then
-    bashunit::skip "jq is required for JSON assertions"
+    bashunit::skip::__mark "jq is required for JSON assertions" 3
     return 1
   fi
   return 0
@@ -11671,6 +13931,38 @@ function assert_json_key_exists() {
   local result
   if ! result=$(printf '%s' "$json" | jq -e "$key" 2>/dev/null) || [ "$result" = "null" ]; then
     bashunit::assert::fail_with "" "${json}" "to have key" "${key}"
+    return
+  fi
+
+  bashunit::state::add_assertions_passed
+}
+
+function assert_json_key_not_exists() {
+  bashunit::assert::should_skip && return 0
+  if [ "$#" -lt 2 ]; then
+    bashunit::assert::usage_error "${FUNCNAME[0]}" 2 "key, json" "$#"
+    return 2
+  fi
+  bashunit::assert_json::require_jq || return 0
+
+  local key="$1"
+  local json="$2"
+
+  if ! printf '%s' "$json" | jq -e 'true' >/dev/null 2>&1; then
+    bashunit::assert::fail_with "" "${json}" "to be valid JSON" ""
+    return
+  fi
+
+  local exists
+  if ! exists=$(printf '%s' "$json" | jq -r \
+    "(path($key)) as \$path | if \$path == [] then true else any(paths; . == \$path) end" \
+    2>/dev/null); then
+    bashunit::assert::fail_with "" "${json}" "to use a valid key path" "${key}"
+    return
+  fi
+
+  if [ "$exists" = true ]; then
+    bashunit::assert::fail_with "" "${json}" "to not have key" "${key}"
     return
   fi
 
@@ -11713,6 +14005,61 @@ function assert_json_equals() {
 
   if [ "$expected_valid" = false ] || [ "$actual_valid" = false ] ||
     [ "$expected_sorted" != "$actual_sorted" ]; then
+    bashunit::assert::fail_with "" "${expected}" "but got " "${actual}"
+    return
+  fi
+
+  bashunit::state::add_assertions_passed
+}
+
+function assert_json_length() {
+  bashunit::assert::should_skip && return 0
+  if [ "$#" -lt 3 ]; then
+    bashunit::assert::usage_error "${FUNCNAME[0]}" 3 "expected, key, json" "$#"
+    return 2
+  fi
+
+  local expected="$1"
+  local key="$2"
+  local json="$3"
+
+  case "$expected" in
+  '' | *[!0-9]*)
+    bashunit::assert::usage_error_detail "${FUNCNAME[0]}" \
+      "expects a non-negative integer length, got '$expected'"
+    return 2
+    ;;
+  esac
+
+  bashunit::assert_json::require_jq || return 0
+
+  if ! printf '%s' "$json" | jq -e 'true' >/dev/null 2>&1; then
+    bashunit::assert::fail_with "" "${json}" "to be valid JSON" ""
+    return
+  fi
+
+  local exists
+  if ! exists=$(printf '%s' "$json" | jq -r \
+    "(path($key)) as \$path | if \$path == [] then true else any(paths; . == \$path) end" \
+    2>/dev/null); then
+    bashunit::assert::fail_with "" "${json}" "to use a valid key path" "${key}"
+    return
+  fi
+  if [ "$exists" != true ]; then
+    bashunit::assert::fail_with "" "${json}" "to have path" "${key}"
+    return
+  fi
+
+  local actual
+  local length_filter
+  length_filter="$key | if type == \"array\" or type == \"object\" or type == \"string\""
+  length_filter="$length_filter then length else error(\"unsupported type\") end"
+  if ! actual=$(printf '%s' "$json" | jq -r "$length_filter" 2>/dev/null); then
+    bashunit::assert::fail_with "" "${json}" "to have a measurable length at path" "${key}"
+    return
+  fi
+
+  if [ "$actual" != "$expected" ]; then
     bashunit::assert::fail_with "" "${expected}" "but got " "${actual}"
     return
   fi
@@ -11801,7 +14148,10 @@ function bashunit::snapshot::normalize_path() {
   builtin echo "$path"
 }
 
-function bashunit::snapshot::report_unused() {
+_BASHUNIT_SNAPSHOT_UNUSED_OUT=""
+_BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT=0
+
+function bashunit::snapshot::collect_unused() {
   local -a search_paths=()
   local path
   for path in "$@"; do
@@ -11838,9 +14188,22 @@ function bashunit::snapshot::report_unused() {
 
   local unused=""
   local total=0
-  local dir file normalized
+  local dir file normalized parent disk_owners candidate
   while IFS= read -r dir; do
     [ -z "$dir" ] && continue
+
+    case "$dir" in
+    */snapshots) parent="${dir%/snapshots}" ;;
+    snapshots) parent="." ;;
+    *) parent="$dir" ;;
+    esac
+    disk_owners=""
+    for candidate in "$parent"/*; do
+      [ -f "$candidate" ] || continue
+      bashunit::helper::normalize_variable_name_to_slot "${candidate##*/}"
+      disk_owners="$disk_owners$_BASHUNIT_HELPER_VARNAME_OUT
+"
+    done
     for file in "$dir"/*.snapshot; do
       [ -f "$file" ] || continue
       normalized="$(bashunit::snapshot::normalize_path "$file")"
@@ -11851,7 +14214,12 @@ function bashunit::snapshot::report_unused() {
       owner="${owner%%.*}"
       case "$owners" in
       *"$owner"$'\n'*) ;;
-      *) continue ;;
+      *)
+
+        case "$disk_owners" in
+        *"$owner"$'\n'*) continue ;;
+        esac
+        ;;
       esac
       total=$((total + 1))
       unused="$unused  $normalized
@@ -11859,16 +14227,63 @@ function bashunit::snapshot::report_unused() {
     done
   done < <(find "${search_paths[@]}" -type d -name snapshots 2>/dev/null | sort -u)
 
-  if [ "$total" -eq 0 ]; then
+  _BASHUNIT_SNAPSHOT_UNUSED_OUT="$unused"
+  _BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT="$total"
+}
+
+function bashunit::snapshot::report_unused() {
+  bashunit::snapshot::collect_unused "$@"
+
+  if [ "$_BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT" -eq 0 ]; then
     printf "\n%sNo unused snapshots.%s\n" \
       "${_BASHUNIT_COLOR_FAINT}" "${_BASHUNIT_COLOR_DEFAULT}"
     return
   fi
 
   printf "\n%sUnused snapshots (%s), no test resolved them:%s\n%s" \
-    "${_BASHUNIT_COLOR_SKIPPED}" "$total" "${_BASHUNIT_COLOR_DEFAULT}" "$unused"
-  printf "%sNothing was deleted. Delete them yourself once you have checked the tests are gone.%s\n" \
+    "${_BASHUNIT_COLOR_SKIPPED}" "$_BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT" \
+    "${_BASHUNIT_COLOR_DEFAULT}" "$_BASHUNIT_SNAPSHOT_UNUSED_OUT"
+  printf "%sNothing was deleted. Run with --snapshot-prune to remove them.%s\n" \
     "${_BASHUNIT_COLOR_FAINT}" "${_BASHUNIT_COLOR_DEFAULT}"
+}
+
+function bashunit::snapshot::prune_unused() {
+  if [ "${_BASHUNIT_TESTS_FAILED:-0}" -gt 0 ]; then
+    printf "\n%sSnapshots were not pruned: the run has failing tests, so a%s\n" \
+      "${_BASHUNIT_COLOR_SKIPPED}" "${_BASHUNIT_COLOR_DEFAULT}"
+    printf "%ssnapshot may be unresolved rather than unused.%s\n" \
+      "${_BASHUNIT_COLOR_SKIPPED}" "${_BASHUNIT_COLOR_DEFAULT}"
+    return
+  fi
+
+  bashunit::snapshot::collect_unused "$@"
+
+  if [ "$_BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT" -eq 0 ]; then
+    printf "\n%sNo unused snapshots.%s\n" \
+      "${_BASHUNIT_COLOR_FAINT}" "${_BASHUNIT_COLOR_DEFAULT}"
+    return
+  fi
+
+  printf "\n%sDeleted %s unused snapshot(s):%s\n" \
+    "${_BASHUNIT_COLOR_SKIPPED}" "$_BASHUNIT_SNAPSHOT_UNUSED_COUNT_OUT" \
+    "${_BASHUNIT_COLOR_DEFAULT}"
+
+  local entry path
+  while IFS= read -r entry; do
+
+    path="${entry#"${entry%%[![:space:]]*}"}"
+    [ -n "$path" ] || continue
+    case "$path" in
+    *.snapshot) ;;
+    *) continue ;;
+    esac
+    [ -f "$path" ] || continue
+
+    printf "  %s\n" "$path"
+    rm -f "$path"
+  done <<EOF
+$_BASHUNIT_SNAPSHOT_UNUSED_OUT
+EOF
 }
 
 function bashunit::snapshot::assert() {
@@ -11876,7 +14291,8 @@ function bashunit::snapshot::assert() {
   local snapshot_file="$2"
   local test_fn="$3"
 
-  if bashunit::env::is_snapshot_report_unused_enabled; then
+  if bashunit::env::is_snapshot_report_unused_enabled ||
+    bashunit::env::is_snapshot_prune_enabled; then
     printf '%s\n' "$snapshot_file" >>"${SNAPSHOT_USED_OUTPUT_PATH:-/dev/null}" 2>/dev/null || true
   fi
 
@@ -12049,10 +14465,15 @@ function bashunit::unmock() {
     if [ "${_BASHUNIT_MOCKED_FUNCTIONS[$i]:-}" = "$command" ]; then
       unset "_BASHUNIT_MOCKED_FUNCTIONS[$i]"
       unset -f "$command"
+
+      bashunit::sandbox::restore_shim "$command"
       local variable
       variable="$(bashunit::helper::normalize_variable_name "$command")"
       local times_file_var="_BASHUNIT_SPY_${variable}_TIMES_FILE"
       local params_file_var="_BASHUNIT_SPY_${variable}_PARAMS_FILE"
+      local sequence_file_var="_BASHUNIT_MOCK_${variable}_SEQUENCE_FILE"
+      [ -f "${!sequence_file_var-}" ] && rm -f "${!sequence_file_var}"
+      unset "$sequence_file_var"
       [ -f "${!times_file_var-}" ] && rm -f "${!times_file_var}"
       [ -f "${!params_file_var-}" ] && rm -f "${!params_file_var}"
       unset "$times_file_var"
@@ -12069,9 +14490,32 @@ function bashunit::doubles::is_exit_code() {
   return 0
 }
 
+function bashunit::doubles::refuse_unusable_name() {
+  local fn=$1 command=$2
+
+  case "$command" in
+  '')
+    bashunit::assert::fail_with "" "$fn" "expects a command name, got" "nothing"
+    return 0
+    ;;
+  *[[:space:]\;\|\&\(\)\{\}\<\>\"\'\`]*)
+
+    bashunit::assert::fail_with "" "$command" \
+      "is not a usable command name for $fn; name the command alone, as in" "$fn ls"
+    return 0
+    ;;
+  esac
+
+  return 1
+}
+
 function bashunit::mock() {
   local command=$1
   shift
+
+  if bashunit::doubles::refuse_unusable_name "bashunit::mock" "$command"; then
+    return 1
+  fi
 
   if [ $# -eq 1 ] && bashunit::doubles::is_exit_code "$1"; then
     eval "function $command() { return $1; }"
@@ -12082,6 +14526,77 @@ function bashunit::mock() {
   fi
 
   export -f "${command?}"
+
+  _BASHUNIT_MOCKED_FUNCTIONS[${#_BASHUNIT_MOCKED_FUNCTIONS[@]}]="$command"
+}
+
+function bashunit::mock_sequence() {
+  local command=$1
+  shift
+
+  if bashunit::doubles::refuse_unusable_name "bashunit::mock_sequence" "$command"; then
+    return 1
+  fi
+
+  if [ $# -eq 0 ]; then
+    bashunit::assert::usage_error_detail "bashunit::mock_sequence" \
+      "expects at least one answer after the command"
+    return 2
+  fi
+
+  local variable
+  bashunit::helper::normalize_variable_name_to_slot "$command"
+  variable=$_BASHUNIT_HELPER_VARNAME_OUT
+
+  local test_id="${BASHUNIT_CURRENT_TEST_ID:-global}"
+  local step_file
+  step_file=$(bashunit::temp_file "${test_id}_${variable}_sequence")
+  builtin echo 1 >"$step_file"
+  export "_BASHUNIT_MOCK_${variable}_SEQUENCE_FILE"="$step_file"
+
+  local times_file_var="_BASHUNIT_SPY_${variable}_TIMES_FILE"
+  local params_file_var="_BASHUNIT_SPY_${variable}_PARAMS_FILE"
+  local record=""
+  if [ -n "${!times_file_var-}" ]; then
+    record="bashunit::doubles::record_call '${!params_file_var}' '${!times_file_var}' \"\$@\""
+  fi
+
+  local total=$#
+  local index=0
+  local arms=""
+  local entry body
+  for entry in "$@"; do
+    index=$((index + 1))
+    if bashunit::doubles::is_exit_code "$entry"; then
+      body="return $entry"
+    else
+      body="$entry \"\$@\""
+    fi
+
+    if [ "$index" -eq "$total" ]; then
+      arms="$arms
+    *) $body ;;"
+    else
+      arms="$arms
+    $index) $body ;;"
+    fi
+  done
+
+  eval "function $command() {
+    $record
+    local _step=1
+    read -r _step < '$step_file' 2>/dev/null || _step=1
+    case \"\$_step\" in '' | *[!0-9]*) _step=1 ;; esac
+    if [ \"\$_step\" -lt $total ]; then
+      builtin echo \"\$((_step + 1))\" > '$step_file'
+    fi
+    case \"\$_step\" in$arms
+    esac
+  }"
+
+  export -f "${command?}"
+
+  export -f bashunit::doubles::record_call
 
   _BASHUNIT_MOCKED_FUNCTIONS[${#_BASHUNIT_MOCKED_FUNCTIONS[@]}]="$command"
 }
@@ -12212,9 +14727,34 @@ function bashunit::spy::serialize_args_to_slot() {
   _BASHUNIT_SPY_SERIALIZED_OUT=${serialized%$'\x1f'}
 }
 
+function bashunit::doubles::record_call() {
+  local params_file=$1
+  local times_file=$2
+  shift 2
+
+  local raw="$*"
+  local serialized=""
+  local arg
+  for arg in "$@"; do
+    serialized="$serialized$(builtin printf '%q' "$arg")"$'\x1f'
+  done
+  serialized=${serialized%$'\x1f'}
+  builtin printf '%s\x1e%s\n' "$raw" "$serialized" >>"$params_file"
+
+  local count=""
+  read -r count <"$times_file" 2>/dev/null || count=""
+  case "$count" in '' | *[!0-9]*) count=0 ;; esac
+  builtin echo "$((count + 1))" >"$times_file"
+}
+
 function bashunit::spy() {
   local command=$1
   local exit_code_or_impl="${2:-}"
+
+  if bashunit::doubles::refuse_unusable_name "bashunit::spy" "$command"; then
+    return 1
+  fi
+
   local variable
   bashunit::helper::normalize_variable_name_to_slot "$command"
   variable=$_BASHUNIT_HELPER_VARNAME_OUT
@@ -12236,23 +14776,13 @@ function bashunit::spy() {
   fi
 
   eval "function $command() {
-    local raw=\"\$*\"
-    local serialized=\"\"
-    local arg
-    for arg in \"\$@\"; do
-      serialized=\"\$serialized\$(builtin printf '%q' \"\$arg\")\"$'\\x1f'
-    done
-    serialized=\${serialized%$'\\x1f'}
-    builtin printf '%s\x1e%s\\n' \"\$raw\" \"\$serialized\" >> '$params_file'
-    local _c=\"\"
-    read -r _c < '$times_file' 2>/dev/null || _c=\"\"
-    case \"\$_c\" in '' | *[!0-9]*) _c=0 ;; esac
-    _c=\$((_c+1))
-    builtin echo \"\$_c\" > '$times_file'
+    bashunit::doubles::record_call '$params_file' '$times_file' \"\$@\"
     $body_suffix
   }"
 
   export -f "${command?}"
+
+  export -f bashunit::doubles::record_call
 
   _BASHUNIT_MOCKED_FUNCTIONS[${#_BASHUNIT_MOCKED_FUNCTIONS[@]}]="$command"
 }
@@ -12505,6 +15035,37 @@ function assert_have_been_called_nth_with() {
   bashunit::state::add_assertions_passed
 }
 
+function assert_have_never_been_called() {
+  local command=$1
+  bashunit::spy::times_to_slot "$command"
+  local times=$_BASHUNIT_SPY_TIMES_OUT
+  local label="${2:-}"
+  if [ -z "$label" ]; then
+    bashunit::helper::normalize_test_function_name_to_slot "${FUNCNAME[1]}"
+    label=$_BASHUNIT_HELPER_NORMALIZED_OUT
+  fi
+
+  if [ "$_BASHUNIT_SPY_REGISTERED_OUT" = false ]; then
+    bashunit::spy::fail_unregistered "$command" "$label"
+    return
+  fi
+
+  if [ "$times" -ne 0 ]; then
+    bashunit::state::add_assertions_failed
+    bashunit::spy::call_log_to_slot "$command"
+    local unit="times"
+    if [ "$times" -eq 1 ]; then
+      unit="time"
+    fi
+    bashunit::console_results::print_failed_test "${label}" "${command}" \
+      "to have never been called" "" \
+      "actual" "${times} ${unit}" "$_BASHUNIT_SPY_CALL_LOG_OUT"
+    return
+  fi
+
+  bashunit::state::add_assertions_passed
+}
+
 function assert_not_called() {
   local command=$1
   local label="${2:-}"
@@ -12518,6 +15079,8 @@ function assert_not_called() {
 # src/reports/index.sh
 
 # src/reports/collect.sh
+
+_BASHUNIT_REPORTS_FIELD_SEP=$'\037'
 
 function bashunit::reports::__strip_ansi() {
   printf '%s' "$1" | sed -e 's/\x1b\[[0-9;]*[a-zA-Z]//g'
@@ -12574,6 +15137,8 @@ function bashunit::reports::is_enabled() {
     [ -n "${BASHUNIT_REPORT_TAP:-}" ] ||
     [ -n "${BASHUNIT_REPORT_JSON:-}" ] ||
     [ -n "${BASHUNIT_REPORT_MD:-}" ] ||
+    bashunit::env::is_json_output_enabled ||
+    bashunit::env::is_junit_output_enabled ||
     bashunit::env::should_append_step_summary ||
     bashunit::env::should_print_gha_annotations
 }
@@ -12598,16 +15163,15 @@ function bashunit::reports::add_test() {
   esac
 
   if bashunit::parallel::is_enabled; then
-    printf '%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
-      "$(bashunit::helper::encode_base64 "$file")" \
-      "$(bashunit::helper::encode_base64 "$test_name")" \
-      "$(bashunit::helper::encode_base64 "$status")" \
-      "$(bashunit::helper::encode_base64 "$duration")" \
-      "$(bashunit::helper::encode_base64 "$assertions")" \
-      "$(bashunit::helper::encode_base64 "$failure_message")" \
-      "$(bashunit::helper::encode_base64 "$line")" \
-      "$(bashunit::helper::encode_base64 "$retries")" \
-      "$(bashunit::helper::encode_base64 "$test_output")" \
+    local us=$_BASHUNIT_REPORTS_FIELD_SEP
+    local row
+    row="$(bashunit::helper::encode_base64 "$file")$us"
+    row="$row$(bashunit::helper::encode_base64 "$test_name")$us"
+    row="$row$status$us$duration$us$assertions$us"
+    row="$row$(bashunit::helper::encode_base64 "$failure_message")$us"
+    row="$row$line$us$retries$us"
+    row="$row$(bashunit::helper::encode_base64 "$test_output")"
+    printf '%s\n' "$row" \
       >>"${REPORTS_OUTPUT_PATH:-/dev/null}" 2>/dev/null || true
   fi
 
@@ -12626,18 +15190,30 @@ function bashunit::reports::load_spooled() {
   bashunit::reports::is_enabled || return 0
   [ -f "${REPORTS_OUTPUT_PATH:-}" ] || return 0
 
+  _BASHUNIT_REPORTS_TEST_FILES=()
+  _BASHUNIT_REPORTS_TEST_NAMES=()
+  _BASHUNIT_REPORTS_TEST_STATUSES=()
+  _BASHUNIT_REPORTS_TEST_DURATIONS=()
+  _BASHUNIT_REPORTS_TEST_ASSERTIONS=()
+  _BASHUNIT_REPORTS_TEST_FAILURES=()
+  _BASHUNIT_REPORTS_TEST_LINES=()
+  _BASHUNIT_REPORTS_TEST_RETRIES=()
+  _BASHUNIT_REPORTS_TEST_OUTPUTS=()
+
   local file test_name status duration assertions failure_message line retries test_output n
-  while IFS='|' read -r file test_name status duration assertions failure_message line retries test_output; do
+
+  while IFS="$_BASHUNIT_REPORTS_FIELD_SEP" read -r \
+    file test_name status duration assertions failure_message line retries test_output; do
     [ -n "$file" ] || continue
     local n=${#_BASHUNIT_REPORTS_TEST_FILES[@]}
     _BASHUNIT_REPORTS_TEST_FILES[n]=$(bashunit::helper::decode_base64 "$file")
     _BASHUNIT_REPORTS_TEST_NAMES[n]=$(bashunit::helper::decode_base64 "$test_name")
-    _BASHUNIT_REPORTS_TEST_STATUSES[n]=$(bashunit::helper::decode_base64 "$status")
-    _BASHUNIT_REPORTS_TEST_DURATIONS[n]=$(bashunit::helper::decode_base64 "$duration")
-    _BASHUNIT_REPORTS_TEST_ASSERTIONS[n]=$(bashunit::helper::decode_base64 "$assertions")
+    _BASHUNIT_REPORTS_TEST_STATUSES[n]=$status
+    _BASHUNIT_REPORTS_TEST_DURATIONS[n]=$duration
+    _BASHUNIT_REPORTS_TEST_ASSERTIONS[n]=$assertions
     _BASHUNIT_REPORTS_TEST_FAILURES[n]=$(bashunit::helper::decode_base64 "$failure_message")
-    _BASHUNIT_REPORTS_TEST_LINES[n]=$(bashunit::helper::decode_base64 "$line")
-    _BASHUNIT_REPORTS_TEST_RETRIES[n]=$(bashunit::helper::decode_base64 "$retries")
+    _BASHUNIT_REPORTS_TEST_LINES[n]=$line
+    _BASHUNIT_REPORTS_TEST_RETRIES[n]=$retries
     _BASHUNIT_REPORTS_TEST_OUTPUTS[n]=$(bashunit::helper::decode_base64 "$test_output")
   done <"$REPORTS_OUTPUT_PATH"
 }
@@ -12670,8 +15246,10 @@ function bashunit::reports::__junit_classname() {
 }
 
 function bashunit::reports::generate_junit_xml() {
-  local output_file="$1"
+  bashunit::reports::print_junit_xml >"$1"
+}
 
+function bashunit::reports::print_junit_xml() {
   local timestamp
   timestamp=$(date '+%Y-%m-%dT%H:%M:%S')
 
@@ -12726,8 +15304,12 @@ function bashunit::reports::generate_junit_xml() {
     bashunit::reports::__junit_classname "$file"
     classname=$_BASHUNIT_REPORTS_CLASSNAME_OUT
 
+    classname=$(bashunit::reports::__xml_escape "$classname")
+    local escaped_file
+    escaped_file=$(bashunit::reports::__xml_escape "$file")
+
     local case_xml="    <testcase classname=\"$classname\" name=\"$escaped_name\"
-        file=\"$file\" time=\"$test_time\">
+        file=\"$escaped_file\" time=\"$test_time\">
 "
 
     if [ "$status" = "failed" ]; then
@@ -12799,7 +15381,9 @@ retries\">$escaped_flaky</flakyFailure>
       local suite_time_s
       bashunit::reports::__ms_to_s "${suite_time[$s]}"
       suite_time_s=$_BASHUNIT_REPORTS_MS_TO_S_OUT
-      echo "  <testsuite name=\"${suite_files[$s]}\" tests=\"${suite_tests[$s]}\"" \
+      local escaped_suite
+      escaped_suite=$(bashunit::reports::__xml_escape "${suite_files[$s]}")
+      echo "  <testsuite name=\"$escaped_suite\" tests=\"${suite_tests[$s]}\"" \
         "failures=\"${suite_failures[$s]}\" skipped=\"${suite_skipped[$s]}\" errors=\"0\"" \
         "time=\"$suite_time_s\" timestamp=\"$timestamp\">"
       printf '%s' "${cases[$s]}"
@@ -12807,7 +15391,7 @@ retries\">$escaped_flaky</flakyFailure>
     done
 
     echo "</testsuites>"
-  } >"$output_file"
+  }
 }
 
 # src/reports/tap.sh
@@ -12816,6 +15400,13 @@ function bashunit::reports::__tap_message() {
   bashunit::reports::__strip_ansi "$1" |
     tr '\n' ' ' |
     sed -e "s/'/''/g"
+}
+
+function bashunit::reports::__tap_description() {
+  local text="$1"
+  text="${text//\\/\\\\}"
+
+  printf '%s' "${text//[#]/\\#}"
 }
 
 function bashunit::reports::generate_report_tap() {
@@ -12829,7 +15420,8 @@ function bashunit::reports::generate_report_tap() {
     local i seq=0
     for i in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
       seq=$((seq + 1))
-      local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
+      local name
+      name="$(bashunit::reports::__tap_description "${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}")"
       local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
       local failure_message="${_BASHUNIT_REPORTS_TEST_FAILURES[$i]:-}"
 
@@ -12876,7 +15468,10 @@ function bashunit::reports::__json_escape() {
 }
 
 function bashunit::reports::generate_report_json() {
-  local output_file="$1"
+  bashunit::reports::print_report_json >"$1"
+}
+
+function bashunit::reports::print_report_json() {
   local total="${#_BASHUNIT_REPORTS_TEST_NAMES[@]}"
 
   local passed=0 failed=0 skipped=0 incomplete=0 flaky=0 duration_total=0
@@ -12922,7 +15517,7 @@ function bashunit::reports::generate_report_json() {
     done
     printf '  ]\n'
     printf '}\n'
-  } >"$output_file"
+  }
 }
 
 # src/reports/gha.sh
@@ -12931,9 +15526,17 @@ function bashunit::reports::__gha_encode() {
   local text="$1"
   text=$(bashunit::reports::__strip_ansi "$text")
 
-  text="${text//%/%25}"
+  text="${text//[%]/%25}"
   text="${text//$'\r'/%0D}"
   text="${text//$'\n'/%0A}"
+  printf '%s' "$text"
+}
+
+function bashunit::reports::__gha_encode_property() {
+  local text
+  text=$(bashunit::reports::__gha_encode "$1")
+  text="${text//:/%3A}"
+  text="${text//,/%2C}"
   printf '%s' "$text"
 }
 
@@ -12975,14 +15578,15 @@ function bashunit::reports::print_gha_annotations() {
       continue
     fi
 
-    local location="file=${file}"
+    local location="file=$(bashunit::reports::__gha_encode_property "$file")"
     if [ -n "$line" ]; then
       location="${location},line=${line}"
     fi
 
-    local encoded_message
+    local encoded_message encoded_name
     encoded_message=$(bashunit::reports::__gha_encode "$message")
-    echo "::${level} ${location},title=${name}::${encoded_message}"
+    encoded_name=$(bashunit::reports::__gha_encode_property "$name")
+    echo "::${level} ${location},title=${encoded_name}::${encoded_message}"
   done
 }
 
@@ -13002,10 +15606,16 @@ function bashunit::reports::generate_report_html() {
   local tests_incomplete=$(bashunit::state::get_tests_incomplete)
   local tests_snapshot=$(bashunit::state::get_tests_snapshot)
   local tests_failed=$(bashunit::state::get_tests_failed)
+
+  local tests_risky=$(bashunit::state::get_tests_risky)
+  local tests_flaky=$(bashunit::state::get_tests_flaky)
   local time=$(bashunit::clock::total_runtime_in_milliseconds)
 
   local temp_file
   temp_file=$(mktemp "${TMPDIR:-/tmp}/bashunit-report.XXXXXX")
+
+  local _us
+  _us=$(printf '\037')
 
   : >"$temp_file"
   local i
@@ -13014,10 +15624,22 @@ function bashunit::reports::generate_report_html() {
     local name="${_BASHUNIT_REPORTS_TEST_NAMES[$i]:-}"
     local status="${_BASHUNIT_REPORTS_TEST_STATUSES[$i]:-}"
     local test_time="${_BASHUNIT_REPORTS_TEST_DURATIONS[$i]:-}"
-    local test_case="$file|$name|$status|$test_time"
+    local test_case="$file$_us$name$_us$status$_us$test_time"
 
     echo "$test_case" >>"$temp_file"
   done
+
+  local escaped_file
+  escaped_file=$(mktemp "${TMPDIR:-/tmp}/bashunit-report-esc.XXXXXX")
+  awk -v FS="$_us" -v OFS="$_us" '{
+    for (i = 1; i <= NF; i++) {
+      gsub(/&/, "\\&amp;", $i)
+      gsub(/</, "\\&lt;", $i)
+      gsub(/>/, "\\&gt;", $i)
+      gsub(/"/, "\\&quot;", $i)
+    }
+    print
+  }' "$temp_file" >"$escaped_file" && mv "$escaped_file" "$temp_file"
 
   {
     echo "<!DOCTYPE html>"
@@ -13051,6 +15673,8 @@ function bashunit::reports::generate_report_html() {
     echo "        <th>Incomplete</th>"
     echo "        <th>Skipped</th>"
     echo "        <th>Snapshot</th>"
+    echo "        <th>Risky</th>"
+    echo "        <th>Flaky</th>"
     echo "        <th>Time (ms)</th>"
     echo "      </tr>"
     echo "    </thead>"
@@ -13062,6 +15686,8 @@ function bashunit::reports::generate_report_html() {
     echo "        <td>$tests_incomplete</td>"
     echo "        <td>$tests_skipped</td>"
     echo "        <td>$tests_snapshot</td>"
+    echo "        <td>$tests_risky</td>"
+    echo "        <td>$tests_flaky</td>"
     echo "        <td>$time</td>"
     echo "      </tr>"
     echo "    </tbody>"
@@ -13070,7 +15696,7 @@ function bashunit::reports::generate_report_html() {
 
     local current_file=""
     local file name status test_time
-    while IFS='|' read -r file name status test_time; do
+    while IFS="$_us" read -r file name status test_time; do
       if [ "$file" != "$current_file" ]; then
         if [ -n "$current_file" ]; then
           echo "    </tbody>"
@@ -13099,6 +15725,36 @@ function bashunit::reports::generate_report_html() {
       echo "    </tbody>"
       echo "  </table>"
     fi
+
+    local any_failure=false
+    local j
+    for j in "${!_BASHUNIT_REPORTS_TEST_NAMES[@]}"; do
+
+      case "${_BASHUNIT_REPORTS_TEST_STATUSES[$j]:-}" in
+      failed) ;;
+      *) continue ;;
+      esac
+
+      if [ "$any_failure" = false ]; then
+        echo "  <h2>Failures</h2>"
+        any_failure=true
+      fi
+
+      local f_name f_file f_line f_message
+      f_name=$(bashunit::str::html_escape "${_BASHUNIT_REPORTS_TEST_NAMES[$j]:-}")
+      f_file=$(bashunit::str::html_escape "${_BASHUNIT_REPORTS_TEST_FILES[$j]:-}")
+      f_line="${_BASHUNIT_REPORTS_TEST_LINES[$j]:-}"
+      f_message=$(bashunit::str::html_escape \
+        "$(bashunit::reports::__strip_ansi "${_BASHUNIT_REPORTS_TEST_FAILURES[$j]:-}")")
+
+      echo "  <h3>$f_name</h3>"
+      if [ -n "$f_line" ]; then
+        echo "  <p><code>$f_file:$f_line</code></p>"
+      else
+        echo "  <p><code>$f_file</code></p>"
+      fi
+      echo "  <pre>$f_message</pre>"
+    done
 
     echo "</body>"
     echo "</html>"
@@ -13194,9 +15850,16 @@ function bashunit::reports::__md_failures() {
       printf '`%s`\n\n' "$file"
     fi
 
-    echo '```'
+    local fence='```'
+    while :; do
+      case "$message" in
+      *"$fence"*) fence="$fence"'`' ;;
+      *) break ;;
+      esac
+    done
+    printf '%s\n' "$fence"
     printf '%s\n' "$message"
-    echo '```'
+    printf '%s\n' "$fence"
     echo ""
   done
 }
@@ -13355,6 +16018,172 @@ function bashunit::runner::needs_test_duration() {
   bashunit::reports::is_enabled && return 0
   bashunit::env::is_show_execution_time_enabled && return 0
   return 1
+}
+
+# src/runner/sandbox.sh
+
+_BASHUNIT_SANDBOX_BASELINE="awk sed grep cat cut tr sort uniq head tail wc
+date mktemp mkdir rm rmdir mv cp ln touch chmod stat find dirname basename
+base64 cksum od diff sleep env printf test true false expr id getconf
+bc perl python3 uname tput git kill ps sh bash"
+
+_BASHUNIT_SANDBOX_DIR=""
+
+_BASHUNIT_SANDBOX_VIOLATION_FILE=""
+_BASHUNIT_SANDBOX_VIOLATION_SEQ=0
+_BASHUNIT_SANDBOX_ALLOWED=""
+
+_BASHUNIT_SANDBOX_BUILTINS=""
+
+function bashunit::sandbox::_allowed_list() {
+  local allowed="$_BASHUNIT_SANDBOX_BASELINE"
+  if [ -n "${BASHUNIT_SANDBOX_ALLOW:-}" ]; then
+
+    allowed="$allowed $(printf '%s' "$BASHUNIT_SANDBOX_ALLOW" | tr ',' ' ')"
+  fi
+
+  printf ' %s ' "$(printf '%s' "$allowed" | tr '\n' ' ')"
+}
+
+function bashunit::sandbox::is_allowed() {
+  case "$_BASHUNIT_SANDBOX_ALLOWED" in
+  *" $1 "*) return 0 ;;
+  esac
+  return 1
+}
+
+function bashunit::sandbox::shim() {
+  local name=$1
+
+  case "$name" in
+  '' | *[!A-Za-z0-9_.+-]*) return 0 ;;
+  esac
+  case "$_BASHUNIT_SANDBOX_BUILTINS" in
+  *" $name "*) return 0 ;;
+  esac
+  bashunit::sandbox::is_allowed "$name" && return 0
+
+  eval "function $name() { bashunit::sandbox::blocked '$name'; }"
+}
+
+function bashunit::sandbox::restore_shim() {
+  bashunit::env::is_sandbox_enabled || return 0
+  bashunit::sandbox::shim "$1"
+}
+
+function bashunit::sandbox::blocked() {
+  local name=$1
+
+  if [ -n "$_BASHUNIT_SANDBOX_VIOLATION_FILE" ]; then
+    printf '%s\n' "$name" >>"$_BASHUNIT_SANDBOX_VIOLATION_FILE" 2>/dev/null || true
+  fi
+
+  bashunit::sandbox::violation_message "$name" >&2
+  return 127
+}
+
+function bashunit::sandbox::violation_message() {
+  printf "Sandbox: '%s' is not mocked and not allowed. %s\n" \
+    "$1" "Mock it with bashunit::mock, or run with --sandbox-allow $1."
+}
+
+function bashunit::sandbox::prepare() {
+  bashunit::env::is_sandbox_enabled || return 0
+
+  _BASHUNIT_SANDBOX_ALLOWED=$(bashunit::sandbox::_allowed_list)
+
+  _BASHUNIT_SANDBOX_BUILTINS=" $(compgen -b | tr '\n' ' ') "
+
+  local dir="${_BASHUNIT_RUN_OUTPUT_DIR:-${BASHUNIT_TEMP_DIR:-${TMPDIR:-/tmp}}}/sandbox"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  _BASHUNIT_SANDBOX_DIR="$dir"
+  export _BASHUNIT_SANDBOX_DIR
+
+  local link_allowed=true
+  if bashunit::check_os::is_windows; then
+    link_allowed=false
+  fi
+
+  local entry name target
+  local path_dir
+  local IFS=':'
+  for path_dir in $PATH; do
+    [ -n "$path_dir" ] || continue
+    [ -d "$path_dir" ] || continue
+    for entry in "$path_dir"/*; do
+
+      if [ "$link_allowed" = true ]; then
+        [ -f "$entry" ] || continue
+        [ -x "$entry" ] || continue
+      fi
+      name=${entry##*/}
+      if bashunit::sandbox::is_allowed "$name"; then
+        if [ "$link_allowed" = true ] && [ ! -e "$dir/$name" ]; then
+          ln -s "$entry" "$dir/$name" 2>/dev/null || true
+        fi
+        continue
+      fi
+      bashunit::sandbox::shim "$name"
+    done
+  done
+
+  [ "$link_allowed" = true ] || return 0
+
+  unset IFS
+  for name in $_BASHUNIT_SANDBOX_ALLOWED; do
+    [ -e "$dir/$name" ] && continue
+    target=$(command -v "$name" 2>/dev/null) || continue
+    case "$target" in
+    /*) ln -s "$target" "$dir/$name" 2>/dev/null || true ;;
+    esac
+  done
+}
+
+function bashunit::sandbox::activate() {
+  bashunit::env::is_sandbox_enabled || return 0
+  [ -n "$_BASHUNIT_SANDBOX_DIR" ] || return 0
+
+  if bashunit::check_os::is_windows; then
+    return 0
+  fi
+
+  PATH="$_BASHUNIT_SANDBOX_DIR"
+  export PATH
+}
+
+function bashunit::sandbox::begin_test() {
+  bashunit::env::is_sandbox_enabled || return 0
+  [ -n "$_BASHUNIT_SANDBOX_DIR" ] || return 0
+
+  _BASHUNIT_SANDBOX_VIOLATION_SEQ=$((_BASHUNIT_SANDBOX_VIOLATION_SEQ + 1))
+  _BASHUNIT_SANDBOX_VIOLATION_FILE="$_BASHUNIT_SANDBOX_DIR/violation-$$-$_BASHUNIT_SANDBOX_VIOLATION_SEQ"
+  export _BASHUNIT_SANDBOX_VIOLATION_FILE
+  rm -f "$_BASHUNIT_SANDBOX_VIOLATION_FILE" 2>/dev/null || true
+}
+
+function bashunit::sandbox::peek_violation() {
+  bashunit::env::is_sandbox_enabled || return 1
+  [ -n "$_BASHUNIT_SANDBOX_VIOLATION_FILE" ] || return 1
+  [ -s "$_BASHUNIT_SANDBOX_VIOLATION_FILE" ]
+}
+
+_BASHUNIT_SANDBOX_COMMAND_OUT=""
+function bashunit::sandbox::violation_of_test() {
+  _BASHUNIT_SANDBOX_COMMAND_OUT=""
+
+  bashunit::env::is_sandbox_enabled || return 1
+  [ -n "$_BASHUNIT_SANDBOX_VIOLATION_FILE" ] || return 1
+  [ -s "$_BASHUNIT_SANDBOX_VIOLATION_FILE" ] || return 1
+
+  local first=""
+  while IFS= read -r first; do
+    [ -n "$first" ] && break
+  done <"$_BASHUNIT_SANDBOX_VIOLATION_FILE"
+  rm -f "$_BASHUNIT_SANDBOX_VIOLATION_FILE" 2>/dev/null || true
+
+  [ -n "$first" ] || return 1
+  _BASHUNIT_SANDBOX_COMMAND_OUT=$first
+  return 0
 }
 
 # src/runner/payload.sh
@@ -13589,8 +16418,7 @@ function bashunit::runner::_scan_diagnostic_lines() {
       *"too many arguments"* | *"value too great"* | \
       *"not a valid identifier"* | *"unexpected EOF"*)
 
-      local runtime_error="${runtime_output#*: }"
-      _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="${runtime_error//$'\n'/}"
+      _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="${line#*: }"
       return
       ;;
     esac
@@ -13679,6 +16507,17 @@ $usage_after"
   127) _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="command not found (exit code 127)" ;;
   126) _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="not executable (exit code 126)" ;;
   esac
+
+  if bashunit::sandbox::violation_of_test; then
+    local blocked=$_BASHUNIT_SANDBOX_COMMAND_OUT
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="Sandbox: '$blocked' is not mocked and"
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT not"
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT allowed."
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT Mock it with"
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT bashunit::mock,"
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT or run with"
+    _BASHUNIT_RUNNER_RUNTIME_ERROR_OUT="$_BASHUNIT_RUNNER_RUNTIME_ERROR_OUT --sandbox-allow $blocked."
+  fi
 }
 
 function bashunit::runner::classify_kill_signal() {
@@ -13741,6 +16580,8 @@ function bashunit::runner::render_running_file_header() {
 
   if bashunit::env::is_tap_output_enabled; then
     printf "# %s\n" "$script"
+  elif bashunit::env::is_machine_output_enabled; then
+    return
   elif ! bashunit::env::is_simple_output_enabled; then
     if bashunit::env::is_verbose_enabled; then
       printf "\n${_BASHUNIT_COLOR_BOLD}%s${_BASHUNIT_COLOR_DEFAULT}\n" "Running $script"
@@ -13820,7 +16661,7 @@ function bashunit::runner::spinner() {
     return
   fi
 
-  if bashunit::env::is_no_progress_enabled; then
+  if bashunit::env::is_no_progress_enabled || bashunit::env::is_machine_output_enabled; then
     while true; do sleep 1; done
     return
   fi
@@ -13874,6 +16715,10 @@ function bashunit::runner::cleanup_on_exit() {
     bashunit::state::set_test_exit_code "$teardown_status"
   else
     bashunit::state::set_test_exit_code "$exit_code"
+  fi
+
+  if bashunit::sandbox::peek_violation; then
+    bashunit::state::set_test_exit_code 127
   fi
 
   bashunit::state::export_subshell_context
@@ -14106,6 +16951,8 @@ function bashunit::runner::run_tear_down_after_script() {
     if ! bashunit::env::is_simple_output_enabled &&
       ! bashunit::env::is_failures_only_enabled &&
       ! bashunit::env::is_no_progress_enabled &&
+      ! bashunit::env::is_json_output_enabled &&
+      ! bashunit::env::is_junit_output_enabled &&
       ! bashunit::parallel::is_enabled; then
       echo ""
     fi
@@ -14138,6 +16985,8 @@ function bashunit::runner::run_tear_down_after_script() {
   if ! bashunit::env::is_simple_output_enabled &&
     ! bashunit::env::is_failures_only_enabled &&
     ! bashunit::env::is_no_progress_enabled &&
+    ! bashunit::env::is_json_output_enabled &&
+    ! bashunit::env::is_junit_output_enabled &&
     ! bashunit::parallel::is_enabled; then
     echo ""
   fi
@@ -14358,6 +17207,11 @@ function bashunit::runner::parse_data_provider_args() {
     has_metachar=true
   fi
 
+  local trailing="${input##*[!\\]}"
+  if [ $((${#trailing} % 2)) -eq 1 ]; then
+    has_metachar=true
+  fi
+
   if [ "$has_metachar" = false ] && eval "args=($input)" 2>/dev/null; then
 
     args_count=0
@@ -14481,13 +17335,44 @@ function bashunit::runner::order_functions_for_script() {
     _fn_seed=$(((_base + _crc) & 2147483647))
     local -a _shuffled_fns=()
     local _sfn
+
     while IFS= read -r _sfn; do
       [ -n "$_sfn" ] && _shuffled_fns[${#_shuffled_fns[@]}]=$_sfn
-    done < <(printf '%s\n' "${ordered[@]+"${ordered[@]}"}" | bashunit::math::shuffle "$_fn_seed")
+    done <<<"$(printf '%s\n' "${ordered[@]+"${ordered[@]}"}" | bashunit::math::shuffle "$_fn_seed")"
     ordered=("${_shuffled_fns[@]+"${_shuffled_fns[@]}"}")
   fi
 
   _BASHUNIT_RUNNER_ORDERED_FNS_OUT="${ordered[*]+${ordered[*]}}"
+}
+
+function bashunit::runner::report_unusable_provider() {
+  local test_file="$1"
+  local fn_name="$2"
+  local provider="$3"
+
+  local reason
+  if declare -F "$provider" >/dev/null 2>&1; then
+    reason="data provider '$provider' produced no data, so the test never ran"
+  else
+    reason="data provider '$provider' is not defined, so the test never ran"
+  fi
+
+  bashunit::state::add_tests_failed
+  bashunit::console_results::print_error_test "$fn_name" "$reason"
+  local _normalized_fn
+  _normalized_fn="$(bashunit::helper::normalize_test_function_name "$fn_name")"
+  bashunit::reports::add_test_failed "$test_file" "$_normalized_fn" 0 0 "$reason"
+  bashunit::runner::write_failure_result_output "$test_file" "$fn_name" "$reason"
+
+  if bashunit::parallel::is_enabled; then
+    bashunit::runner::parallel_suite_dir_to_slot "$test_file"
+    local suite_dir=$_BASHUNIT_RUNNER_SUITE_DIR_OUT
+    [ -d "$suite_dir" ] || mkdir -p "$suite_dir"
+    local payload="##ASSERTIONS_FAILED=0##ASSERTIONS_PASSED=0##ASSERTIONS_SKIPPED=0"
+    payload="$payload##ASSERTIONS_INCOMPLETE=0##ASSERTIONS_SNAPSHOT=0##TEST_EXIT_CODE=1##"
+    printf '%s\n' "$payload" \
+      >"${suite_dir}/${_BASHUNIT_RUNNER_RESULT_ORDINAL}.result"
+  fi
 }
 
 function bashunit::runner::call_test_functions() {
@@ -14508,8 +17393,6 @@ function bashunit::runner::call_test_functions() {
     return
   fi
 
-  bashunit::helper::check_duplicate_functions "$script" || true
-
   local -a provider_data=()
   local provider_data_count=0
   local -a parsed_data=()
@@ -14518,6 +17401,8 @@ function bashunit::runner::call_test_functions() {
   local _test_ordinal=0
 
   bashunit::helper::build_provider_map "$script"
+
+  bashunit::helper::annotations_validate_or_exit "$script"
 
   local allow_test_parallel=true
   if [ "$_BASHUNIT_PROVIDER_MAP_NO_PARALLEL" = true ]; then
@@ -14557,6 +17442,16 @@ function bashunit::runner::call_test_functions() {
       provider_data_count=$((provider_data_count + 1))
     done <<<"$(bashunit::helper::execute_function_if_exists "$_BASHUNIT_PROVIDER_FN_OUT")"
 
+    if [ "$provider_data_count" -eq 0 ]; then
+
+      _test_ordinal=$((_test_ordinal + 1))
+      _BASHUNIT_RUNNER_RESULT_ORDINAL=$_test_ordinal
+      bashunit::runner::report_unusable_provider \
+        "$script" "$fn_name" "$_BASHUNIT_PROVIDER_FN_OUT"
+      unset -v fn_name
+      continue
+    fi
+
     local data
     for data in "${provider_data[@]+"${provider_data[@]}"}"; do
       parsed_data=()
@@ -14587,6 +17482,8 @@ function bashunit::runner::call_test_functions() {
 _BASHUNIT_RUNNER_EXEC_OUT=""
 _BASHUNIT_RUNNER_TIMED_OUT="false"
 
+_BASHUNIT_RUNNER_TIMEOUT_SECS=0
+
 function bashunit::runner::execute_test_body() {
   local test_file=$1
   shift
@@ -14595,7 +17492,9 @@ function bashunit::runner::execute_test_body() {
 
   exec 5>&1
 
-  trap "exit_code=\$?; bashunit::runner::cleanup_on_exit \"$test_file\" \"\$exit_code\"" EXIT
+  _BASHUNIT_RUNNER_EXIT_FILE=$test_file
+
+  trap 'exit_code=$?; bashunit::runner::cleanup_on_exit "$_BASHUNIT_RUNNER_EXIT_FILE" "$exit_code"' EXIT
   bashunit::state::initialize_assertions_count
 
   if bashunit::env::is_login_shell_enabled; then
@@ -14606,7 +17505,18 @@ function bashunit::runner::execute_test_body() {
     bashunit::coverage::enable_trap
   fi
 
+  bashunit::helper::annotations_for_function "$fn_name"
+  if [ "$_BASHUNIT_ANNOT_SKIP_OUT" = true ]; then
+    bashunit::helper::normalize_test_function_name_to_slot "$fn_name"
+    bashunit::skip::__mark_with_label \
+      "$_BASHUNIT_HELPER_NORMALIZED_OUT" "$_BASHUNIT_ANNOT_REASON_OUT"
+    exit 0
+  fi
+
+  bashunit::sandbox::activate
+
   _BASHUNIT_SETUP_COMPLETED=false
+
   local setup_exit_code=0
   bashunit::runner::run_set_up "$test_file"
   setup_exit_code=$?
@@ -14641,8 +17551,8 @@ function bashunit::runner::run_with_timeout() {
   shift
   local fn_name=$1
   shift
-  local secs
-  secs=$(bashunit::env::test_timeout_secs)
+
+  local secs=$_BASHUNIT_RUNNER_TIMEOUT_SECS
 
   local tmp_dir="${BASHUNIT_TEMP_DIR:-${TMPDIR:-/tmp}}"
   local out_file marker_file
@@ -14654,7 +17564,16 @@ function bashunit::runner::run_with_timeout() {
   (bashunit::runner::execute_test_body "$test_file" "$fn_name" "$@") >"$out_file" 2>&1 &
   local test_pid=$!
   (
-    sleep "$secs"
+
+    exec 3>&- 5>&-
+
+    waited=0
+    while [ "$waited" -lt "$secs" ]; do
+      kill -0 "$$" 2>/dev/null || exit 0
+      kill -0 "$test_pid" 2>/dev/null || exit 0
+      sleep 1
+      waited=$((waited + 1))
+    done
 
     kill -0 "$test_pid" 2>/dev/null || exit 0
     : >"$marker_file"
@@ -14705,8 +17624,24 @@ function bashunit::runner::run_test() {
 
   local test_execution_result
   local timed_out="false"
+
+  bashunit::helper::annotations_for_function "$fn_name"
+  if bashunit::env::is_test_timeout_enabled; then
+    _BASHUNIT_RUNNER_TIMEOUT_SECS=${BASHUNIT_TEST_TIMEOUT:-0}
+  else
+    _BASHUNIT_RUNNER_TIMEOUT_SECS=0
+  fi
+  if [ -n "$_BASHUNIT_ANNOT_TIMEOUT_OUT" ]; then
+    _BASHUNIT_RUNNER_TIMEOUT_SECS=$_BASHUNIT_ANNOT_TIMEOUT_OUT
+  fi
+
+  bashunit::sandbox::begin_test
+
   bashunit::env::resolve_retry_count
   local retry_max=$_BASHUNIT_RETRY_VALIDATED
+  if [ -n "$_BASHUNIT_ANNOT_RETRY_OUT" ]; then
+    retry_max=$_BASHUNIT_ANNOT_RETRY_OUT
+  fi
   local retries_used=0
 
   local first_attempt_result=""
@@ -14726,7 +17661,7 @@ function bashunit::runner::run_test() {
         bashunit::clock::now_to_slot
         start_time=$_BASHUNIT_CLOCK_NOW_OUT
       fi
-      if bashunit::env::is_test_timeout_enabled; then
+      if [ "$_BASHUNIT_RUNNER_TIMEOUT_SECS" -gt 0 ]; then
         bashunit::runner::run_with_timeout "$test_file" "$fn_name" "$@"
         test_execution_result="$_BASHUNIT_RUNNER_EXEC_OUT"
         timed_out="$_BASHUNIT_RUNNER_TIMED_OUT"
@@ -14867,7 +17802,7 @@ function bashunit::runner::run_test() {
     fi
 
     if [ "$timed_out" = "true" ]; then
-      error_message="Test timed out after $(bashunit::env::test_timeout_secs)s"
+      error_message="Test timed out after ${_BASHUNIT_RUNNER_TIMEOUT_SECS}s"
     fi
 
     error_message="$error_message$repeat_note"
@@ -14997,6 +17932,11 @@ function bashunit::runner::list_functions() {
 
   bashunit::runner::order_functions_for_script "$script" "$fns"
 
+  if bashunit::env::is_list_tags_enabled; then
+    bashunit::helper::build_tags_map "$script"
+    return 0
+  fi
+
   local wants_json=false
   if [ "$BASHUNIT_LIST_FORMAT" = "json" ]; then
     wants_json=true
@@ -15048,7 +17988,25 @@ function bashunit::runner::list_functions() {
   done
 }
 
+function bashunit::runner::list_render_tags() {
+  [ -z "$_BASHUNIT_SEEN_TAGS" ] && return 0
+
+  local tag
+
+  local old_ifs="$IFS"
+  IFS=','
+  for tag in $_BASHUNIT_SEEN_TAGS; do
+    printf '%s\n' "$tag"
+  done | sort -u
+  IFS="$old_ifs"
+}
+
 function bashunit::runner::list_render_summary() {
+  if bashunit::env::is_list_tags_enabled; then
+    bashunit::runner::list_render_tags
+    return 0
+  fi
+
   if [ "$BASHUNIT_LIST_FORMAT" = "json" ]; then
     printf '{"count":%s,"tests":[%s]}\n' \
       "$_BASHUNIT_LIST_COUNT" "$_BASHUNIT_LIST_JSON_ITEMS"
@@ -15066,6 +18024,9 @@ function bashunit::runner::load_test_files() {
   local filter=$1
   local tag_filter="${2:-}"
   local exclude_tag_filter="${3:-}"
+
+  _BASHUNIT_ACTIVE_FILTER="$filter"
+  _BASHUNIT_ACTIVE_TAG_FILTER="$tag_filter"
   shift 3
   local IFS=$' \t\n'
   local -a files
@@ -15124,6 +18085,18 @@ function bashunit::runner::load_test_files() {
     local source_err_file source_err source_status
     source_err_file="$_BASHUNIT_RUN_OUTPUT_DIR/source_err"
 
+    if [ ! -d "$_BASHUNIT_RUN_OUTPUT_DIR" ]; then
+      if [ "${_BASHUNIT_RUN_DIR_VANISHED:-false}" = false ]; then
+        _BASHUNIT_RUN_DIR_VANISHED=true
+        printf 'bashunit: the run scratch directory disappeared mid-run: %s\n' \
+          "$_BASHUNIT_RUN_OUTPUT_DIR" >&2
+        printf 'bashunit: recreating it; please report this with the run log (#1137).\n' >&2
+      fi
+      if ! mkdir -p "$_BASHUNIT_RUN_OUTPUT_DIR" 2>/dev/null; then
+        source_err_file=/dev/null
+      fi
+    fi
+
     source "$test_file" 2>"$source_err_file"
     source_status=$?
 
@@ -15143,7 +18116,14 @@ function bashunit::runner::load_test_files() {
     fi
     if [ "$source_failed" = true ]; then
       local message="$source_err"
-      [ -z "$message" ] && message="Failed to source '$test_file' (exit $source_status)"
+      if [ -z "$message" ]; then
+
+        local source_bytes="unknown"
+        if [ -f "$test_file" ]; then
+          source_bytes=$(bashunit::io::file_size "$test_file")
+        fi
+        message="Failed to source '$test_file' (exit $source_status, $source_bytes bytes, no stderr)"
+      fi
       bashunit::runner::record_file_hook_failure \
         "source" "$test_file" "$message" 1 true
       bashunit::runner::clean_set_up_and_tear_down_after_script
@@ -15218,6 +18198,8 @@ function bashunit::runner::load_test_files() {
       continue
     fi
     local _cached_fns="$functions_for_script"
+
+    bashunit::helper::check_duplicate_functions "$test_file" || true
     if bashunit::parallel::is_enabled; then
       bashunit::runner::wait_for_job_slot
 
@@ -15239,7 +18221,7 @@ function bashunit::runner::load_test_files() {
     bashunit::runner::restore_workdir
   done
 
-  if bashunit::parallel::is_enabled; then
+  if bashunit::parallel::is_enabled && ! bashunit::env::is_list_enabled; then
     wait
     bashunit::runner::spinner &
     local spinner_pid=$!
@@ -15247,7 +18229,12 @@ function bashunit::runner::load_test_files() {
 
     disown "$spinner_pid" 2>/dev/null || true
     kill "$spinner_pid" 2>/dev/null || true
-    printf "\r  \r"
+
+    if [ -t 1 ] &&
+      ! bashunit::env::is_no_progress_enabled &&
+      ! bashunit::env::is_machine_output_enabled; then
+      printf "\r  \r"
+    fi
 
     local _stderr_idx=0
     while [ "$_stderr_idx" -lt "$worker_stderr_count" ]; do
@@ -15319,9 +18306,39 @@ function bashunit::runner::load_bench_files() {
     bashunit::helper::generate_id "${bench_file}"
     export BASHUNIT_CURRENT_SCRIPT_ID="$_BASHUNIT_HELPER_ID_OUT"
 
-    source "$bench_file"
+    local source_err_file source_err source_status
+    source_err_file="$_BASHUNIT_RUN_OUTPUT_DIR/bench_source_err"
+    : >"$source_err_file" 2>/dev/null || source_err_file=/dev/null
+
+    source "$bench_file" 2>"$source_err_file"
+    source_status=$?
 
     set +euo pipefail
+
+    source_err=""
+    if [ -s "$source_err_file" ]; then
+      source_err="$(cat "$source_err_file")"
+    fi
+
+    local source_failed=false
+    if [ "$source_status" -ne 0 ]; then
+      source_failed=true
+    else
+      case "$source_err" in
+      *"syntax error"* | *"unexpected EOF"*) source_failed=true ;;
+      esac
+    fi
+    if [ "$source_failed" = true ]; then
+      local message="$source_err"
+      if [ -z "$message" ]; then
+        message="Failed to source '$bench_file' (exit $source_status)"
+      fi
+      bashunit::runner::record_file_hook_failure "source" "$bench_file" "$message" 1 true
+      bashunit::runner::clean_set_up_and_tear_down_after_script
+      bashunit::cleanup_script_temp_files
+      bashunit::runner::restore_workdir
+      continue
+    fi
 
     _BASHUNIT_CACHED_ALL_FUNCTIONS=$(compgen -A function)
 
@@ -15387,7 +18404,7 @@ function bashunit::runner::call_bench_functions() {
     local parsed_annotations
     parsed_annotations=$(bashunit::benchmark::parse_annotations "$fn_name" "$script") || exit 1
     read -r revs its max_ms <<<"$parsed_annotations"
-    bashunit::benchmark::run_function "$fn_name" "$revs" "$its" "$max_ms"
+    bashunit::benchmark::run_function "$fn_name" "$revs" "$its" "$max_ms" "$script"
     unset -v fn_name
   done
 
@@ -15406,12 +18423,17 @@ _BASHUNIT_BENCH_ITS=()
 _BASHUNIT_BENCH_AVERAGES=()
 _BASHUNIT_BENCH_MAX_MILLIS=()
 
+_BASHUNIT_BENCH_FILES=()
+_BASHUNIT_BENCH_DURATIONS=()
+
 function bashunit::benchmark::add_result() {
   _BASHUNIT_BENCH_NAMES[${#_BASHUNIT_BENCH_NAMES[@]}]="$1"
   _BASHUNIT_BENCH_REVS[${#_BASHUNIT_BENCH_REVS[@]}]="$2"
   _BASHUNIT_BENCH_ITS[${#_BASHUNIT_BENCH_ITS[@]}]="$3"
   _BASHUNIT_BENCH_AVERAGES[${#_BASHUNIT_BENCH_AVERAGES[@]}]="$4"
   _BASHUNIT_BENCH_MAX_MILLIS[${#_BASHUNIT_BENCH_MAX_MILLIS[@]}]="$5"
+  _BASHUNIT_BENCH_FILES[${#_BASHUNIT_BENCH_FILES[@]}]="${6:-}"
+  _BASHUNIT_BENCH_DURATIONS[${#_BASHUNIT_BENCH_DURATIONS[@]}]="${7:-}"
 }
 
 function bashunit::benchmark::print_results() {
@@ -15552,6 +18574,7 @@ function bashunit::benchmark::run_function() {
   local revs=$2
   local its=$3
   local max_ms=$4
+  local bench_file=${5:-}
   local IFS=$' \t\n'
   local -a durations=()
   local durations_count=0
@@ -15583,1179 +18606,360 @@ function bashunit::benchmark::run_function() {
     sum=$(bashunit::math::calculate "$sum + $d")
   done
   local avg=$(bashunit::math::calculate "$sum / ${#durations[@]}")
-  bashunit::benchmark::add_result "$fn_name" "$revs" "$its" "$avg" "$max_ms"
+  local joined="${durations[*]+${durations[*]}}"
+  bashunit::benchmark::add_result "$fn_name" "$revs" "$its" "$avg" "$max_ms" \
+    "$bench_file" "$joined"
 }
 
-# src/learn/index.sh
+# src/benchmark/reports.sh
 
-# src/learn/progress.sh
+_BASHUNIT_BENCH_STATS_MIN_OUT=""
+_BASHUNIT_BENCH_STATS_MAX_OUT=""
+_BASHUNIT_BENCH_STATS_MEDIAN_OUT=""
 
-declare -r LEARN_PROGRESS_FILE="$HOME/.bashunit_learn_progress"
+function bashunit::benchmark::stats_to_slots() {
+  local durations=$1
+  _BASHUNIT_BENCH_STATS_MIN_OUT=""
+  _BASHUNIT_BENCH_STATS_MAX_OUT=""
+  _BASHUNIT_BENCH_STATS_MEDIAN_OUT=""
 
-function bashunit::learn::mark_completed() {
-  local lesson=$1
-  echo "$lesson" >>"$LEARN_PROGRESS_FILE"
+  [ -n "$durations" ] || return 0
+
+  local stats
+  stats=$(printf '%s\n' "$durations" | env LC_ALL=C awk '
+    {
+      n = 0
+      for (i = 1; i <= NF; i++) { values[++n] = $i + 0 }
+      if (n == 0) { exit }
+      for (i = 2; i <= n; i++) {
+        v = values[i]
+        j = i - 1
+        while (j >= 1 && values[j] > v) { values[j + 1] = values[j]; j-- }
+        values[j + 1] = v
+      }
+      if (n % 2) {
+        median = values[(n + 1) / 2]
+      } else {
+        median = (values[n / 2] + values[n / 2 + 1]) / 2
+      }
+      printf "%.3f %.3f %.3f\n", values[1], values[n], median
+    }
+  ')
+
+  local min max median
+  read -r min max median <<EOF
+$stats
+EOF
+  _BASHUNIT_BENCH_STATS_MIN_OUT=$min
+  _BASHUNIT_BENCH_STATS_MAX_OUT=$max
+  _BASHUNIT_BENCH_STATS_MEDIAN_OUT=$median
 }
 
-function bashunit::learn::is_completed() {
-  local lesson=$1
-  [ -f "$LEARN_PROGRESS_FILE" ] && [ "$("$GREP" -c "^$lesson$" "$LEARN_PROGRESS_FILE" || true)" -gt 0 ]
-}
+function bashunit::benchmark::_verdict() {
+  local index=$1
+  local threshold="${_BASHUNIT_BENCH_MAX_MILLIS[$index]:-}"
+  [ -n "$threshold" ] || return 0
 
-function bashunit::learn::show_progress() {
-  if [ ! -f "$LEARN_PROGRESS_FILE" ]; then
-    echo "${_BASHUNIT_COLOR_INCOMPLETE}No progress yet. Start with lesson 1!${_BASHUNIT_COLOR_DEFAULT}"
-    return
+  if bashunit::math::is_le "${_BASHUNIT_BENCH_AVERAGES[$index]:-0}" "$threshold"; then
+    printf 'true'
+  else
+    printf 'false'
   fi
+}
 
-  echo "${_BASHUNIT_COLOR_BOLD}Your Progress:${_BASHUNIT_COLOR_DEFAULT}"
-  echo ""
-
-  local total_lessons=10
-  local completed=0
-
-  local i
-  for i in $(seq 1 $total_lessons); do
-    if bashunit::learn::is_completed "lesson_$i"; then
-      echo "  ${_BASHUNIT_COLOR_PASSED}✓${_BASHUNIT_COLOR_DEFAULT} Lesson $i completed"
-      ((++completed)) || true
+function bashunit::benchmark::_iterations_json() {
+  local durations=$1
+  local out=""
+  local value
+  local IFS=' '
+  for value in $durations; do
+    if [ -z "$out" ]; then
+      out="$value"
     else
-      echo "  ${_BASHUNIT_COLOR_INCOMPLETE}○${_BASHUNIT_COLOR_DEFAULT} Lesson $i"
+      out="$out, $value"
+    fi
+  done
+  printf '%s' "$out"
+}
+
+function bashunit::benchmark::report_json() {
+  local output_file=$1
+
+  local timestamp
+  timestamp=$(date '+%Y-%m-%dT%H:%M:%S')
+  local os
+  os=$(uname -s 2>/dev/null || printf 'unknown')
+
+  {
+    printf '{\n'
+    printf '  "run": {\n'
+    printf '    "timestamp": "%s",\n' "$timestamp"
+    printf '    "duration_ms": %s,\n' "$(bashunit::benchmark::_run_duration_ms)"
+    printf '    "bashunit_version": "%s",\n' "$(bashunit::reports::__json_escape "${BASHUNIT_VERSION:-unknown}")"
+    printf '    "bash_version": "%s",\n' "${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]}.${BASH_VERSINFO[2]}"
+    printf '    "os": "%s"\n' "$(bashunit::reports::__json_escape "$os")"
+    printf '  },\n'
+    printf '  "benchmarks": [\n'
+
+    local total=${#_BASHUNIT_BENCH_NAMES[@]}
+    local i sep name label file durations threshold verdict
+    for i in $(bashunit::benchmark::_indexes); do
+      name="${_BASHUNIT_BENCH_NAMES[$i]:-}"
+      bashunit::helper::normalize_test_function_name_to_slot "$name"
+      label=$_BASHUNIT_HELPER_NORMALIZED_OUT
+      file="${_BASHUNIT_BENCH_FILES[$i]:-}"
+      durations="${_BASHUNIT_BENCH_DURATIONS[$i]:-}"
+      bashunit::benchmark::stats_to_slots "$durations"
+      threshold="${_BASHUNIT_BENCH_MAX_MILLIS[$i]:-}"
+      verdict=$(bashunit::benchmark::_verdict "$i")
+      sep=","
+      [ "$i" -eq "$((total - 1))" ] && sep=""
+
+      printf '    {\n'
+      printf '      "file": "%s",\n' "$(bashunit::reports::__json_escape "$file")"
+      printf '      "function": "%s",\n' "$(bashunit::reports::__json_escape "$name")"
+      printf '      "name": "%s",\n' "$(bashunit::reports::__json_escape "$label")"
+      printf '      "revs": %s,\n' "${_BASHUNIT_BENCH_REVS[$i]:-0}"
+      printf '      "its": %s,\n' "${_BASHUNIT_BENCH_ITS[$i]:-0}"
+      printf '      "iterations_ms": [%s],\n' "$(bashunit::benchmark::_iterations_json "$durations")"
+      printf '      "average_ms": %s,\n' "${_BASHUNIT_BENCH_AVERAGES[$i]:-0}"
+      printf '      "min_ms": %s,\n' "${_BASHUNIT_BENCH_STATS_MIN_OUT:-0}"
+      printf '      "max_ms": %s,\n' "${_BASHUNIT_BENCH_STATS_MAX_OUT:-0}"
+      printf '      "median_ms": %s,\n' "${_BASHUNIT_BENCH_STATS_MEDIAN_OUT:-0}"
+
+      printf '      "threshold_ms": %s,\n' "${threshold:-null}"
+      printf '      "within_threshold": %s\n' "${verdict:-null}"
+      printf '    }%s\n' "$sep"
+    done
+
+    printf '  ]\n'
+    printf '}\n'
+  } >"$output_file"
+}
+
+function bashunit::benchmark::report_junit() {
+  local output_file=$1
+
+  local timestamp
+  timestamp=$(date '+%Y-%m-%dT%H:%M:%S')
+  local total=${#_BASHUNIT_BENCH_NAMES[@]}
+  local failures=0
+  local i verdict
+  for i in $(bashunit::benchmark::_indexes); do
+    verdict=$(bashunit::benchmark::_verdict "$i")
+    if [ "$verdict" = "false" ]; then
+      failures=$((failures + 1))
     fi
   done
 
-  echo ""
-  echo "Progress: $completed/$total_lessons lessons completed"
+  local run_seconds
+  bashunit::reports::__ms_to_s "$(bashunit::benchmark::_run_duration_ms)"
+  run_seconds=$_BASHUNIT_REPORTS_MS_TO_S_OUT
 
-  if [ $completed -eq $total_lessons ]; then
-    echo ""
-    printf "%s%s🎉 Congratulations! You've completed all lessons!%s\n" \
-      "$_BASHUNIT_COLOR_PASSED" "$_BASHUNIT_COLOR_BOLD" "$_BASHUNIT_COLOR_DEFAULT"
+  {
+    printf '<?xml version="1.0" encoding="UTF-8"?>\n'
+    printf '<testsuites name="bashunit-bench" tests="%s" failures="%s" errors="0" time="%s">\n' \
+      "$total" "$failures" "$run_seconds"
+    printf '  <testsuite name="benchmarks" tests="%s" failures="%s" errors="0" time="%s" timestamp="%s">\n' \
+      "$total" "$failures" "$run_seconds" "$timestamp"
+
+    local name label file classname seconds threshold
+    for i in $(bashunit::benchmark::_indexes); do
+      name="${_BASHUNIT_BENCH_NAMES[$i]:-}"
+      bashunit::helper::normalize_test_function_name_to_slot "$name"
+      label=$(bashunit::reports::__xml_escape "$_BASHUNIT_HELPER_NORMALIZED_OUT")
+      file="${_BASHUNIT_BENCH_FILES[$i]:-}"
+      bashunit::reports::__junit_classname "$file"
+      classname=$_BASHUNIT_REPORTS_CLASSNAME_OUT
+      bashunit::reports::__ms_to_s "${_BASHUNIT_BENCH_AVERAGES[$i]:-0}"
+      seconds=$_BASHUNIT_REPORTS_MS_TO_S_OUT
+      threshold="${_BASHUNIT_BENCH_MAX_MILLIS[$i]:-}"
+
+      printf '    <testcase classname="%s" name="%s" file="%s" time="%s">\n' \
+        "$classname" "$label" "$(bashunit::reports::__xml_escape "$file")" "$seconds"
+      if [ "$(bashunit::benchmark::_verdict "$i")" = "false" ]; then
+        printf '      <failure message="%s" type="PerformanceRegression">%s</failure>\n' \
+          "average ${_BASHUNIT_BENCH_AVERAGES[$i]:-0}ms exceeds @max_ms ${threshold}" \
+          "revs=${_BASHUNIT_BENCH_REVS[$i]:-0} its=${_BASHUNIT_BENCH_ITS[$i]:-0}"
+      fi
+      printf '    </testcase>\n'
+    done
+
+    printf '  </testsuite>\n'
+    printf '</testsuites>\n'
+  } >"$output_file"
+}
+
+function bashunit::benchmark::_indexes() {
+  local total=${#_BASHUNIT_BENCH_NAMES[@]}
+  local i=0
+  while [ "$i" -lt "$total" ]; do
+    printf '%s\n' "$i"
+    i=$((i + 1))
+  done
+}
+
+function bashunit::benchmark::_run_duration_ms() {
+  if [ -z "${_BASHUNIT_START_TIME:-}" ]; then
+    printf '0'
+    return
+  fi
+  local elapsed
+  elapsed=$(bashunit::clock::total_runtime_in_milliseconds)
+  case "$elapsed" in
+  '' | *[!0-9.]*) elapsed=0 ;;
+  esac
+  printf '%s' "$elapsed"
+}
+
+# src/benchmark/baseline.sh
+
+_BASHUNIT_BASELINE_NAMES=()
+_BASHUNIT_BASELINE_MEDIANS=()
+
+function bashunit::benchmark::baseline_load() {
+  local file=$1
+  _BASHUNIT_BASELINE_NAMES=()
+  _BASHUNIT_BASELINE_MEDIANS=()
+
+  if [ ! -f "$file" ] || [ ! -r "$file" ]; then
+    printf "%sError: cannot read the baseline file: '%s'.%s\n" \
+      "${_BASHUNIT_COLOR_FAILED}" "$file" "${_BASHUNIT_COLOR_DEFAULT}" >&2
+    exit 1
   fi
 
-  read -p "Press Enter to continue..." -r
-}
-
-function bashunit::learn::reset_progress() {
-  rm -f "$LEARN_PROGRESS_FILE"
-  echo "${_BASHUNIT_COLOR_PASSED}Progress reset successfully.${_BASHUNIT_COLOR_DEFAULT}"
-  read -p "Press Enter to continue..." -r
-}
-
-# src/learn/session.sh
-
-LEARN_TEMP_DIR=""
-
-function bashunit::learn::init() {
-  LEARN_TEMP_DIR=$("${MKTEMP:-mktemp}" -d "${TMPDIR:-/tmp}/bashunit_learn.XXXXXXXX")
-  mkdir -p tests
-}
-
-function bashunit::learn::cleanup() {
-  if [ -n "${LEARN_TEMP_DIR:-}" ] && [ -d "$LEARN_TEMP_DIR" ]; then
-    rm -rf "$LEARN_TEMP_DIR"
-  fi
-}
-
-function bashunit::learn::create_example_file() {
-  local filename=$1
-  local content=$2
-
-  echo ""
-  echo "Creating example file ${_BASHUNIT_COLOR_BOLD}$filename${_BASHUNIT_COLOR_DEFAULT}..."
-  echo "$content" >"$filename"
-  chmod +x "$filename"
-  echo "${_BASHUNIT_COLOR_PASSED}✓ Created $filename${_BASHUNIT_COLOR_DEFAULT}"
-  echo ""
-  echo "File created! Edit it to complete the TODO items, then run this lesson again."
-  read -p "Press Enter to continue..." -r
-  return 0
-}
-
-function bashunit::learn::run_lesson_test() {
-  local test_file=$1
-  local lesson_number=$2
-
-  echo "${_BASHUNIT_COLOR_BOLD}Running your test...${_BASHUNIT_COLOR_DEFAULT}"
-  echo ""
-
-  if "$BASHUNIT_ROOT_DIR/bashunit" "$test_file" --simple; then
-    echo ""
-    printf "%s%s✓ Excellent! Lesson %s completed!%s\n" \
-      "$_BASHUNIT_COLOR_PASSED" "$_BASHUNIT_COLOR_BOLD" "$lesson_number" "$_BASHUNIT_COLOR_DEFAULT"
-    bashunit::learn::mark_completed "lesson_$lesson_number"
-    read -p "Press Enter to continue..." -r
-    return 0
-  else
-    echo ""
-    echo "${_BASHUNIT_COLOR_FAILED}Not quite right. Review the requirements and try again.${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-}
-
-# src/learn/lessons/basics.sh
-
-function bashunit::learn::lesson_basics() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║                    Lesson 1: Your First Test                   ║
-╚════════════════════════════════════════════════════════════════╝
-
-Welcome to bashunit! Let's write your first test.
-
-CONCEPT: A test is a function that starts with 'test_' and uses
-assertions to verify behavior.
-
-TASK: Create a test file that checks if two values are equal.
-
-File: tests/first_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function test_bashunit_works() {
-  # TODO: Use assert_same to check if "hello" equals "hello"
-  # Hint: assert_same "expected" "actual"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • The assert_same function takes two arguments:
-    assert_same "expected" "actual"
-  • Test functions must start with "test_" prefix
-  • Always quote your strings to avoid word splitting
-  • Keep test files in a tests/ directory for better organization
-EOF
-
-  local default_file="tests/first_test.sh"
-  echo ""
-  printf "When ready, enter file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function test_bashunit_works() {
-  # TODO: Use assert_same to check if "hello" equals "hello"
-  # Hint: assert_same "expected" "actual"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "assert_same" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should use assert_same${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 1
-}
-
-# src/learn/lessons/assertions.sh
-
-function bashunit::learn::lesson_assertions() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║              Lesson 2: Testing Different Conditions            ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: bashunit provides many assertion functions for different checks:
-  • assert_same - exact equality
-  • assert_contains - substring check
-  • assert_matches - regex pattern
-  • assert_not_same - inequality
-  • assert_empty - checks if value is empty
-  • assert_not_empty - checks if value is not empty
-
-TASK: Write a test file with 3 different assertions.
-
-File: tests/assertions_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function test_multiple_assertions() {
-  local message="Hello, bashunit!"
-
-  # TODO: Check that message contains "bashunit"
-  # Hint: assert_contains "substring" "$message"
-
-  # TODO: Check that message matches the pattern "Hello.*!"
-  # Hint: assert_matches "pattern" "$message"
-
-  # TODO: Check that message is not empty
-  # Hint: assert_not_empty "$message"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • assert_same checks exact equality (useful for strings/numbers)
-  • assert_contains is more flexible for partial matches
-  • assert_matches uses regex patterns (e.g., "^[0-9]+$" for numbers)
-  • Explore more: assert_empty, assert_true, assert_false
-EOF
-
-  local default_file="tests/assertions_test.sh"
-  echo ""
-  printf "When ready, enter file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function test_multiple_assertions() {
-  local message="Hello, bashunit!"
-
-  # TODO: Check that message contains "bashunit"
-  # Hint: assert_contains "substring" "$message"
-
-  # TODO: Check that message matches the pattern "Hello.*!"
-  # Hint: assert_matches "pattern" "$message"
-
-  # TODO: Check that message is not empty
-  # Hint: assert_not_empty "$message"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "assert_contains" "$test_file" || true)" -eq 0 ] ||
-    [ "$("$GREP" -c "assert_matches" "$test_file" || true)" -eq 0 ] ||
-    [ "$("$GREP" -c "assert_not_empty" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should use all three assertion types${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 2
-}
-
-# src/learn/lessons/lifecycle.sh
-
-function bashunit::learn::lesson_lifecycle() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║           Lesson 3: Setup and Teardown Functions               ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: Tests often need preparation and cleanup. bashunit provides:
-  • set_up() - runs before EACH test
-  • tear_down() - runs after EACH test
-  • set_up_before_script() - runs once before ALL tests
-  • tear_down_after_script() - runs once after ALL tests
-
-TASK: Create a test that uses setup and teardown to manage files.
-
-File: tests/lifecycle_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function set_up() {
-  # Create a temp file before each test
-  # TODO: export TEST_FILE="/tmp/test_$$"
-  # TODO: echo "test content" > "$TEST_FILE"
-}
-
-function tear_down() {
-  # Clean up after each test
-  # TODO: rm -f "$TEST_FILE"
-}
-
-function test_file_exists() {
-  # TODO: assert_file_exists "$TEST_FILE"
-}
-
-function test_file_has_content() {
-  # TODO: assert_file_contains "test content" "$TEST_FILE"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • set_up() runs before EACH test (good for test isolation)
-  • set_up_before_script() runs ONCE before all tests (good for expensive setup)
-  • Always clean up in tear_down() to avoid polluting other tests
-  • Use $$ for unique temp file names to avoid conflicts
-EOF
-
-  local default_file="tests/lifecycle_test.sh"
-  echo ""
-  printf "When ready, enter file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  # Create a temp file before each test
-  # TODO: export TEST_FILE="/tmp/test_$$"
-  # TODO: echo "test content" > "$TEST_FILE"
-}
-
-function tear_down() {
-  # Clean up after each test
-  # TODO: rm -f "$TEST_FILE"
-}
-
-function test_file_exists() {
-  # TODO: assert_file_exists "$TEST_FILE"
-}
-
-function test_file_has_content() {
-  # TODO: assert_file_contains "test content" "$TEST_FILE"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "function set_up()" "$test_file" || true)" -eq 0 ] ||
-    [ "$("$GREP" -c "function tear_down()" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should define set_up and tear_down functions${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 3
-}
-
-# src/learn/lessons/functions.sh
-
-function bashunit::learn::lesson_functions() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║              Lesson 4: Testing Bash Functions                  ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: To test functions, source the file containing them, then
-call them in your tests.
-
-TASK: Create a script with a function, then test it.
-
-File: calculator.sh (source code)
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function add() {
-  echo $(($1 + $2))
-}
-───────────────────────────────────────────────────────────────
-
-File: tests/calculator_test.sh (test file)
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function set_up() {
-  # TODO: Source calculator.sh from parent directory
-  # Hint: source ../calculator.sh
-}
-
-function test_add_positive_numbers() {
-  # TODO: Test that add 2 3 returns "5"
-  # Hint: result=$(add 2 3)
-  # Hint: assert_same "5" "$result"
-}
-
-function test_add_negative_numbers() {
-  # TODO: Test that add -2 -3 returns "-5"
-  # Hint: result=$(add -2 -3)
-  # Hint: assert_same "-5" "$result"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • Source files in set_up() to reload them fresh for each test
-  • Capture function output with: result=$(function_name args)
-  • Test edge cases: positive, negative, zero, large numbers
-  • Source files from parent directory: source ../file.sh
-EOF
-
-  local default_file="tests/calculator_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  # TODO: Source calculator.sh from parent directory
-  # Hint: source ../calculator.sh
-}
-
-function test_add_positive_numbers() {
-  # TODO: Test that add 2 3 returns "5"
-  # Hint: result=$(add 2 3)
-  # Hint: assert_same "5" "$result"
-}
-
-function test_add_negative_numbers() {
-  # TODO: Test that add -2 -3 returns "-5"
-  # Hint: result=$(add -2 -3)
-  # Hint: assert_same "-5" "$result"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "source" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should source the calculator.sh file${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 4
-}
-
-# src/learn/lessons/scripts.sh
-
-function bashunit::learn::lesson_scripts() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║                 Lesson 5: Testing Bash Scripts                 ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: Scripts that execute commands directly are tested differently.
-Run them and capture their output.
-
-TASK: Create a script and test its output.
-
-File: greeter.sh (source code)
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-name=${1:-World}
-echo "Hello, $name!"
-───────────────────────────────────────────────────────────────
-
-File: tests/greeter_test.sh (test file)
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function test_default_greeting() {
-  # TODO: Run greeter.sh from parent directory and capture output
-  # Hint: output=$(../greeter.sh)
-
-  # TODO: Assert output contains "Hello, World!"
-  # Hint: assert_contains "Hello, World!" "$output"
-}
-
-function test_custom_greeting() {
-  # TODO: Run greeter.sh with argument "Alice"
-  # Hint: output=$(../greeter.sh "Alice")
-
-  # TODO: Assert output contains "Hello, Alice!"
-  # Hint: assert_contains "Hello, Alice!" "$output"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • Use command substitution: output=$(./script.sh)
-  • Make scripts executable: chmod +x script.sh
-  • Test both default behavior and with various arguments
-  • Scripts run in subshells, so they can't modify parent environment
-  • Run scripts from parent directory: ../script.sh
-EOF
-
-  local default_file="tests/greeter_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function test_default_greeting() {
-  # TODO: Run greeter.sh from parent directory and capture output
-  # Hint: output=$(../greeter.sh)
-
-  # TODO: Assert output contains "Hello, World!"
-  # Hint: assert_contains "Hello, World!" "$output"
-}
-
-function test_custom_greeting() {
-  # TODO: Run greeter.sh with argument "Alice"
-  # Hint: output=$(../greeter.sh "Alice")
-
-  # TODO: Assert output contains "Hello, Alice!"
-  # Hint: assert_contains "Hello, Alice!" "$output"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 5
-}
-
-# src/learn/lessons/mocking.sh
-
-function bashunit::learn::lesson_mocking() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║               Lesson 6: Mocking External Commands              ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: Mocks let you override external commands or functions to
-control their behavior in tests.
-
-TASK: Test a function that uses external commands.
-
-File: system_info.sh (source code)
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function get_system_info() {
-  echo "OS: $(uname -s)"
-}
-───────────────────────────────────────────────────────────────
-
-File: tests/system_info_test.sh (test file)
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function set_up() {
-  source ../system_info.sh
-}
-
-function test_system_info_on_linux() {
-  # TODO: Mock uname to return "Linux"
-  # Hint: mock uname echo "Linux"
-
-  local output
-  output=$(get_system_info)
-
-  # TODO: Assert output contains "OS: Linux"
-}
-
-function test_system_info_on_macos() {
-  # TODO: Mock uname to return "Darwin"
-
-  local output
-  output=$(get_system_info)
-
-  # TODO: Assert output contains "OS: Darwin"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • Mocks replace commands/functions with custom behavior
-  • Syntax: mock command_name echo "mocked output"
-  • Mocks are automatically cleaned up after each test
-  • Use mocks to avoid calling expensive external commands
-EOF
-
-  local default_file="tests/system_info_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  source ../system_info.sh
-}
-
-function test_system_info_on_linux() {
-  # TODO: Mock uname to return "Linux"
-  # Hint: mock uname echo "Linux"
-
-  local output
-  output=$(get_system_info)
-
-  # TODO: Assert output contains "OS: Linux"
-}
-
-function test_system_info_on_macos() {
-  # TODO: Mock uname to return "Darwin"
-
-  local output
-  output=$(get_system_info)
-
-  # TODO: Assert output contains "OS: Darwin"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "mock" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should use mock${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 6
-}
-
-# src/learn/lessons/spies.sh
-
-function bashunit::learn::lesson_spies() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║              Lesson 7: Spies - Verifying Calls                 ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: Spies let you verify that functions were called with specific
-arguments or a certain number of times.
-
-KEY DIFFERENCE: Spies track calls without changing behavior, while
-mocks (Lesson 6) replace the function entirely with custom behavior.
-
-TASK: Use spies to verify function calls.
-
-File: deploy.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function deploy_app() {
-  git push origin main
-  docker build -t myapp .
-  docker push myapp
-}
-───────────────────────────────────────────────────────────────
-
-File: deploy_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function set_up() {
-  source deploy.sh
-}
-
-function test_deploy_calls_git_push() {
-  # TODO: Create spies for git and docker
-  # Hint: spy git
-  # Hint: spy docker
-
-  deploy_app
-
-  # TODO: Assert git was called
-  # Hint: assert_have_been_called git
-
-  # TODO: Assert docker was called
-}
-
-function test_deploy_calls_docker_twice() {
-  # TODO: Spy on docker
-
-  deploy_app
-
-  # TODO: Assert docker was called exactly 2 times
-  # Hint: assert_have_been_called_times 2 docker
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • Spies track calls but don't change behavior (unlike mocks)
-  • assert_have_been_called - verifies at least one call
-  • assert_have_been_called_times N - verifies exact call count
-  • assert_have_been_called_with - verifies specific arguments
-  • Spies are cleaned up automatically after each test
-EOF
-
-  local default_file="deploy_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  source deploy.sh
-}
-
-function test_deploy_calls_git_push() {
-  # TODO: Create spies for git and docker
-  # Hint: spy git
-  # Hint: spy docker
-
-  deploy_app
-
-  # TODO: Assert git was called
-  # Hint: assert_have_been_called git
-
-  # TODO: Assert docker was called
-}
-
-function test_deploy_calls_docker_twice() {
-  # TODO: Spy on docker
-
-  deploy_app
-
-  # TODO: Assert docker was called exactly 2 times
-  # Hint: assert_have_been_called_times 2 docker
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "spy" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should use spy${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 7
-}
-
-# src/learn/lessons/data_providers.sh
-
-function bashunit::learn::lesson_data_providers() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║           Lesson 8: Data Providers - Parameterized Tests       ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: Data providers let you run the same test with different inputs.
-Define a function that echoes test data, one per line.
-
-HOW IT WORKS: Each line from data_provider_* becomes $1 in your test.
-The test runs once for each line of data.
-
-TASK: Test multiple email formats using a data provider.
-
-File: validator.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function is_valid_email() {
-  local email_pattern='^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
-  [ "$(echo "$1" | "$GREP" -cE "$email_pattern" || true)" -gt 0 ]
-}
-───────────────────────────────────────────────────────────────
-
-File: validator_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function set_up() {
-  source validator.sh
-}
-
-function data_provider_valid_emails() {
-  # TODO: Echo valid email addresses, one per line
-  # Example: echo "user@example.com"
-}
-
-function test_valid_emails() {
-  # $1 contains the email from data provider
-  # TODO: Assert is_valid_email succeeds
-  # Hint: assert_successful_code "is_valid_email \"$1\""
-}
-
-function data_provider_invalid_emails() {
-  # TODO: Echo invalid email addresses, one per line
-  # Example: echo "not-an-email"
-}
-
-function test_invalid_emails() {
-  # TODO: Assert is_valid_email fails
-  # Hint: assert_general_error "is_valid_email \"$1\""
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • Data providers must be named: data_provider_<test_name>
-  • Each line of output becomes one test case
-  • The test function receives the line as $1
-  • Great for testing multiple inputs without duplicating code
-  • You can have multiple data provider/test pairs in one file
-EOF
-
-  local default_file="validator_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  source validator.sh
-}
-
-function data_provider_valid_emails() {
-  # TODO: Echo valid email addresses, one per line
-  # Example: echo "user@example.com"
-}
-
-function test_valid_emails() {
-  # $1 contains the email from data provider
-  # TODO: Assert is_valid_email succeeds
-  # Hint: assert_successful_code "is_valid_email \"$1\""
-}
-
-function data_provider_invalid_emails() {
-  # TODO: Echo invalid email addresses, one per line
-  # Example: echo "not-an-email"
-}
-
-function test_invalid_emails() {
-  # TODO: Assert is_valid_email fails
-  # Hint: assert_general_error "is_valid_email \"$1\""
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  if [ "$("$GREP" -c "function data_provider_" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should define data provider functions${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 8
-}
-
-# src/learn/lessons/exit_codes.sh
-
-function bashunit::learn::lesson_exit_codes() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║             Lesson 9: Testing Exit Codes                       ║
-╚════════════════════════════════════════════════════════════════╝
-
-CONCEPT: Exit codes indicate success (0) or failure (non-zero).
-bashunit provides assertions to test them:
-  • assert_successful_code - expects exit code 0
-  • assert_general_error - expects exit code 1
-  • assert_exit_code N - expects specific exit code N
-
-TASK: Test different exit codes.
-
-File: checker.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function check_file() {
-  if [ ! -e "$1" ]; then
-    echo "File not found" >&2
-    return 127
-  fi
-
-  if [ ! -r "$1" ]; then
-    echo "Permission denied" >&2
-    return 1
-  fi
-
-  echo "File OK"
-  return 0
-}
-───────────────────────────────────────────────────────────────
-
-File: checker_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function set_up() {
-  source checker.sh
-  # Create a test file
-  export TEST_FILE="/tmp/test_file_$$"
-  touch "$TEST_FILE"
-}
-
-function tear_down() {
-  rm -f "$TEST_FILE"
-}
-
-function test_existing_file_returns_success() {
-  # TODO: Assert check_file succeeds with TEST_FILE
-  # Hint: assert_successful_code "check_file '$TEST_FILE'"
-}
-
-function test_missing_file_returns_127() {
-  # TODO: Assert check_file returns exit code 127 for missing file
-  # Hint: assert_exit_code 127 "check_file '/nonexistent/file'"
-}
-───────────────────────────────────────────────────────────────
-
-TIPS:
-  • Exit code 0 = success (assert_successful_code)
-  • Exit code 1 = general error (assert_general_error)
-  • Other codes = specific errors (assert_exit_code N)
-  • Bash uses 'return N' in functions, 'exit N' in scripts
-  • Common codes: 127=not found, 126=not executable, 2=misuse
-EOF
-
-  local default_file="checker_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  source checker.sh
-  # Create a test file
-  export TEST_FILE="/tmp/test_file_$$"
-  touch "$TEST_FILE"
-}
-
-function tear_down() {
-  rm -f "$TEST_FILE"
-}
-
-function test_existing_file_returns_success() {
-  # TODO: Assert check_file succeeds with TEST_FILE
-  # Hint: assert_successful_code "check_file '\''$TEST_FILE'\''"
-}
-
-function test_missing_file_returns_127() {
-  # TODO: Assert check_file returns exit code 127 for missing file
-  # Hint: assert_exit_code 127 "check_file '\''/nonexistent/file'\''"
-}'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  local _exit_assert_pattern="assert_successful_code\|assert_exit_code\|assert_general_error"
-  if [ "$("$GREP" -c "$_exit_assert_pattern" "$test_file" || true)" -eq 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Your test should use exit code assertions${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  bashunit::learn::run_lesson_test "$test_file" 9
-}
-
-# src/learn/lessons/challenge.sh
-
-function bashunit::learn::lesson_challenge() {
-  clear
-  cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║          Lesson 10: Complete Challenge - Backup Script         ║
-╚════════════════════════════════════════════════════════════════╝
-
-FINAL CHALLENGE: Combine everything you've learned!
-
-CONCEPT: Real-world tests combine multiple concepts: lifecycle
-management, assertions, exit codes, and test doubles.
-
-TASK: Create a backup script and comprehensive tests.
-
-File: backup.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-function create_backup() {
-  local source=$1
-  local dest=$2
-
-  if [ ! -d "$source" ]; then
-    echo "Source directory not found" >&2
-    return 1
-  fi
-
-  tar -czf "$dest" -C "$source" .
-  echo "Backup created: $dest"
-}
-───────────────────────────────────────────────────────────────
-
-File: backup_test.sh
-───────────────────────────────────────────────────────────────
-#!/usr/bin/env bash
-
-Your test must include:
-  1. set_up and tear_down functions
-  2. Test successful backup creation
-  3. Test failure when source doesn't exist
-  4. Mock or spy on tar command
-  5. Verify backup file exists
-  6. Check output message
-
-TIP: Combine patterns from all previous lessons!
-EOF
-
-  local default_file="backup_test.sh"
-  echo ""
-  printf "When ready, enter TEST file path %s[%s]%s: " \
-    "${_BASHUNIT_COLOR_FAINT}" "$default_file" "${_BASHUNIT_COLOR_DEFAULT}"
-  read -r test_file
-  test_file="${test_file:-$default_file}"
-
-  if [ ! -f "$test_file" ]; then
-    local template='#!/usr/bin/env bash
-
-function set_up() {
-  source backup.sh
-  # TODO: Create test directories and variables
-}
-
-function tear_down() {
-  # TODO: Clean up test files
-}
-
-function test_successful_backup() {
-  # TODO: Test backup creation
-}
-
-function test_backup_failure_when_source_missing() {
-  # TODO: Test failure case
-}
-
-# Add more tests as needed:
-# - Mock or spy on tar command
-# - Verify backup file exists
-# - Check output message
-#
-# TIPS:
-# - Combine lifecycle (set_up/tear_down) with file assertions
-# - Use spies to verify tar was called correctly
-# - Test both success and failure scenarios
-# - Mock external commands to avoid side effects'
-
-    bashunit::learn::create_example_file "$test_file" "$template"
-    return 1
-  fi
-
-  local -a missing_components=()
-  local missing_components_count=0
-
-  if [ "$("$GREP" -c "function set_up()" "$test_file" || true)" -eq 0 ]; then
-    missing_components[missing_components_count]="set_up function"
-    missing_components_count=$((missing_components_count + 1))
-  fi
-
-  if [ "$("$GREP" -c "function tear_down()" "$test_file" || true)" -eq 0 ]; then
-    missing_components[missing_components_count]="tear_down function"
-    missing_components_count=$((missing_components_count + 1))
-  fi
-
-  if [ "$missing_components_count" -gt 0 ]; then
-    echo "${_BASHUNIT_COLOR_FAILED}Missing required components:${_BASHUNIT_COLOR_DEFAULT}"
-    printf "  - %s\n" "${missing_components[@]}"
-    read -p "Press Enter to continue..." -r
-    return 1
-  fi
-
-  if bashunit::learn::run_lesson_test "$test_file" 10; then
-    echo ""
-    echo "${_BASHUNIT_COLOR_PASSED}${_BASHUNIT_COLOR_BOLD}"
-    cat <<'EOF'
-╔════════════════════════════════════════════════════════════════╗
-║                   🎉 CONGRATULATIONS! 🎉                       ║
-║                                                                ║
-║          You've completed all bashunit lessons!                ║
-║                                                                ║
-║  You now know how to:                                          ║
-║    ✓ Write and run tests                                       ║
-║    ✓ Use various assertions                                    ║
-║    ✓ Manage test lifecycle                                     ║
-║    ✓ Test functions and scripts                                ║
-║    ✓ Mock external dependencies                                ║
-║    ✓ Spy on function calls                                     ║
-║    ✓ Use data providers                                        ║
-║    ✓ Test exit codes                                           ║
-║                                                                ║
-║  Next steps:                                                   ║
-║    • Explore https://bashunit.com                              ║
-║    • Check out /common-patterns for more examples              ║
-║    • Start testing your own bash scripts!                      ║
-╚════════════════════════════════════════════════════════════════╝
-EOF
-    echo "${_BASHUNIT_COLOR_DEFAULT}"
-    read -p "Press Enter to continue..." -r
+  local name median
+  while IFS=$'\t' read -r name median; do
+    [ -n "$name" ] || continue
+    _BASHUNIT_BASELINE_NAMES[${#_BASHUNIT_BASELINE_NAMES[@]}]="$name"
+    _BASHUNIT_BASELINE_MEDIANS[${#_BASHUNIT_BASELINE_MEDIANS[@]}]="$median"
+  done < <(env LC_ALL=C awk '
+    # The document is bashunit s own, one field per line, so the pairing is a
+    # matter of remembering the last "function" seen before each "median_ms".
+    /"function"[[:space:]]*:/ {
+      line = $0
+      sub(/.*"function"[[:space:]]*:[[:space:]]*"/, "", line)
+      sub(/".*/, "", line)
+      fn = line
+    }
+    /"median_ms"[[:space:]]*:/ {
+      line = $0
+      sub(/.*"median_ms"[[:space:]]*:[[:space:]]*/, "", line)
+      sub(/[^0-9.eE+-].*/, "", line)
+      if (fn != "" && line != "") { printf "%s\t%s\n", fn, line; fn = "" }
+    }
+  ' "$file")
+
+  if [ "${#_BASHUNIT_BASELINE_NAMES[@]}" -eq 0 ]; then
+    printf "%sError: the baseline file holds no benchmark results: '%s'.%s\n" \
+      "${_BASHUNIT_COLOR_FAILED}" "$file" "${_BASHUNIT_COLOR_DEFAULT}" >&2
+    exit 1
   fi
 }
 
-# src/learn/menu.sh
+_BASHUNIT_BASELINE_MEDIAN_OUT=""
+function bashunit::benchmark::baseline_median_of() {
+  local wanted=$1
+  local i=0
+  local total=${#_BASHUNIT_BASELINE_NAMES[@]}
+  _BASHUNIT_BASELINE_MEDIAN_OUT=""
 
-function bashunit::learn::print_menu() {
-  cat <<EOF
-${_BASHUNIT_COLOR_BOLD}${_BASHUNIT_COLOR_PASSED}bashunit${_BASHUNIT_COLOR_DEFAULT} - Interactive Learning
-
-Choose a lesson:
-
-  ${_BASHUNIT_COLOR_BOLD}1.${_BASHUNIT_COLOR_DEFAULT} Basics - Your First Test
-  ${_BASHUNIT_COLOR_BOLD}2.${_BASHUNIT_COLOR_DEFAULT} Assertions - Testing Different Conditions
-  ${_BASHUNIT_COLOR_BOLD}3.${_BASHUNIT_COLOR_DEFAULT} Setup & Teardown - Managing Test Lifecycle
-  ${_BASHUNIT_COLOR_BOLD}4.${_BASHUNIT_COLOR_DEFAULT} Testing Functions - Unit Testing Patterns
-  ${_BASHUNIT_COLOR_BOLD}5.${_BASHUNIT_COLOR_DEFAULT} Testing Scripts - Integration Testing
-  ${_BASHUNIT_COLOR_BOLD}6.${_BASHUNIT_COLOR_DEFAULT} Mocking - Test Doubles and Mocks
-  ${_BASHUNIT_COLOR_BOLD}7.${_BASHUNIT_COLOR_DEFAULT} Spies - Verifying Function Calls
-  ${_BASHUNIT_COLOR_BOLD}8.${_BASHUNIT_COLOR_DEFAULT} Data Providers - Parameterized Tests
-  ${_BASHUNIT_COLOR_BOLD}9.${_BASHUNIT_COLOR_DEFAULT} Exit Codes - Testing Success and Failure
-  ${_BASHUNIT_COLOR_BOLD}10.${_BASHUNIT_COLOR_DEFAULT} Complete Challenge - Real World Scenario
-
-  ${_BASHUNIT_COLOR_BOLD}p.${_BASHUNIT_COLOR_DEFAULT} Show Progress
-  ${_BASHUNIT_COLOR_BOLD}r.${_BASHUNIT_COLOR_DEFAULT} Reset Progress
-  ${_BASHUNIT_COLOR_BOLD}q.${_BASHUNIT_COLOR_DEFAULT} Quit
-
-Enter your choice:
-EOF
+  while [ "$i" -lt "$total" ]; do
+    if [ "${_BASHUNIT_BASELINE_NAMES[i]}" = "$wanted" ]; then
+      _BASHUNIT_BASELINE_MEDIAN_OUT="${_BASHUNIT_BASELINE_MEDIANS[i]}"
+      return 0
+    fi
+    i=$((i + 1))
+  done
+  return 1
 }
 
-function bashunit::learn::start() {
-  bashunit::learn::init
+function bashunit::benchmark::baseline_delta() {
+  local before=$1
+  local now=$2
+  local tolerance=$3
 
-  trap 'bashunit::learn::cleanup' EXIT
+  env LC_ALL=C awk -v before="$before" -v now="$now" -v tol="$tolerance" '
+    BEGIN {
+      before = before + 0
+      now = now + 0
+      if (before <= 0) {
+        # No usable previous number: report the change as unknown rather than
+        # dividing by zero and calling it an infinite regression.
+        printf "n/a\tno\n"
+        exit
+      }
+      delta = ((now - before) / before) * 100
+      printf "%+.1f%%\t%s\n", delta, (delta > tol + 0 ? "yes" : "no")
+    }
+  '
+}
 
-  while true; do
-    echo ""
-    bashunit::learn::print_menu
-    read -r choice
-    echo ""
+function bashunit::benchmark::baseline_compare() {
+  local tolerance=$1
+  local regressed=0
 
-    case "$choice" in
-    1) bashunit::learn::lesson_basics || true ;;
-    2) bashunit::learn::lesson_assertions || true ;;
-    3) bashunit::learn::lesson_lifecycle || true ;;
-    4) bashunit::learn::lesson_functions || true ;;
-    5) bashunit::learn::lesson_scripts || true ;;
-    6) bashunit::learn::lesson_mocking || true ;;
-    7) bashunit::learn::lesson_spies || true ;;
-    8) bashunit::learn::lesson_data_providers || true ;;
-    9) bashunit::learn::lesson_exit_codes || true ;;
-    10) bashunit::learn::lesson_challenge || true ;;
-    p) bashunit::learn::show_progress ;;
-    r) bashunit::learn::reset_progress ;;
-    q)
-      echo "${_BASHUNIT_COLOR_PASSED}Happy testing!${_BASHUNIT_COLOR_DEFAULT}"
-      break
-      ;;
-    *)
-      echo "${_BASHUNIT_COLOR_FAILED}Invalid choice. Please try again.${_BASHUNIT_COLOR_DEFAULT}"
-      ;;
-    esac
+  printf "\nBaseline comparison (median ms, tolerance %s%%)\n" "$tolerance"
+  bashunit::print_line 80 "="
+  printf '%-40s %12s %12s %10s\n' "Name" "Baseline" "Current" "Delta"
+
+  local i total name median before delta verdict
+  total=${#_BASHUNIT_BENCH_NAMES[@]}
+  i=0
+  while [ "$i" -lt "$total" ]; do
+    name="${_BASHUNIT_BENCH_NAMES[$i]:-}"
+    bashunit::benchmark::stats_to_slots "${_BASHUNIT_BENCH_DURATIONS[$i]:-}"
+    median=$_BASHUNIT_BENCH_STATS_MEDIAN_OUT
+
+    if ! bashunit::benchmark::baseline_median_of "$name"; then
+      printf '%-40s %12s %12s %10s\n' "$name" "-" "$median" "new"
+      i=$((i + 1))
+      continue
+    fi
+    before=$_BASHUNIT_BASELINE_MEDIAN_OUT
+
+    IFS=$'\t' read -r delta verdict < <(
+      bashunit::benchmark::baseline_delta "$before" "$median" "$tolerance"
+    )
+
+    if [ "$verdict" = "yes" ]; then
+      regressed=$((regressed + 1))
+      printf '%-40s %12s %12s %s%10s%s\n' "$name" "$before" "$median" \
+        "$_BASHUNIT_COLOR_FAILED" "$delta" "$_BASHUNIT_COLOR_DEFAULT"
+    else
+      printf '%-40s %12s %12s %10s\n' "$name" "$before" "$median" "$delta"
+    fi
+    i=$((i + 1))
   done
 
-  bashunit::learn::cleanup
+  local j baseline_total baseline_name found k
+  baseline_total=${#_BASHUNIT_BASELINE_NAMES[@]}
+  j=0
+  while [ "$j" -lt "$baseline_total" ]; do
+    baseline_name="${_BASHUNIT_BASELINE_NAMES[$j]}"
+    found=false
+    k=0
+    while [ "$k" -lt "$total" ]; do
+      if [ "${_BASHUNIT_BENCH_NAMES[$k]:-}" = "$baseline_name" ]; then
+        found=true
+        break
+      fi
+      k=$((k + 1))
+    done
+    if [ "$found" = false ]; then
+      printf '%-40s %12s %12s %10s\n' "$baseline_name" \
+        "${_BASHUNIT_BASELINE_MEDIANS[$j]}" "-" "removed"
+    fi
+    j=$((j + 1))
+  done
+
+  if [ "$regressed" -gt 0 ]; then
+    printf "\n%s%s%s\n" "$_BASHUNIT_COLOR_FAILED" \
+      " Performance regression in $regressed benchmark(s) " "$_BASHUNIT_COLOR_DEFAULT"
+    return 1
+  fi
+
+  return 0
 }
 
 # src/main/index.sh
@@ -16778,11 +18982,79 @@ function bashunit::main::require_non_negative_int_or_exit() {
   esac
 }
 
+function bashunit::main::report_path_is_a_directory() {
+  printf "%sError: %s is a directory, not a file: '%s'.%s\n" \
+    "$_BASHUNIT_COLOR_FAILED" "${2:-path}" "$1" "$_BASHUNIT_COLOR_DEFAULT" >&2
+  exit 1
+}
+
+function bashunit::main::report_unreadable_bootstrap() {
+  local boot_file=$1
+  local raw=${2-}
+
+  if [ ! -e "$boot_file" ]; then
+    printf "%sError: the bootstrap file does not exist: '%s'.%s\n" \
+      "$_BASHUNIT_COLOR_FAILED" "$boot_file" "$_BASHUNIT_COLOR_DEFAULT" >&2
+  elif [ -d "$boot_file" ]; then
+    printf "%sError: the bootstrap path is a directory, not a file: '%s'.%s\n" \
+      "$_BASHUNIT_COLOR_FAILED" "$boot_file" "$_BASHUNIT_COLOR_DEFAULT" >&2
+  elif [ ! -f "$boot_file" ]; then
+
+    printf "%sError: the bootstrap path is not a regular file: '%s'.%s\n" \
+      "$_BASHUNIT_COLOR_FAILED" "$boot_file" "$_BASHUNIT_COLOR_DEFAULT" >&2
+  else
+    printf "%sError: cannot read the bootstrap file: '%s'.%s\n" \
+      "$_BASHUNIT_COLOR_FAILED" "$boot_file" "$_BASHUNIT_COLOR_DEFAULT" >&2
+  fi
+
+  if [ "$raw" != "$boot_file" ] && [ -r "$raw" ]; then
+    printf "%s--env splits its value on the first space to pass bootstrap arguments,%s\n" \
+      "$_BASHUNIT_COLOR_FAINT" "$_BASHUNIT_COLOR_DEFAULT" >&2
+    printf "%sso a path containing one cannot be used. Set BASHUNIT_BOOTSTRAP='%s' instead.%s\n" \
+      "$_BASHUNIT_COLOR_FAINT" "$raw" "$_BASHUNIT_COLOR_DEFAULT" >&2
+  fi
+
+  exit 1
+}
+
+function bashunit::main::require_existing_path_or_exit() {
+  local path=$1
+
+  case "$path" in
+  *"*"*) return 0 ;;
+  esac
+
+  [ -e "$path" ] && return 0
+
+  printf "%sError: no such path: '%s'.%s\n" \
+    "${_BASHUNIT_COLOR_FAILED}" "$path" "${_BASHUNIT_COLOR_DEFAULT}" >&2
+  exit 1
+}
+
+function bashunit::main::option_takes_value() {
+  case "$1" in
+  -a | --assert | -e | --env | --boot | -f | --filter | --exclude-filter | \
+    --tag | --exclude-tag | --sandbox-allow | --output | --list-format | \
+    -j | --jobs | -r | --retry | --repeat | --test-timeout | --order-by | \
+    --seed | --shard | --suite | --coverage-min | --coverage-paths | \
+    --coverage-exclude | --coverage-diff | --log-junit | --log-gha | \
+    --gha-annotations | --report-html | --report-json | --report-junit | \
+    --report-md | --report-tap)
+    return 0
+    ;;
+  esac
+  return 1
+}
+
 function bashunit::main::require_writable_path_or_exit() {
   local path=$1
   local parent=${1%/*}
   [ "$parent" = "$1" ] && parent="."
   [ -z "$parent" ] && parent="/"
+
+  if [ -d "$path" ]; then
+    bashunit::main::report_path_is_a_directory "$path" "${2:-}"
+  fi
 
   if [ -e "$path" ]; then
     [ -w "$path" ] && return 0
@@ -16805,6 +19077,10 @@ function bashunit::main::require_creatable_path_or_exit() {
     esac
   done
   [ -z "$ancestor" ] && ancestor="/"
+
+  if [ -d "$path" ]; then
+    bashunit::main::report_path_is_a_directory "$path" "${2:-}"
+  fi
 
   if [ -d "$ancestor" ] && [ -w "$ancestor" ] &&
     { [ ! -e "$path" ] || [ -w "$path" ]; }; then
@@ -16893,10 +19169,19 @@ function bashunit::main::validate_config_or_exit() {
   fi
 
   case "${BASHUNIT_OUTPUT_FORMAT:-}" in
-  '' | tap) ;;
+  '' | text | tap | json | junit) ;;
   *)
-    printf "%sError: unsupported output format '%s' for --output. Supported: tap.%s\n" \
+    printf "%sError: unsupported output format '%s' for --output. Supported: text, tap, json, junit.%s\n" \
       "${_BASHUNIT_COLOR_FAILED}" "${BASHUNIT_OUTPUT_FORMAT}" "${_BASHUNIT_COLOR_DEFAULT}" >&2
+    exit 1
+    ;;
+  esac
+
+  case "${BASHUNIT_SANDBOX_ALLOW:-}" in
+  '') ;;
+  *[!A-Za-z0-9_.+,-]*)
+    printf "%sError: invalid --sandbox-allow value '%s'. Expected a comma-separated list of commands.%s\n" \
+      "${_BASHUNIT_COLOR_FAILED}" "${BASHUNIT_SANDBOX_ALLOW}" "${_BASHUNIT_COLOR_DEFAULT}" >&2
     exit 1
     ;;
   esac
@@ -17026,16 +19311,19 @@ function bashunit::main::exec_tests() {
 
   local test_files
   local test_files_count=0
+
   local _line
-  while IFS= read -r _line; do
-    [ -z "$_line" ] && continue
-    test_files[test_files_count]="$_line"
-    test_files_count=$((test_files_count + 1))
-  done < <(bashunit::helper::load_test_files "$filter" "$@")
+  if [ "$#" -gt 0 ] || [ "${_BASHUNIT_MAIN_PATHS_GIVEN:-false}" != true ]; then
+    while IFS= read -r _line; do
+      [ -z "$_line" ] && continue
+      test_files[test_files_count]="$_line"
+      test_files_count=$((test_files_count + 1))
+    done < <(bashunit::helper::load_test_files "$filter" "$@")
+  fi
 
   bashunit::internal_log "exec_tests" "filter:$filter" "files:${test_files[*]:-}"
 
-  if [ "$test_files_count" -eq 0 ]; then
+  if [ "$test_files_count" -eq 0 ] && [ "${_BASHUNIT_MAIN_PATHS_GIVEN:-false}" != true ]; then
     printf "%sError: At least one file path is required.%s\n" "${_BASHUNIT_COLOR_FAILED}" "${_BASHUNIT_COLOR_DEFAULT}"
     bashunit::console_header::print_help
     exit 1
@@ -17089,10 +19377,15 @@ function bashunit::main::exec_tests() {
     bashunit::parallel::init
   fi
 
+  bashunit::sandbox::prepare
+
   if bashunit::env::is_list_enabled; then
     :
   elif bashunit::env::is_tap_output_enabled; then
     printf "TAP version 13\n"
+  elif bashunit::env::is_machine_output_enabled; then
+
+    :
   else
     bashunit::console_header::print_version_with_env "$filter" "${test_files[@]}"
   fi
@@ -17102,7 +19395,7 @@ function bashunit::main::exec_tests() {
       BASHUNIT_SEED=$RANDOM
       export -n BASHUNIT_SEED
     fi
-    if ! bashunit::env::is_tap_output_enabled && ! bashunit::env::is_list_enabled; then
+    if ! bashunit::env::is_machine_output_enabled && ! bashunit::env::is_list_enabled; then
       bashunit::console_header::print_random_order_seed "$BASHUNIT_SEED"
     fi
   fi
@@ -17133,11 +19426,12 @@ function bashunit::main::exec_tests() {
     wait
   fi
 
-  if bashunit::parallel::is_enabled && bashunit::parallel::must_stop_on_failure; then
-    printf "\r%sStop on failure enabled...%s\n" "${_BASHUNIT_COLOR_SKIPPED}" "${_BASHUNIT_COLOR_DEFAULT}"
+  if bashunit::parallel::is_enabled && bashunit::parallel::must_stop_on_failure &&
+    ! bashunit::env::is_machine_output_enabled; then
+    printf "%sStop on failure enabled...%s\n" "${_BASHUNIT_COLOR_SKIPPED}" "${_BASHUNIT_COLOR_DEFAULT}"
   fi
 
-  if ! bashunit::env::is_tap_output_enabled; then
+  if ! bashunit::env::is_machine_output_enabled; then
     bashunit::console_results::print_failing_tests_and_reset
     bashunit::console_results::print_risky_tests_and_reset
     bashunit::console_results::print_incomplete_tests_and_reset
@@ -17165,12 +19459,16 @@ function bashunit::main::exec_tests() {
     bashunit::reports::append_step_summary
   fi
 
-  if bashunit::env::is_profile_enabled; then
+  if bashunit::env::is_profile_enabled && ! bashunit::env::is_machine_output_enabled; then
     bashunit::console_results::print_profile_and_reset
   fi
 
   if bashunit::env::is_snapshot_report_unused_enabled; then
     bashunit::snapshot::report_unused ${test_files[@]+"${test_files[@]}"}
+  fi
+
+  if bashunit::env::is_snapshot_prune_enabled; then
+    bashunit::snapshot::prune_unused ${test_files[@]+"${test_files[@]}"}
   fi
 
   if bashunit::env::should_print_gha_annotations; then
@@ -17197,10 +19495,21 @@ function bashunit::main::exec_tests() {
     bashunit::reports::generate_report_json "$BASHUNIT_REPORT_JSON"
   fi
 
+  if bashunit::env::is_json_output_enabled; then
+    bashunit::reports::print_report_json
+  elif bashunit::env::is_junit_output_enabled; then
+    bashunit::reports::print_junit_xml
+  fi
+
   if bashunit::env::is_coverage_enabled; then
     if bashunit::coverage::is_diff_enabled; then
-      bashunit::coverage::report_diff
-    else
+      if bashunit::env::is_machine_output_enabled; then
+
+        bashunit::coverage::report_diff >/dev/null
+      else
+        bashunit::coverage::report_diff
+      fi
+    elif ! bashunit::env::is_machine_output_enabled; then
       bashunit::coverage::report_text
     fi
 
@@ -17260,7 +19569,35 @@ function bashunit::main::exec_benchmarks() {
 
   bashunit::runner::load_bench_files "$filter" "${bench_files[@]}"
 
+  if [ "${#_BASHUNIT_BENCH_NAMES[@]}" -eq 0 ]; then
+    printf "\n%s%s%s\n" "$_BASHUNIT_COLOR_RETURN_ERROR" " No benchmarks found " \
+      "$_BASHUNIT_COLOR_DEFAULT"
+    exit 1
+  fi
+
   bashunit::benchmark::print_results
+
+  if [ -n "${BASHUNIT_BENCH_REPORT_JSON:-}" ]; then
+    bashunit::benchmark::report_json "$BASHUNIT_BENCH_REPORT_JSON"
+  fi
+  if [ -n "${BASHUNIT_BENCH_REPORT_JUNIT:-}" ]; then
+    bashunit::benchmark::report_junit "$BASHUNIT_BENCH_REPORT_JUNIT"
+  fi
+
+  if [ -n "${BASHUNIT_BENCH_BASELINE_UPDATE:-}" ]; then
+    bashunit::benchmark::report_json "$BASHUNIT_BENCH_BASELINE_UPDATE"
+  fi
+
+  if [ -n "${BASHUNIT_BENCH_BASELINE:-}" ]; then
+    bashunit::benchmark::baseline_load "$BASHUNIT_BENCH_BASELINE"
+    if ! bashunit::benchmark::baseline_compare "${BASHUNIT_BENCH_BASELINE_TOLERANCE:-10}"; then
+      exit 1
+    fi
+  fi
+
+  if [ "$(bashunit::state::get_tests_failed)" -gt 0 ]; then
+    exit 1
+  fi
 
   bashunit::internal_log "Finished benchmarks"
 }
@@ -17613,7 +19950,10 @@ function bashunit::main::cmd_doc() {
       fi
     else
 
+      _BASHUNIT_LOADING_BOOTSTRAP="$boot_file"
+
       source "$boot_file" ${BASHUNIT_BOOTSTRAP_ARGS:-}
+      _BASHUNIT_LOADING_BOOTSTRAP=""
     fi
   fi
 
@@ -17627,7 +19967,14 @@ function bashunit::main::cmd_doc() {
     exit 0
   fi
 
-  bashunit::doc::print_asserts "$filter"
+  local rendered
+  rendered=$(bashunit::doc::print_asserts "$filter")
+  if [ -n "$rendered" ]; then
+    printf '%s\n' "$rendered"
+  elif [ -z "$_BASHUNIT_DOC_CUSTOM_FNS_OUT" ]; then
+    printf "No assertion matches '%s'.\n" "$filter"
+    printf 'Run `bashunit doc` without a filter to list them all.\n'
+  fi
 
   if [ -n "$_BASHUNIT_DOC_CUSTOM_FNS_OUT" ]; then
     printf '\n## Custom assertions\n\n'
@@ -17649,18 +19996,6 @@ function bashunit::main::cmd_init() {
   exit 0
 }
 
-function bashunit::main::cmd_learn() {
-  case "${1:-}" in
-  -h | --help)
-    bashunit::console_header::print_learn_help
-    exit 0
-    ;;
-  esac
-
-  bashunit::learn::start
-  exit 0
-}
-
 function bashunit::main::cmd_watch() {
   local path=""
   local -a extra_args=()
@@ -17671,16 +20006,15 @@ function bashunit::main::cmd_watch() {
       bashunit::console_header::print_watch_help
       exit 0
       ;;
-    -f | --filter)
+    -*)
 
       extra_args[${#extra_args[@]}]="$1"
-      shift || true
-      if [ $# -gt 0 ]; then
-        extra_args[${#extra_args[@]}]="$1"
+      if bashunit::main::option_takes_value "$1"; then
+        shift || true
+        if [ $# -gt 0 ]; then
+          extra_args[${#extra_args[@]}]="$1"
+        fi
       fi
-      ;;
-    -*)
-      extra_args[${#extra_args[@]}]="$1"
       ;;
     *)
       if [ -z "$path" ]; then
@@ -17729,6 +20063,45 @@ function bashunit::main::cmd_bench() {
       filter="$2"
       shift
       ;;
+    --baseline)
+      BASHUNIT_BENCH_BASELINE="$2"
+      export -n BASHUNIT_BENCH_BASELINE
+      shift
+      ;;
+    --baseline-tolerance)
+      BASHUNIT_BENCH_BASELINE_TOLERANCE="$2"
+      export -n BASHUNIT_BENCH_BASELINE_TOLERANCE
+      case "$BASHUNIT_BENCH_BASELINE_TOLERANCE" in
+      '' | *[!0-9.]*)
+        printf "%sError: --baseline-tolerance expects a percentage, got '%s'.%s\n" \
+          "${_BASHUNIT_COLOR_FAILED}" "$2" "${_BASHUNIT_COLOR_DEFAULT}" >&2
+        exit 1
+        ;;
+      esac
+      shift
+      ;;
+    --baseline-update)
+      BASHUNIT_BENCH_BASELINE_UPDATE="$2"
+      export -n BASHUNIT_BENCH_BASELINE_UPDATE
+      bashunit::main::require_writable_path_or_exit \
+        "$BASHUNIT_BENCH_BASELINE_UPDATE" "BASHUNIT_BENCH_BASELINE_UPDATE"
+      shift
+      ;;
+    --report-json)
+      BASHUNIT_BENCH_REPORT_JSON="$2"
+      export -n BASHUNIT_BENCH_REPORT_JSON
+
+      bashunit::main::require_writable_path_or_exit \
+        "$BASHUNIT_BENCH_REPORT_JSON" "BASHUNIT_BENCH_REPORT_JSON"
+      shift
+      ;;
+    --report-junit)
+      BASHUNIT_BENCH_REPORT_JUNIT="$2"
+      export -n BASHUNIT_BENCH_REPORT_JUNIT
+      bashunit::main::require_writable_path_or_exit \
+        "$BASHUNIT_BENCH_REPORT_JUNIT" "BASHUNIT_BENCH_REPORT_JUNIT"
+      shift
+      ;;
     -s | --simple)
       BASHUNIT_SIMPLE_OUTPUT=true
       export -n BASHUNIT_SIMPLE_OUTPUT
@@ -17747,14 +20120,15 @@ function bashunit::main::cmd_bench() {
       fi
 
       if [ ! -f "$boot_file" ] || [ ! -r "$boot_file" ]; then
-        printf "%sError: cannot read the bootstrap file: '%s'.%s\n" \
-          "${_BASHUNIT_COLOR_FAILED}" "$boot_file" "${_BASHUNIT_COLOR_DEFAULT}" >&2
-        exit 1
+        bashunit::main::report_unreadable_bootstrap "$boot_file" "$2"
       fi
 
       set -o allexport
 
+      _BASHUNIT_LOADING_BOOTSTRAP="$boot_file"
+
       source "$boot_file" ${BASHUNIT_BOOTSTRAP_ARGS:-}
+      _BASHUNIT_LOADING_BOOTSTRAP=""
       set +o allexport
       shift
       ;;
@@ -17792,6 +20166,8 @@ function bashunit::main::cmd_bench() {
   if [ "$raw_args_count" -gt 0 ]; then
     local arg file
     for arg in "${raw_args[@]+"${raw_args[@]}"}"; do
+
+      bashunit::main::require_existing_path_or_exit "$arg"
       while IFS= read -r file; do
         args[args_count]="$file"
         args_count=$((args_count + 1))
@@ -17799,7 +20175,13 @@ function bashunit::main::cmd_bench() {
     done
   fi
 
-  [ -f "${BASHUNIT_BOOTSTRAP:-}" ] && source "$BASHUNIT_BOOTSTRAP" ${BASHUNIT_BOOTSTRAP_ARGS:-}
+  if [ -f "${BASHUNIT_BOOTSTRAP:-}" ]; then
+
+    _BASHUNIT_LOADING_BOOTSTRAP="$BASHUNIT_BOOTSTRAP"
+
+    source "$BASHUNIT_BOOTSTRAP" ${BASHUNIT_BOOTSTRAP_ARGS:-}
+    _BASHUNIT_LOADING_BOOTSTRAP=""
+  fi
 
   set +euo pipefail
 
@@ -17812,6 +20194,79 @@ function bashunit::main::cmd_bench() {
 
 # src/main/test.sh
 
+_BASHUNIT_MAIN_SUITE_ARGV=()
+
+_BASHUNIT_MAIN_PATHS_GIVEN=false
+
+_BASHUNIT_MAIN_SEED_GIVEN=false
+_BASHUNIT_MAIN_ORDER_GIVEN=false
+
+function bashunit::main::apply_suites() {
+  local -a suite_names=()
+  local -a rest=()
+  local -a cli_paths=()
+  local has_suite=false
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    --suite)
+      if [ -z "${2:-}" ]; then
+        printf "%sError: --suite requires a name.%s\n" \
+          "${_BASHUNIT_COLOR_FAILED:-}" "${_BASHUNIT_COLOR_DEFAULT:-}" >&2
+        exit 1
+      fi
+      has_suite=true
+      suite_names[${#suite_names[@]}]="$2"
+      shift
+      ;;
+    --list-suites)
+      bashunit::suites::load ".bashunitrc"
+      bashunit::suites::names
+      exit 0
+      ;;
+    -*)
+      rest[${#rest[@]}]="$1"
+      ;;
+    *)
+      cli_paths[${#cli_paths[@]}]="$1"
+      rest[${#rest[@]}]="$1"
+      ;;
+    esac
+    shift
+  done
+
+  if [ "$has_suite" = false ]; then
+    _BASHUNIT_MAIN_SUITE_ARGV=(${rest[@]+"${rest[@]}"})
+    return 0
+  fi
+
+  bashunit::suites::load ".bashunitrc"
+
+  local -a expanded=()
+  local -a suite_paths=()
+  local name entry path
+  for name in ${suite_names[@]+"${suite_names[@]}"}; do
+    bashunit::suites::resolve "$name"
+    while IFS= read -r entry; do
+      [ -z "$entry" ] && continue
+      expanded[${#expanded[@]}]="$entry"
+    done <<EOF
+$_BASHUNIT_SUITE_ARGS_OUT
+EOF
+    for path in $_BASHUNIT_SUITE_PATHS_OUT; do
+      suite_paths[${#suite_paths[@]}]="$path"
+    done
+  done
+
+  if [ "${#cli_paths[@]}" -eq 0 ]; then
+    for path in ${suite_paths[@]+"${suite_paths[@]}"}; do
+      expanded[${#expanded[@]}]="$path"
+    done
+  fi
+
+  _BASHUNIT_MAIN_SUITE_ARGV=(${expanded[@]+"${expanded[@]}"} ${rest[@]+"${rest[@]}"})
+}
+
 function bashunit::main::cmd_test() {
   local filter=""
   local tag_filter=""
@@ -17823,6 +20278,9 @@ function bashunit::main::cmd_test() {
   local args_count=0
   local assert_fn=""
   local _bashunit_coverage_opt_set=false
+
+  bashunit::main::apply_suites "$@"
+  set -- ${_BASHUNIT_MAIN_SUITE_ARGV[@]+"${_BASHUNIT_MAIN_SUITE_ARGV[@]}"}
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -17863,6 +20321,20 @@ function bashunit::main::cmd_test() {
       fi
       shift
       ;;
+    --sandbox)
+      BASHUNIT_SANDBOX=true
+      export -n BASHUNIT_SANDBOX
+      ;;
+    --sandbox-allow)
+
+      if [ -z "$BASHUNIT_SANDBOX_ALLOW" ]; then
+        BASHUNIT_SANDBOX_ALLOW="$2"
+      else
+        BASHUNIT_SANDBOX_ALLOW="$BASHUNIT_SANDBOX_ALLOW,$2"
+      fi
+      export -n BASHUNIT_SANDBOX_ALLOW
+      shift
+      ;;
     -s | --simple)
       BASHUNIT_SIMPLE_OUTPUT=true
       export -n BASHUNIT_SIMPLE_OUTPUT
@@ -17888,6 +20360,11 @@ function bashunit::main::cmd_test() {
 
       BASHUNIT_STOP_ON_FAILURE=true
       export -n BASHUNIT_STOP_ON_FAILURE
+      ;;
+    --pass-with-no-tests)
+
+      BASHUNIT_PASS_WITH_NO_TESTS=true
+      export -n BASHUNIT_PASS_WITH_NO_TESTS
       ;;
     -p | --parallel)
       BASHUNIT_PARALLEL_RUN=true
@@ -17928,15 +20405,18 @@ function bashunit::main::cmd_test() {
     --random-order)
       BASHUNIT_RANDOM_ORDER=true
       export -n BASHUNIT_RANDOM_ORDER
+      _BASHUNIT_MAIN_ORDER_GIVEN=true
       ;;
     --order-by)
       BASHUNIT_ORDER_BY="$2"
       export -n BASHUNIT_ORDER_BY
+      _BASHUNIT_MAIN_ORDER_GIVEN=true
       shift
       ;;
     --seed)
       BASHUNIT_SEED="$2"
       export -n BASHUNIT_SEED
+      _BASHUNIT_MAIN_SEED_GIVEN=true
       shift
       ;;
     --shard)
@@ -17966,13 +20446,24 @@ function bashunit::main::cmd_test() {
       export -n BASHUNIT_LIST_FORMAT
       shift
       ;;
-    --snapshot-update)
+    --list-tags)
+
+      BASHUNIT_LIST_TAGS=true
+      BASHUNIT_LIST_TESTS=true
+      export -n BASHUNIT_LIST_TAGS
+      export -n BASHUNIT_LIST_TESTS
+      ;;
+    -u | --snapshot-update)
       BASHUNIT_SNAPSHOT_UPDATE=true
       export -n BASHUNIT_SNAPSHOT_UPDATE
       ;;
     --no-snapshot-create)
       BASHUNIT_SNAPSHOT_CREATE=false
       export -n BASHUNIT_SNAPSHOT_CREATE
+      ;;
+    --snapshot-prune)
+      BASHUNIT_SNAPSHOT_PRUNE=true
+      export -n BASHUNIT_SNAPSHOT_PRUNE
       ;;
     --snapshot-report-unused)
       BASHUNIT_SNAPSHOT_REPORT_UNUSED=true
@@ -17992,14 +20483,15 @@ function bashunit::main::cmd_test() {
       fi
 
       if [ ! -f "$boot_file" ] || [ ! -r "$boot_file" ]; then
-        printf "%sError: cannot read the bootstrap file: '%s'.%s\n" \
-          "${_BASHUNIT_COLOR_FAILED}" "$boot_file" "${_BASHUNIT_COLOR_DEFAULT}" >&2
-        exit 1
+        bashunit::main::report_unreadable_bootstrap "$boot_file" "$2"
       fi
 
       set -o allexport
 
+      _BASHUNIT_LOADING_BOOTSTRAP="$boot_file"
+
       source "$boot_file" ${BASHUNIT_BOOTSTRAP_ARGS:-}
+      _BASHUNIT_LOADING_BOOTSTRAP=""
       set +o allexport
       shift
       ;;
@@ -18196,6 +20688,11 @@ function bashunit::main::cmd_test() {
     shift
   done
 
+  if [ "$_BASHUNIT_MAIN_SEED_GIVEN" = true ] && [ "$_BASHUNIT_MAIN_ORDER_GIVEN" = false ]; then
+    BASHUNIT_RANDOM_ORDER=true
+    export -n BASHUNIT_RANDOM_ORDER
+  fi
+
   bashunit::main::validate_config_or_exit
 
   if [ "$_bashunit_coverage_opt_set" = true ]; then
@@ -18212,6 +20709,7 @@ function bashunit::main::cmd_test() {
       args_count="$raw_args_count"
     else
 
+      _BASHUNIT_MAIN_PATHS_GIVEN=true
       local arg
       for arg in "${raw_args[@]+"${raw_args[@]}"}"; do
         local parsed_path parsed_filter
@@ -18224,6 +20722,8 @@ function bashunit::main::cmd_test() {
           inline_filter="$parsed_filter"
           inline_filter_file="$parsed_path"
         fi
+
+        bashunit::main::require_existing_path_or_exit "$parsed_path"
 
         local file
         while IFS= read -r file; do
@@ -18256,7 +20756,12 @@ function bashunit::main::cmd_test() {
     fi
   fi
 
-  if bashunit::env::is_snapshot_report_unused_enabled; then
+  if bashunit::env::is_snapshot_report_unused_enabled ||
+    bashunit::env::is_snapshot_prune_enabled; then
+    local _snapshot_flag="--snapshot-report-unused"
+    if bashunit::env::is_snapshot_prune_enabled; then
+      _snapshot_flag="--snapshot-prune"
+    fi
     local _partial_flag=""
     [ -n "$filter" ] && _partial_flag="--filter"
     [ -n "$tag_filter" ] && _partial_flag="--tag"
@@ -18265,8 +20770,9 @@ function bashunit::main::cmd_test() {
     bashunit::rerun::is_enabled && _partial_flag="--rerun-failed"
     bashunit::env::is_changed_enabled && _partial_flag="--changed"
     if [ -n "$_partial_flag" ]; then
-      printf "%sError: --snapshot-report-unused needs a full run; %s only runs a subset.%s\n" \
-        "${_BASHUNIT_COLOR_FAILED}" "$_partial_flag" "${_BASHUNIT_COLOR_DEFAULT}" >&2
+      printf "%sError: %s needs a full run; %s only runs a subset.%s\n" \
+        "${_BASHUNIT_COLOR_FAILED}" "$_snapshot_flag" "$_partial_flag" \
+        "${_BASHUNIT_COLOR_DEFAULT}" >&2
       exit 1
     fi
   fi
@@ -18292,7 +20798,13 @@ function bashunit::main::cmd_test() {
     fi
   fi
 
-  [ -f "${BASHUNIT_BOOTSTRAP:-}" ] && source "$BASHUNIT_BOOTSTRAP" ${BASHUNIT_BOOTSTRAP_ARGS:-}
+  if [ -f "${BASHUNIT_BOOTSTRAP:-}" ]; then
+
+    _BASHUNIT_LOADING_BOOTSTRAP="$BASHUNIT_BOOTSTRAP"
+
+    source "$BASHUNIT_BOOTSTRAP" ${BASHUNIT_BOOTSTRAP_ARGS:-}
+    _BASHUNIT_LOADING_BOOTSTRAP=""
+  fi
 
   if [ "${BASHUNIT_NO_OUTPUT:-false}" = true ]; then
     exec >/dev/null 2>&1
@@ -18356,9 +20868,16 @@ function _check_bash_version() {
 
 _check_bash_version
 
-declare -r BASHUNIT_VERSION="0.46.0"
+declare -r BASHUNIT_VERSION="0.50.0"
 
-declare -r BASHUNIT_ROOT_DIR="$(dirname "${BASH_SOURCE[0]}")"
+_bashunit_root="${BASH_SOURCE[0]%/*}"
+
+case "$_bashunit_root" in
+"${BASH_SOURCE[0]}") _bashunit_root="." ;;
+"") _bashunit_root="/" ;;
+esac
+declare -r BASHUNIT_ROOT_DIR="$_bashunit_root"
+unset _bashunit_root
 export BASHUNIT_ROOT_DIR
 
 declare -r BASHUNIT_WORKING_DIR="$PWD"
@@ -18382,15 +20901,19 @@ for arg in "$@"; do
   esac
 done
 
-bashunit::check_os::init
 bashunit::clock::init
 
 _SUBCOMMAND=""
 
 case "${1:-}" in
-test | bench | doc | init | learn | upgrade | assert | watch)
+test | bench | doc | init | upgrade | assert | watch)
   _SUBCOMMAND="$1"
   shift
+  ;;
+learn)
+  printf "%sError: 'learn' was removed. Learn bashunit at https://bashunit.com%s\n" \
+    "$_BASHUNIT_COLOR_FAILED" "$_BASHUNIT_COLOR_DEFAULT" >&2
+  exit 1
   ;;
 -v | --version)
   bashunit::console_header::print_version
@@ -18419,7 +20942,6 @@ test) bashunit::main::cmd_test "$@" ;;
 bench) bashunit::main::cmd_bench "$@" ;;
 doc) bashunit::main::cmd_doc "$@" ;;
 init) bashunit::main::cmd_init "$@" ;;
-learn) bashunit::main::cmd_learn "$@" ;;
 upgrade) bashunit::main::cmd_upgrade "$@" ;;
 assert) bashunit::main::cmd_assert "$@" ;;
 watch) bashunit::main::cmd_watch "$@" ;;

--- a/scripts/tests/check/5522_nfs_mount_rwsize_amazon.bashunit.sh
+++ b/scripts/tests/check/5522_nfs_mount_rwsize_amazon.bashunit.sh
@@ -35,10 +35,7 @@ function test_nfs_not_mounted() {
     local rc=$?
 
     #assert
-    if [[ "$rc" != '3' ]]; then
-        bashunit::fail "Expected CheckSkipped RC=3 but got RC=$rc"
-    fi
-    assert_true true
+    assert_exit_code 3 '' "${rc}"
 }
 
 function test_nfs_ok() {
@@ -53,10 +50,7 @@ function test_nfs_ok() {
     local rc=$?
 
     #assert
-    if [[ "$rc" != '0' ]]; then
-        bashunit::fail "Expected CheckOk RC=0 but got RC=$rc"
-    fi
-    assert_true true
+    assert_exit_code 0 '' "${rc}"
 }
 
 function test_nfs_rsize_wrong() {
@@ -69,10 +63,7 @@ function test_nfs_rsize_wrong() {
     local rc=$?
 
     #assert
-    if [[ "$rc" != '1' ]]; then
-        bashunit::fail "Expected CheckWarn RC=1 but got RC=$rc"
-    fi
-    assert_true true
+    assert_exit_code 1 '' "${rc}"
 }
 
 function test_nfs_wsize_wrong() {
@@ -85,10 +76,7 @@ function test_nfs_wsize_wrong() {
     local rc=$?
 
     #assert
-    if [[ "$rc" != '1' ]]; then
-        bashunit::fail "Expected CheckWarn RC=1 but got RC=$rc"
-    fi
-    assert_true true
+    assert_exit_code 1 '' "${rc}"
 }
 
 function test_nfs_wrong_all() {
@@ -103,10 +91,7 @@ function test_nfs_wrong_all() {
     local rc=$?
 
     #assert
-    if [[ "$rc" != '1' ]]; then
-        bashunit::fail "Expected CheckWarn RC=1 but got RC=$rc"
-    fi
-    assert_true true
+    assert_exit_code 1 '' "${rc}"
 }
 
 function set_up_before_script() {

--- a/scripts/tests/check/README.md
+++ b/scripts/tests/check/README.md
@@ -19,22 +19,23 @@ bash ../check-coverage-report.sh --untested-only  # Only list untested checks
 
 ## Critical Rules
 
-### 0. End Every Test with `assert_true true`
+### 0. Register a Real Assertion in Every Test
 
 bashunit 0.34.1+ flags tests as **"risky"** when no assertion is registered during a test run.
-Since `bashunit::fail` only increments the assertion counter when it fires (i.e., on failure),
-tests that pass without hitting `bashunit::fail` have zero assertions and get flagged as risky.
+`bashunit::fail` only increments the assertion counter when it fires (i.e., on failure), so it
+does not count on the happy path. Prefer a native assertion, which always registers a result.
 
-**Fix:** Add `assert_true true` at the end of every `test_*` function:
+**Return codes:** Capture the check return code and assert it directly:
 ```bash
 function test_example() {
     check_NNNN_check_name
-    if [[ $? -ne 0 ]]; then
-        bashunit::fail "Expected RC=0 (ok) for example scenario"
-    fi
-    assert_true true  # Registers a passing assertion to prevent risky flag
+    local rc=$?
+
+    assert_exit_code 0 '' "${rc}"
 }
 ```
+
+Use `assert_true true` only when no meaningful native assertion applies.
 
 ### 1. ALWAYS Test for RC=99 (Unprocessed Check)
 
@@ -49,9 +50,7 @@ returning the default RC=99 instead of properly executing the check.
 assert_check_processed() {
     local rc=$1
     local context="${2:-}"
-    if [[ ${rc} -eq 99 ]]; then
-        bashunit::fail "RC=99 (unprocessed) - check logic did not reach a conclusion${context:+ in }${context}"
-    fi
+    assert_not_equals 99 "${rc}" "Check must be processed${context:+ in }${context}"
 }
 
 # Usage in tests
@@ -62,7 +61,7 @@ function test_rhel_check_executes() {
     
     # CRITICAL: Always check this first!
     assert_check_processed ${rc} "RHEL"
-    assert_true true
+    assert_exit_code 0 '' "${rc}"
 }
 ```
 
@@ -178,10 +177,7 @@ function test_something() {
     
     # assert - ALWAYS check RC != 99 first!
     assert_check_processed ${rc}
-    if [[ ${rc} -ne 0 ]]; then
-        bashunit::fail "Expected RC=0"
-    fi
-    assert_true true
+    assert_exit_code 0 '' "${rc}"
 }
 ```
 
@@ -200,7 +196,7 @@ function test_sles_check_executes() {
     
     assert_check_processed ${rc} "SLES"
     # Additional assertions...
-    assert_true true
+    assert_exit_code 0 '' "${rc}"
 }
 
 function test_rhel_check_executes() {
@@ -213,7 +209,7 @@ function test_rhel_check_executes() {
     
     assert_check_processed ${rc} "RHEL"
     # Additional assertions...
-    assert_true true
+    assert_exit_code 0 '' "${rc}"
 }
 ```
 

--- a/scripts/tests/check/_TEMPLATE.bashunit.sh.template
+++ b/scripts/tests/check/_TEMPLATE.bashunit.sh.template
@@ -36,9 +36,7 @@ LIB_FUNC_IS_SLES() { return 0; }
 assert_check_processed() {
     local rc=$1
     local context="${2:-}"
-    if [[ ${rc} -eq 99 ]]; then
-        bashunit::fail "RC=99 (unprocessed) - check logic did not reach a conclusion${context:+ in }${context}"
-    fi
+    assert_not_equals 99 "${rc}" "Check must be processed${context:+ in }${context}"
 }
 
 function set_up_before_script() {
@@ -80,8 +78,8 @@ function test_sles_check_executes() {
 
     #assert - CRITICAL: Verify check was actually processed
     assert_check_processed ${rc} "SLES"
-    # Add specific RC assertion based on expected behavior
-    assert_true true
+    # Add a specific native RC assertion based on expected behavior.
+    # Example: assert_exit_code 0 '' "${rc}"
 }
 
 #------------------------------------------------------------------
@@ -100,8 +98,8 @@ function test_rhel_check_executes() {
 
     #assert - CRITICAL: Verify check was actually processed
     assert_check_processed ${rc} "RHEL"
-    # Add specific RC assertion based on expected behavior
-    assert_true true
+    # Add a specific native RC assertion based on expected behavior.
+    # Example: assert_exit_code 0 '' "${rc}"
 }
 
 # Example test: check skipped when precondition not met
@@ -114,10 +112,7 @@ function test_precondition_not_met() {
     local rc=$?
 
     #assert
-    if [[ ${rc} -ne 3 ]]; then
-        bashunit::fail "Expected RC=3 (skipped) when precondition not met, got RC=${rc}"
-    fi
-    assert_true true
+    assert_exit_code 3 '' "${rc}"
 }
 
 # Example test: check passes with correct values
@@ -131,10 +126,7 @@ function test_correct_values() {
 
     #assert - Always check RC != 99 first!
     assert_check_processed ${rc} "correct values"
-    if [[ ${rc} -ne 0 ]]; then
-        bashunit::fail "Expected RC=0 (ok) for correct values, got RC=${rc}"
-    fi
-    assert_true true
+    assert_exit_code 0 '' "${rc}"
 }
 
 # Example test: check fails with incorrect values
@@ -148,10 +140,7 @@ function test_incorrect_values() {
 
     #assert - Always check RC != 99 first!
     assert_check_processed ${rc} "incorrect values"
-    if [[ ${rc} -ne 2 ]]; then
-        bashunit::fail "Expected RC=2 (error) for incorrect values, got RC=${rc}"
-    fi
-    assert_true true
+    assert_exit_code 2 '' "${rc}"
 }
 
 # Example test: RHEL-specific behavior with correct value
@@ -167,8 +156,5 @@ function test_rhel_correct_value() {
 
     #assert - Always check RC != 99 first!
     assert_check_processed ${rc} "RHEL correct value"
-    if [[ ${rc} -ne 0 ]]; then
-        bashunit::fail "Expected RC=0 (ok) for RHEL with correct value, got RC=${rc}"
-    fi
-    assert_true true
+    assert_exit_code 0 '' "${rc}"
 }


### PR DESCRIPTION
Upgrade the bundled bashunit runner from 0.46.0 to 0.50.0, bringing in the latest reporting, output, timing, and test execution improvements.

Update the CI workflow and NFS mount unit test for compatibility with the new runner. Refresh the bashunit README and test template with the current setup requirements, assertion practices, and guidance for avoiding risky tests.